### PR TITLE
`MessageField` and `ThrowableMessage` improvements

### DIFF
--- a/base/src/main/java/io/spine/base/ThrowableMessage.java
+++ b/base/src/main/java/io/spine/base/ThrowableMessage.java
@@ -25,6 +25,7 @@ import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.Identifier;
+import io.spine.annotation.Internal;
 import io.spine.string.Stringifiers;
 
 import javax.annotation.Nullable;
@@ -40,6 +41,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * the {@code message} thrown is a detailed description of the rejection reason.
  *
  * @author Alex Tymchenko
+ * @author Alexander Yevsyukov
  */
 public abstract class ThrowableMessage extends Throwable {
 
@@ -60,7 +62,7 @@ public abstract class ThrowableMessage extends Throwable {
 
     protected ThrowableMessage(GeneratedMessageV3 message) {
         super();
-        this.message = message;
+        this.message = checkNotNull(message);
         this.timestamp = getCurrentTime();
     }
 
@@ -76,19 +78,21 @@ public abstract class ThrowableMessage extends Throwable {
     }
 
     /**
-     * Initialized the ID of the entity, which thrown the message.
+     * Initializes the ID of the entity, which thrown the message.
      *
-     * <p>This method can be called only once.
+     * <p>This internal API method can be called only once. It is supposed to be used by
+     * the framework, and must not be called by the user's code.
      *
      * @param  producerId the ID of the entity packed into {@code Any}
      * @return a reference to this {@code ThrowableMessage} instance
      */
+    @Internal
     public synchronized ThrowableMessage initProducer(Any producerId) {
         checkNotNull(producerId);
         if (this.producerId != null) {
             final Object unpackedId = Identifier.unpack(producerId);
             final String stringId = Stringifiers.toString(unpackedId);
-            throw newIllegalStateException("Producer already initialized %s", stringId);
+            throw newIllegalStateException("Producer already initialized: %s", stringId);
         }
         this.producerId = producerId;
         return this;

--- a/base/src/main/java/io/spine/protobuf/MessageField.java
+++ b/base/src/main/java/io/spine/protobuf/MessageField.java
@@ -81,12 +81,11 @@ public abstract class MessageField implements Serializable {
      * @return field value
      * @throws RuntimeException or a derived exception class if the field is not available
      * @see #isFieldAvailable(Message)
-     * @see #createUnavailableFieldException(Message, String)
+     * @see #createUnavailableFieldException(Message)
      */
     public Object getValue(Message message) {
         if (!isFieldAvailable(message)) {
-            final String fieldName = getFieldName(message, getIndex());
-            throw createUnavailableFieldException(message, fieldName);
+            throw createUnavailableFieldException(message);
         }
 
         final Method method = getAccessor(message);
@@ -94,6 +93,7 @@ public abstract class MessageField implements Serializable {
             final Object result = method.invoke(message);
             return result;
         } catch (InvocationTargetException | IllegalAccessException e) {
+            //TODO:2017-08-01:alexander.yevsyukov: raise MessageFieldException
             throw new IllegalStateException(e);
         }
     }
@@ -102,11 +102,9 @@ public abstract class MessageField implements Serializable {
      * Creates an exception for the case of a missing or incompatible field in the passed message.
      *
      * @param message   a message passed for obtaining value
-     * @param fieldName a name of the field at the required index
      * @return new exception instance
      */
-    protected abstract RuntimeException createUnavailableFieldException(Message message,
-                                                                        String fieldName);
+    protected abstract RuntimeException createUnavailableFieldException(Message message);
 
     /**
      * Verifies if a field is available in the passed message.

--- a/base/src/main/java/io/spine/protobuf/MessageFieldException.java
+++ b/base/src/main/java/io/spine/protobuf/MessageFieldException.java
@@ -1,0 +1,56 @@
+package io.spine.protobuf;
+
+import com.google.protobuf.Message;
+
+import javax.annotation.Nullable;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Signals an error working with a protobuf message field.
+ *
+ * @author Alexander Yevsyukov
+ */
+public class MessageFieldException extends RuntimeException {
+
+    private final Message protobufMessage;
+
+    /**
+     * Constructs a {@code MessageFieldException} with the formatted message text.
+     *
+     * @param protobufMessage    a Protobuf message object working with a field of which caused
+     *                           an error
+     * @param errorMessageFormat a formatted string for error message
+     * @param params             error message parameters
+     */
+    public MessageFieldException(Message protobufMessage,
+                                 String errorMessageFormat,
+                                 @Nullable Object... params) {
+        super(formatMessage(checkNotNull(errorMessageFormat), params));
+        this.protobufMessage = checkNotNull(protobufMessage);
+    }
+
+    /**
+     * Constructs a {@code MessageFieldException} without no message text.
+     *
+     * @param protobufMessage a Protobuf message object working with a field of which caused
+     *                        an error
+     */
+    public MessageFieldException(Message protobufMessage) {
+        this(protobufMessage, "");
+    }
+
+    /**
+     * Obtains a Protobuf message working with a field of which caused an error
+     */
+    public Message getProtobufMessage() {
+        return protobufMessage;
+    }
+
+    private static String formatMessage(String format, @Nullable Object... params) {
+        if (params == null) {
+            return format;
+        }
+        return String.format(format, params);
+    }
+}

--- a/base/src/main/java/io/spine/protobuf/MessageFieldException.java
+++ b/base/src/main/java/io/spine/protobuf/MessageFieldException.java
@@ -2,12 +2,11 @@ package io.spine.protobuf;
 
 import com.google.protobuf.Message;
 
-import javax.annotation.Nullable;
-
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
 
 /**
- * Signals an error working with a protobuf message field.
+ * Signals an error working with a Protobuf message field.
  *
  * @author Alexander Yevsyukov
  */
@@ -20,13 +19,13 @@ public class MessageFieldException extends RuntimeException {
      *
      * @param protobufMessage    a Protobuf message object working with a field of which caused
      *                           an error
-     * @param errorMessageFormat a formatted string for error message
+     * @param errorMessageFormat a format string for the error message
      * @param params             error message parameters
      */
     public MessageFieldException(Message protobufMessage,
                                  String errorMessageFormat,
-                                 @Nullable Object... params) {
-        super(formatMessage(checkNotNull(errorMessageFormat), params));
+                                 Object... params) {
+        super(format(checkNotNull(errorMessageFormat), params));
         this.protobufMessage = checkNotNull(protobufMessage);
     }
 
@@ -45,12 +44,5 @@ public class MessageFieldException extends RuntimeException {
      */
     public Message getProtobufMessage() {
         return protobufMessage;
-    }
-
-    private static String formatMessage(String format, @Nullable Object... params) {
-        if (params == null) {
-            return format;
-        }
-        return String.format(format, params);
     }
 }

--- a/base/src/test/java/io/spine/base/ThrowableMessageShould.java
+++ b/base/src/test/java/io/spine/base/ThrowableMessageShould.java
@@ -24,6 +24,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.protobuf.util.Timestamps;
 import io.spine.Identifier;
+import io.spine.test.Tests;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,6 +78,17 @@ public class ThrowableMessageShould {
     public void not_allow_repeated_producer_initialization() {
         throwableMessage.initProducer(producer)
                         .initProducer(producer);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void not_allow_null_producer() {
+        throwableMessage.initProducer(Tests.<Any>nullRef());
+    }
+
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test(expected = NullPointerException.class)
+    public void prohibit_null_message() {
+        new TestThrowableMessage(Tests.<GeneratedMessageV3>nullRef());
     }
 
     /**

--- a/base/src/test/java/io/spine/protobuf/MessageFieldExceptionShould.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldExceptionShould.java
@@ -1,0 +1,41 @@
+package io.spine.protobuf;
+
+import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
+import io.spine.time.Time;
+import org.junit.Test;
+
+import static io.spine.test.TestValues.newUuidValue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("ThrowableNotThrown")
+public class MessageFieldExceptionShould {
+
+    @Test
+    public void construct_instance_with_formatted_message() {
+        final String param1 = "Букварь";
+        final String param2 = "blue";
+        final String param3 = String.valueOf(3);
+        final StringValue protobufMessage = newUuidValue();
+        final MessageFieldException exception =
+                new MessageFieldException(protobufMessage,
+                                          "Reading log is: %s %s %s",
+                                          param1, param2, param3);
+
+        assertEquals(protobufMessage, exception.getProtobufMessage());
+        final String exceptionMessage = exception.getMessage();
+        assertTrue(exceptionMessage.contains(param1));
+        assertTrue(exceptionMessage.contains(param2));
+        assertTrue(exceptionMessage.contains(param3));
+    }
+
+    @Test
+    public void contains_instance_without_text() {
+        final Timestamp protobufMessage = Time.getCurrentTime();
+        final MessageFieldException exception = new MessageFieldException(protobufMessage);
+
+        assertEquals(protobufMessage, exception.getProtobufMessage());
+        assertTrue(exception.getMessage().isEmpty());
+    }
+}

--- a/base/src/test/java/io/spine/protobuf/MessageFieldExceptionShould.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldExceptionShould.java
@@ -1,7 +1,9 @@
 package io.spine.protobuf;
 
+import com.google.protobuf.Empty;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
+import io.spine.test.Tests;
 import io.spine.time.Time;
 import org.junit.Test;
 
@@ -37,5 +39,10 @@ public class MessageFieldExceptionShould {
 
         assertEquals(protobufMessage, exception.getProtobufMessage());
         assertTrue(exception.getMessage().isEmpty());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void allow_null_params() {
+        new MessageFieldException(Empty.getDefaultInstance(), Tests.<String>nullRef());
     }
 }

--- a/base/src/test/java/io/spine/protobuf/MessageFieldShould.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldShould.java
@@ -20,13 +20,16 @@
 
 package io.spine.protobuf;
 
+import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
+import com.google.protobuf.Timestamp;
 import org.junit.Test;
 
 import static com.google.protobuf.Descriptors.FieldDescriptor;
 import static com.google.protobuf.Descriptors.FieldDescriptor.JavaType;
 import static io.spine.Identifier.newUuid;
+import static io.spine.protobuf.MessageField.getFieldCount;
 import static io.spine.protobuf.MessageField.getFieldDescriptor;
 import static io.spine.protobuf.MessageField.getFieldName;
 import static io.spine.protobuf.MessageField.toAccessorMethodName;
@@ -66,7 +69,7 @@ public class MessageFieldShould {
         new TestMessageField(-5);
     }
 
-    @Test(expected = IllegalStateException.class)
+    @Test(expected = MessageFieldException.class)
     public void throw_exception_if_field_is_not_available() {
         final TestMessageField field = new TestMessageField(STR_VALUE_FIELD_INDEX);
         field.setIsFieldAvailable(false);
@@ -111,21 +114,29 @@ public class MessageFieldShould {
         assertEquals("getAggregateRootId", toAccessorMethodName("aggregate_root_id"));
     }
 
+    @Test
+    public void obtain_number_of_fields() {
+        assertEquals(0, getFieldCount(Empty.getDefaultInstance()));
+        assertEquals(1, getFieldCount(StringValue.getDefaultInstance()));
+        assertEquals(2, getFieldCount(Timestamp.getDefaultInstance()));
+    }
+
     private static class TestMessageField extends MessageField {
 
         private boolean isFieldAvailable = true;
 
-        protected TestMessageField(int index) {
+        TestMessageField(int index) {
             super(index);
         }
 
+        @SuppressWarnings("SameParameterValue") // Now is used only once to overwrite default value.
         void setIsFieldAvailable(boolean isFieldAvailable) {
             this.isFieldAvailable = isFieldAvailable;
         }
 
         @Override
-        protected RuntimeException createUnavailableFieldException(Message message) {
-            return new IllegalStateException("");
+        protected MessageFieldException createUnavailableFieldException(Message message) {
+            return new MessageFieldException(message);
         }
 
         @Override

--- a/base/src/test/java/io/spine/protobuf/MessageFieldShould.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldShould.java
@@ -124,8 +124,7 @@ public class MessageFieldShould {
         }
 
         @Override
-        protected RuntimeException createUnavailableFieldException(Message message,
-                                                                   String fieldName) {
+        protected RuntimeException createUnavailableFieldException(Message message) {
             return new IllegalStateException("");
         }
 

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.45-SNAPSHOT'
+def final SPINE_VERSION = '0.9.47-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR
  * Introduces `MessageFieldException` is introduced, which improves diagnostics for error cases.
  * Adds the ability to set producer ID for a `ThrowableMessage`.
