### PR TITLE
Migrate to `spine-base` dependency instead of `spine-client-core` + `ThrowableMessage`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.25-SNAPSHOT'
+def final SPINE_VERSION = '0.9.29-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
@@ -37,7 +37,7 @@ ext {
     jUnitVersion = '4.12'
 
     // We use Spine tools in the build process.
-    spineToolsVersion = '0.9.10-SNAPSHOT'
+    spineToolsVersion = '0.9.25-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.1'
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -33,8 +33,7 @@ dependencies {
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion
     compile group: 'com.google.protobuf', name: 'protobuf-java-util', version: protobufVersion
 
-    //TODO:6/20/17:alex.tymchenko: Switch the dependency from `core` to `base` instead.
-    compile (group: 'io.spine', name: 'spine-client-core', version: spineVersion) {
+    compile (group: 'io.spine', name: 'spine-base', version: spineVersion) {
         exclude(group: 'com.google.protobuf')
     }
 
@@ -43,7 +42,7 @@ dependencies {
     // to make their annotation more convenient.
     compile group: 'org.jboss.forge.roaster', name: 'roaster-api', version: roasterVersion
     compile group: 'org.jboss.forge.roaster', name: 'roaster-jdt', version: roasterVersion
-    testCompile group: 'io.spine', name: 'spine-testutil-core', version: spineVersion
+    testCompile group: 'io.spine', name: 'spine-testutil-base', version: spineVersion
     testCompile group: 'com.google.guava', name: 'guava-testlib', version: guavaVersion
     testCompile gradleTestKit()
 

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
@@ -37,7 +37,8 @@ import static java.util.Collections.singletonList;
  *
  * @author Alex Tymchenko
  */
-@SuppressWarnings("PublicField")    // as this is a Gradle extension.
+@SuppressWarnings({"PublicField", "ClassWithTooManyMethods", "WeakerAccess"})
+// as this is a Gradle extension.
 public class Extension {
 
     private static final String DEFAULT_GEN_ROOT_DIR = "/generated";
@@ -46,14 +47,14 @@ public class Extension {
     private static final String DEFAULT_MAIN_GEN_RES_DIR = DEFAULT_GEN_ROOT_DIR + "/main/resources";
     private static final String DEFAULT_MAIN_GEN_DIR = DEFAULT_GEN_ROOT_DIR + "/main/java";
     private static final String DEFAULT_MAIN_GEN_GRPC_DIR = DEFAULT_GEN_ROOT_DIR + "/main/grpc";
-    private static final String DEFAULT_MAIN_GEN_FAILURES_DIR = DEFAULT_GEN_ROOT_DIR + "/main/spine";
+    private static final String DEFAULT_MAIN_GEN_SPINE_DIR = DEFAULT_GEN_ROOT_DIR + "/main/spine";
     private static final String DEFAULT_MAIN_DESCRIPTORS_PATH = "/build/descriptors/main.desc";
 
     private static final String DEFAULT_TEST_PROTO_SRC_DIR = "/src/test/proto";
     private static final String DEFAULT_TEST_GEN_RES_DIR = DEFAULT_GEN_ROOT_DIR + "/test/resources";
     private static final String DEFAULT_TEST_GEN_DIR = DEFAULT_GEN_ROOT_DIR + "/test/java";
     private static final String DEFAULT_TEST_GEN_GRPC_DIR = DEFAULT_GEN_ROOT_DIR + "/test/grpc";
-    private static final String DEFAULT_TEST_GEN_FAILURES_DIR = DEFAULT_GEN_ROOT_DIR + "/test/spine";
+    private static final String DEFAULT_TEST_GEN_SPINE_DIR = DEFAULT_GEN_ROOT_DIR + "/test/spine";
     private static final String DEFAULT_TEST_DESCRIPTORS_PATH = "/build/descriptors/test.desc";
 
     /**
@@ -121,14 +122,14 @@ public class Extension {
     public String targetTestGenFailuresRootDir;
 
     /**
-     * The absolute path to the main target generated validators root directory.
+     * The absolute path to the main target generated validating builders root directory.
      */
-    public String targetGenValidatorsRootDir;
+    public String targetGenVBuildersRootDir;
 
     /**
-     * The absolute path to the test target generated validators root directory.
+     * The absolute path to the test target generated generated validating builders root directory.
      */
-    public String targetTestGenValidatorsRootDir;
+    public String targetTestGenVBuildersRootDir;
 
     /**
      * The absolute path to directory to delete.
@@ -163,143 +164,79 @@ public class Extension {
     public List<String> dirsToClean = new LinkedList<>();
 
     public static String getMainProtoSrcDir(Project project) {
-        final String path = spineProtobuf(project).mainProtoSrcDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_PROTO_SRC_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).mainProtoSrcDir,
+                             root(project) + DEFAULT_MAIN_PROTO_SRC_DIR);
     }
 
     public static String getMainTargetGenResourcesDir(Project project) {
-        final String path = spineProtobuf(project).mainTargetGenResourcesDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_GEN_RES_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).mainTargetGenResourcesDir,
+                             root(project) + DEFAULT_MAIN_GEN_RES_DIR);
     }
 
     public static String getMainGenGrpcDir(Project project) {
-        final String path = spineProtobuf(project).mainGenGrpcDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_GEN_GRPC_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).mainGenGrpcDir,
+                             root(project) + DEFAULT_MAIN_GEN_GRPC_DIR);
     }
 
     public static String getMainGenProtoDir(Project project) {
-        final String path = spineProtobuf(project).mainGenProtoDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_GEN_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).mainGenProtoDir,
+                             root(project) + DEFAULT_MAIN_GEN_DIR);
     }
 
     public static String getTestTargetGenResourcesDir(Project project) {
-        final String path = spineProtobuf(project).testTargetGenResourcesDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_GEN_RES_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).testTargetGenResourcesDir,
+                             root(project) + DEFAULT_TEST_GEN_RES_DIR);
     }
 
     public static String getTestProtoSrcDir(Project project) {
-        final String path = spineProtobuf(project).testProtoSrcDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_PROTO_SRC_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).testProtoSrcDir,
+                             root(project) + DEFAULT_TEST_PROTO_SRC_DIR);
     }
 
     public static String getTestGenGrpcDir(Project project) {
-        final String path = spineProtobuf(project).testGenGrpcDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_GEN_GRPC_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).testGenGrpcDir,
+                             root(project) + DEFAULT_TEST_GEN_GRPC_DIR);
     }
 
     public static String getTestGenProtoDir(Project project) {
-        final String path = spineProtobuf(project).testGenProtoDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_GEN_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).testGenProtoDir,
+                             root(project) + DEFAULT_TEST_GEN_DIR);
     }
 
     public static String getMainDescriptorSetPath(Project project) {
-        final String path = spineProtobuf(project).mainDescriptorSetPath;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_DESCRIPTORS_PATH;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).mainDescriptorSetPath,
+                             root(project) + DEFAULT_MAIN_DESCRIPTORS_PATH);
     }
 
     public static String getTestDescriptorSetPath(Project project) {
-        final String path = spineProtobuf(project).testDescriptorSetPath;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_DESCRIPTORS_PATH;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).testDescriptorSetPath,
+                             root(project) + DEFAULT_TEST_DESCRIPTORS_PATH);
     }
 
     public static String getTargetGenFailuresRootDir(Project project) {
-        final String path = spineProtobuf(project).targetGenFailuresRootDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_GEN_FAILURES_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).targetGenFailuresRootDir,
+                             root(project) + DEFAULT_MAIN_GEN_SPINE_DIR);
     }
 
     public static String getTargetTestGenFailuresRootDir(Project project) {
-        final String path = spineProtobuf(project).targetTestGenFailuresRootDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_GEN_FAILURES_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).targetTestGenFailuresRootDir,
+                             root(project) + DEFAULT_TEST_GEN_SPINE_DIR);
     }
 
     public static String getTargetGenValidatorsRootDir(Project project) {
-        final String path = spineProtobuf(project).targetGenValidatorsRootDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_MAIN_GEN_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).targetGenVBuildersRootDir,
+                             root(project) + DEFAULT_MAIN_GEN_SPINE_DIR);
     }
 
     public static String getTargetTestGenValidatorsRootDir(Project project) {
-        final String path = spineProtobuf(project).targetTestGenValidatorsRootDir;
-        if (isNullOrEmpty(path)) {
-            return project.getProjectDir()
-                          .getAbsolutePath() + DEFAULT_TEST_GEN_DIR;
-        } else {
-            return path;
-        }
+        return pathOrDefault(spineProtobuf(project).targetTestGenVBuildersRootDir,
+                             root(project) + DEFAULT_TEST_GEN_SPINE_DIR);
+    }
+
+    private static String pathOrDefault(String path, String defaultValue) {
+        return isNullOrEmpty(path)
+                ? defaultValue
+                : path;
     }
 
     public static boolean isGenerateValidatingBuilders(Project project) {
@@ -354,10 +291,14 @@ public class Extension {
             log().debug("Found directory to clean: {}", singleDir);
             return singletonList(singleDir);
         }
-        final String defaultValue = project.getProjectDir()
-                                           .getAbsolutePath() + DEFAULT_GEN_ROOT_DIR;
+        final String defaultValue = root(project) + DEFAULT_GEN_ROOT_DIR;
         log().debug("Default directory to clean: {}", defaultValue);
         return singletonList(defaultValue);
+    }
+
+    private static String root(Project project) {
+        return project.getProjectDir()
+                      .getAbsolutePath();
     }
 
     private static Extension spineProtobuf(Project project) {

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/failure/FailureWriter.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/failure/FailureWriter.java
@@ -26,7 +26,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import io.spine.base.FailureThrowable;
+import io.spine.base.ThrowableMessage;
 import io.spine.gradle.compiler.message.fieldtype.FieldType;
 import io.spine.gradle.compiler.message.fieldtype.FieldTypeFactory;
 import io.spine.gradle.compiler.util.GenerationUtils;
@@ -92,10 +92,10 @@ public class FailureWriter {
                                              .addJavadoc(javadocGenerator.generateClassJavadoc())
                                              .addAnnotation(GenerationUtils.constructGeneratedAnnotation())
                                              .addModifiers(PUBLIC)
-                                             .superclass(FailureThrowable.class)
+                                             .superclass(ThrowableMessage.class)
                                              .addField(constructSerialVersionUID())
                                              .addMethod(constructConstructor())
-                                             .addMethod(constructGetFailureMessage())
+                                             .addMethod(constructGetMessageThrown())
                                              .build();
             final JavaFile javaFile = JavaFile.builder(failureMetadata.getJavaPackage(), failure)
                                               .skipJavaLangImports(true)
@@ -147,16 +147,16 @@ public class FailureWriter {
         return superStatement.toString();
     }
 
-    private MethodSpec constructGetFailureMessage() {
-        log().trace("Constructing getFailureMessage()");
+    private MethodSpec constructGetMessageThrown() {
+        log().trace("Constructing getMessageThrown()");
 
         final TypeName returnTypeName = ClassName.get(failureMetadata.getOuterClassName(),
                                                       failureMetadata.getClassName());
-        return MethodSpec.methodBuilder("getFailureMessage")
+        return MethodSpec.methodBuilder("getMessageThrown")
                          .addAnnotation(Override.class)
                          .addModifiers(PUBLIC)
                          .returns(returnTypeName)
-                         .addStatement("return (" + returnTypeName + ") super.getFailureMessage()")
+                         .addStatement("return (" + returnTypeName + ") super.getMessageThrown()")
                          .build();
     }
 

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderWriter.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderWriter.java
@@ -20,7 +20,6 @@
 
 package io.spine.gradle.compiler.validate;
 
-import com.google.common.io.Files;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
@@ -36,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import javax.lang.model.element.Modifier;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import static io.spine.gradle.compiler.util.GenerationUtils.constructGeneratedAnnotation;
 import static io.spine.gradle.compiler.util.JavaSources.getBuilderClassName;
@@ -114,7 +114,7 @@ class ValidatingBuilderWriter {
     private static void writeClass(File rootFolder, TypeSpec validator,
                                    String javaPackage, Indent indent) {
         try {
-            Files.touch(rootFolder);
+            Files.createDirectories(rootFolder.toPath());
             JavaFile.builder(javaPackage, validator)
                     .skipJavaLangImports(true)
                     .indent(indent.toString())

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderWriter.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderWriter.java
@@ -80,12 +80,13 @@ class ValidatingBuilderWriter {
 
         final File rootDirectory = new File(targetDir);
         final TypeSpec.Builder classBuilder = TypeSpec.classBuilder(javaClass);
-        setupClassContract(classBuilder,
-                           messageClassName,
-                           messageBuilderClassName,
-                           methodsAssembler.createMethods());
-        final TypeSpec javaClassToWrite = classBuilder.addAnnotation(constructGeneratedAnnotation())
-                                                      .build();
+        final TypeSpec javaClassToWrite =
+                setupClassContract(classBuilder,
+                                   messageClassName,
+                                   messageBuilderClassName,
+                                   methodsAssembler.createMethods())
+                        .addAnnotation(constructGeneratedAnnotation())
+                        .build();
 
         log().debug("Writing the {} class under the {} package",
                     metadata.getJavaClass(), metadata.getJavaPackage());

--- a/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/ExtensionShould.java
+++ b/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/ExtensionShould.java
@@ -138,11 +138,11 @@ public class ExtensionShould {
 
     @Test
     public void return_targetTestGenValidatorsRootDir_if_set() {
-        spineProtobuf().targetTestGenValidatorsRootDir = newUuid();
+        spineProtobuf().targetTestGenVBuildersRootDir = newUuid();
 
         final String dir = Extension.getTargetTestGenValidatorsRootDir(project);
 
-        assertEquals(spineProtobuf().targetTestGenValidatorsRootDir, dir);
+        assertEquals(spineProtobuf().targetTestGenVBuildersRootDir, dir);
     }
 
     @Test
@@ -154,11 +154,11 @@ public class ExtensionShould {
 
     @Test
     public void return_targetGenValidatorsRootDir_if_set() {
-        spineProtobuf().targetGenValidatorsRootDir = newUuid();
+        spineProtobuf().targetGenVBuildersRootDir = newUuid();
 
         final String dir = Extension.getTargetGenValidatorsRootDir(project);
 
-        assertEquals(spineProtobuf().targetGenValidatorsRootDir, dir);
+        assertEquals(spineProtobuf().targetGenVBuildersRootDir, dir);
     }
 
     @Test

--- a/gradle-plugins/model-compiler/src/test/resources/build.gradle
+++ b/gradle-plugins/model-compiler/src/test/resources/build.gradle
@@ -49,8 +49,7 @@ dependencies {
 
     compile "com.google.protobuf:protobuf-java:${protobufVersion}"
 
-    //TODO:6/20/17:alex.tymchenko: switch to `base` dependency instead.
-    compile(group: 'io.spine', name: 'spine-client-core', version: spineVersion) {
+    compile(group: 'io.spine', name: 'spine-base', version: spineVersion) {
         exclude(group: 'com.google.protobuf')
     }
 


### PR DESCRIPTION
This PR addresses a few things.

1. The plugins no longer depend on `spine-client-core`. Instead, they depend `spine-base`.
2. The test code depends on `spine-testutil-base` instead of `spine-testutil-core`.
3. `ThrowableMessage` is used for code generation instead of `FailureThrowable`.
4. The generation folder for Spine failures is now set to `... /generated/ (main|test) /spine` instead of ` ... /generated/ (main or test) /java`.
5. The dependency on `tools` module is set to `0.9.25-SNAPSHOT` (the one, where there is no model compiler already).

The version for `base` modules is increased to `0.9.29-SNAPSHOT`.
