### PR TITLE
Move `options` to the top of the proto files.

### DIFF
--- a/base/src/test/proto/spine/test/failures.proto
+++ b/base/src/test/proto/spine/test/failures.proto
@@ -21,13 +21,14 @@ syntax = "proto3";
 
 package spine.test.failures;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option (SPI_all) = true;
 option java_package = "io.spine.test.failures";
 // Keep all the failures under the same outer class called `Failures`.
 option java_generate_equals_and_hash = true;
 
-import "spine/options.proto";
 
 // This failure serves as a smoke test of a successful compilation of a generated failure class.
 message ShouldCompileProperly {

--- a/base/src/test/proto/spine/test/identifiers_should.proto
+++ b/base/src/test/proto/spine/test/identifiers_should.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package spine.test.identifiers;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.identifiers";
 option java_multiple_files = true;
@@ -29,7 +31,6 @@ option java_outer_classname = "IdentifiersShouldProto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
-import "spine/options.proto";
 
 // Only for usage in `IdentifiersShould` class.
 

--- a/base/src/test/proto/spine/test/json/json_should.proto
+++ b/base/src/test/proto/spine/test/json/json_should.proto
@@ -21,11 +21,12 @@ syntax = "proto3";
 
 package spine.test.json;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.json.given";
 option java_multiple_files = true;
 
-import "spine/options.proto";
 
 // A simple binary tree node for testing Json output.
 message Node {

--- a/base/src/test/proto/spine/test/messages_should.proto
+++ b/base/src/test/proto/spine/test/messages_should.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package spine.test.messages;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.messages";
 option java_multiple_files = true;
@@ -28,7 +30,6 @@ option java_outer_classname = "MessagesShouldProto";
 
 import "google/protobuf/wrappers.proto";
 
-import "spine/options.proto";
 
 // Only for usage in `MessagesShould` class.
 

--- a/base/src/test/proto/spine/test/option/entity_options_should.proto
+++ b/base/src/test/proto/spine/test/option/entity_options_should.proto
@@ -21,12 +21,13 @@ syntax = "proto3";
 
 package spine.test.options;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.options";
 option java_multiple_files = true;
 option java_outer_classname = "EntityOptionsShouldProto";
 
-import "spine/options.proto";
 
 message FullAccessAggregate {
     option (entity).kind = AGGREGATE;

--- a/base/src/test/proto/spine/test/protobuf/any_packer_should.proto
+++ b/base/src/test/proto/spine/test/protobuf/any_packer_should.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package spine.test.protobuf;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.protobuf";
 option java_multiple_files = true;
@@ -28,7 +30,6 @@ option java_outer_classname = "AnyPackerShouldProto";
 
 import "google/protobuf/wrappers.proto";
 
-import "spine/options.proto";
 
 // Only for usage in `AnyPackerShould` class.
 

--- a/base/src/test/proto/spine/test/types/known_types_should.proto
+++ b/base/src/test/proto/spine/test/types/known_types_should.proto
@@ -21,11 +21,12 @@ syntax = "proto3";
 
 package spine.test.types;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.types";
 option java_multiple_files = true;
 
-import "spine/options.proto";
 
 // The types declared below are used to test the `KnownTypes#getTypesFromPackage`.
 //

--- a/base/src/test/proto/spine/test/validate/msg/alt_fields.proto
+++ b/base/src/test/proto/spine/test/validate/msg/alt_fields.proto
@@ -21,13 +21,14 @@ syntax = "proto3";
 
 package spine.test.validate.msg;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_generate_equals_and_hash = true;
 option java_multiple_files = true;
 option java_outer_classname = "ValidationTestCommandsProto";
 option java_package = "io.spine.test.validate.msg.altfields";
 
-import "spine/options.proto";
 
 message PersonName {
     option (required_field) = "first_name | honorific_prefix & last_name";

--- a/base/src/test/proto/spine/test/validate/msg/commands.proto
+++ b/base/src/test/proto/spine/test/validate/msg/commands.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package spine.test.validate.msg;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_generate_equals_and_hash = true;
 option java_multiple_files = true;
@@ -29,7 +31,6 @@ option java_package = "io.spine.test.validate.msg";
 
 import "google/protobuf/wrappers.proto";
 
-import "spine/options.proto";
 
 // Messages for entity ID in commands validation tests.
 

--- a/base/src/test/proto/spine/test/validate/msg/messages.proto
+++ b/base/src/test/proto/spine/test/validate/msg/messages.proto
@@ -21,6 +21,8 @@ syntax = "proto3";
 
 package spine.test.validate.msg;
 
+import "spine/options.proto";
+
 option (type_url_prefix) = "type.spine.io";
 option java_generate_equals_and_hash = true;
 option java_multiple_files = true;
@@ -30,7 +32,6 @@ option java_package = "io.spine.test.validate.msg";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
-import "spine/options.proto";
 
 // Messages for general validation tests.
 


### PR DESCRIPTION
Move
```protobuf
import "spine/options.proto";
``` 
at the top of the import section in proto files.