### PR TITLE
Small API improvements

### DIFF
--- a/base/src/main/java/io/spine/util/Exceptions.java
+++ b/base/src/main/java/io/spine/util/Exceptions.java
@@ -68,6 +68,34 @@ public final class Exceptions {
     }
 
     /**
+     * Always throws {@code UnsupportedOperationException} initialized with the formatted string.
+     *
+     * <p>Use this method in combination with static import for brevity of code for
+     * unsupported operations.
+     * The return type is given to keep Java type system happy when called in methods with
+     * return type as shown below:
+     *
+     * <pre>
+     *   import static io.spine.util.Exceptions.unsupported;
+     *   ...
+     *   T doSomething() {
+     *      throw unsupported("This operation is not supported because of %s and %s", arg1, arg2);
+     *   }
+     * </pre>
+     *
+     * @param format the format string
+     * @param args   formatting parameters
+     * @return nothing ever
+     * @throws UnsupportedOperationException always
+     */
+    public static UnsupportedOperationException unsupported(String format, Object... args) {
+        checkNotNull(format);
+        checkNotNull(args);
+        final String msg = formatMessage(format, args);
+        return unsupported(msg);
+    }
+
+    /**
      * Always throws {@code UnsupportedOperationException}.
      *
      * <p>Use this method in combination with static import for brevity of code for
@@ -127,7 +155,7 @@ public final class Exceptions {
      * Throws {@code IllegalArgumentException} with the formatted string.
      *
      * @param format the format string
-     * @param args formatting parameters
+     * @param args   formatting parameters
      * @return nothing ever, always throws an exception. The return type is given for convenience.
      * @throws IllegalArgumentException always
      */

--- a/base/src/main/java/io/spine/util/Exceptions.java
+++ b/base/src/main/java/io/spine/util/Exceptions.java
@@ -51,12 +51,13 @@ public final class Exceptions {
      * return type as shown below:
      *
      * <pre>
+     *  {@code
      *   import static io.spine.util.Exceptions.unsupported;
      *   ...
      *   T doSomething() {
      *      throw unsupported("Cannot do this");
      *   }
-     * </pre>
+     * }</pre>
      *
      * @param message a message for exception
      * @return nothing ever
@@ -76,12 +77,14 @@ public final class Exceptions {
      * return type as shown below:
      *
      * <pre>
+     *  {@code
+     *
      *   import static io.spine.util.Exceptions.unsupported;
      *   ...
      *   T doSomething() {
      *      throw unsupported("This operation is not supported because of %s and %s", arg1, arg2);
      *   }
-     * </pre>
+     * }</pre>
      *
      * @param format the format string
      * @param args   formatting parameters

--- a/base/src/main/java/io/spine/util/PropertyFiles.java
+++ b/base/src/main/java/io/spine/util/PropertyFiles.java
@@ -29,6 +29,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.IoUtil.close;
@@ -50,13 +51,14 @@ public class PropertyFiles {
     }
 
     /**
-     * Loads all data from {@code .properties} file(s) into memory.
+     * Loads property file(s) at the passed path into memory.
      *
      * <p>Logs {@link IOException} if it occurs.
      *
      * @param propsFilePath the path of the {@code .properties} file to load
+     * @return immutable set with loaded data
      */
-    public static ImmutableSet<Properties> loadAllProperties(String propsFilePath) {
+    public static Set<Properties> loadAllProperties(String propsFilePath) {
         checkNotNull(propsFilePath);
 
         final ImmutableSet.Builder<Properties> result = ImmutableSet.builder();

--- a/base/src/test/java/io/spine/util/ExceptionsShould.java
+++ b/base/src/test/java/io/spine/util/ExceptionsShould.java
@@ -27,10 +27,15 @@ import static io.spine.Identifier.newUuid;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static io.spine.util.Exceptions.toError;
 import static io.spine.util.Exceptions.unsupported;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * @author Alexander Litus
+ * @author Alexander Yevsyukov
  */
 @SuppressWarnings("ThrowableResultOfMethodCallIgnored")
 public class ExceptionsShould {
@@ -48,6 +53,20 @@ public class ExceptionsShould {
     @Test(expected = UnsupportedOperationException.class)
     public void create_and_throw_unsupported_operation_exception_with_message() {
         unsupported(newUuid());
+    }
+
+    @Test
+    public void throw_formatted_unsupported_exception() {
+        final String arg1 = getClass().getCanonicalName();
+        final long arg2 = 100500L;
+        try {
+            unsupported("%s %d", arg1, arg2);
+            fail();
+        } catch (UnsupportedOperationException e) {
+            final String exceptionMessage = e.getMessage();
+            assertTrue(exceptionMessage.contains(arg1));
+            assertTrue(exceptionMessage.contains(String.valueOf(arg2)));
+        }
     }
 
     @Test
@@ -77,5 +96,15 @@ public class ExceptionsShould {
     public void throw_formatted_ISE_with_cause() {
         newIllegalStateException(new RuntimeException(getClass().getSimpleName()),
                                             "%s %s", "taram", "param");
+    }
+
+    @Test
+    public void convert_throwable_to_Error() {
+        final int errorCode = 404;
+        final String errorMessage = newUuid();
+        io.spine.base.Error error = toError(new RuntimeException(errorMessage), errorCode);
+
+        assertEquals(errorCode, error.getCode());
+        assertEquals(errorMessage, error.getMessage());
     }
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.42-SNAPSHOT'
+def final SPINE_VERSION = '0.9.43-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR:
  * Changes return values from `ImmutableSet` to `Set` (with immutability mentioned in Javadocs)
  * Adds formatted utility for throwing `UnsupportedOperationException`.
  * Advances Spine version to `0.9.43-SNAPSHOT`.