### PR TITLE
Fix wrong search of message declarations

### DIFF
--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -24,6 +24,32 @@ ext {
 
 group = 'io.spine.tools'
 
+buildscript {
+    apply from: "$rootDir/ext.gradle"
+
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+
+    //noinspection GroovyAssignabilityCheck
+    dependencies {
+        classpath(group: 'com.google.protobuf',
+                  name: 'protobuf-gradle-plugin',
+                  version: protobufGradlePluginVerison) {
+            // exclude an old Guava version
+            exclude group: 'com.google.guava'
+        }
+    }
+
+    configurations.all({
+        resolutionStrategy.cacheChangingModulesFor(0, 'seconds')
+    })
+}
+
+apply plugin: 'com.google.protobuf'
+apply from: generateDescriptorSetScript
+
 dependencies {
     compile project(':plugin-base')
     compile project(':base')
@@ -49,6 +75,13 @@ dependencies {
     // It is a local version bundled within the JDK installation.
     // "JAVA_HOME" environment variable must be set for correct work.
     testCompile files("${System.properties['java.home']}/../lib/tools.jar")
+}
+
+protobuf {
+    generatedFilesBaseDir = generatedRootDir
+    protoc {
+        artifact = protobufDependency
+    }
 }
 
 // Tests use the Protobuf plugin.

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/message/MessageDeclaration.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/message/MessageDeclaration.java
@@ -24,6 +24,7 @@ import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import io.spine.type.TypeName;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -89,12 +90,26 @@ public class MessageDeclaration {
     }
 
     /**
+     * Obtains declarations of nested types of this declaration.
+     *
+     * @return the collection of message declarations
+     */
+    public Collection<MessageDeclaration> getNestedDeclarations() {
+        final List<MessageDeclaration> nestedDeclarations = newLinkedList();
+        for (DescriptorProto nestedType : descriptor.getNestedTypeList()) {
+            final MessageDeclaration nestedDeclaration = forNested(nestedType);
+            nestedDeclarations.add(nestedDeclaration);
+        }
+        return nestedDeclarations;
+    }
+
+    /**
      * Obtains the declaration for the specified nested message of the declaration.
      *
      * @param nestedMessage the nested message from this declaration
      * @return the nested message declaration
      */
-    public MessageDeclaration forNested(DescriptorProto nestedMessage) {
+    private MessageDeclaration forNested(DescriptorProto nestedMessage) {
         final boolean isNestedForCurrentTarget = descriptor.getNestedTypeList()
                                                            .contains(nestedMessage);
         if (!isNestedForCurrentTarget) {

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/message/MessageDeclarations.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/message/MessageDeclarations.java
@@ -48,8 +48,8 @@ public class MessageDeclarations {
      * @param predicate       the predicate to test a message
      * @return the message declarations
      */
-    public static Collection<MessageDeclaration> find(
-            Collection<FileDescriptorProto> fileDescriptors, Predicate<DescriptorProto> predicate) {
+    public static Collection<MessageDeclaration> find(Iterable<FileDescriptorProto> fileDescriptors,
+                                                      Predicate<DescriptorProto> predicate) {
         final List<MessageDeclaration> result = newLinkedList();
         for (FileDescriptorProto fileDescriptor : fileDescriptors) {
             final Collection<MessageDeclaration> declarationsFromFile = scanFile(fileDescriptor,
@@ -78,19 +78,18 @@ public class MessageDeclarations {
     private static Collection<MessageDeclaration> scanNestedTypesRecursively(
             MessageDeclaration declaration, Predicate<DescriptorProto> predicate) {
         final List<MessageDeclaration> result = newLinkedList();
-        final List<DescriptorProto> nestedTypes = declaration.getDescriptor()
-                                                             .getNestedTypeList();
-        final Deque<DescriptorProto> deque = newLinkedList(nestedTypes);
+        final Iterable<MessageDeclaration> nestedDeclarations = declaration.getNestedDeclarations();
+        final Deque<MessageDeclaration> deque = newLinkedList(nestedDeclarations);
 
         while (!deque.isEmpty()) {
-            final DescriptorProto nestedMessage = deque.pollFirst();
-            final MessageDeclaration nestedDeclaration = declaration.forNested(nestedMessage);
+            final MessageDeclaration nestedDeclaration = deque.pollFirst();
+            final DescriptorProto nestedDescriptor = nestedDeclaration.getDescriptor();
 
-            if (predicate.apply(nestedMessage)) {
+            if (predicate.apply(nestedDescriptor)) {
                 result.add(nestedDeclaration);
             }
 
-            deque.addAll(nestedMessage.getNestedTypeList());
+            deque.addAll(nestedDeclaration.getNestedDeclarations());
         }
         return result;
     }

--- a/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/message/MessageDeclarationsShould.java
+++ b/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/message/MessageDeclarationsShould.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.compiler.message;
+
+import com.google.common.base.Predicate;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
+import io.spine.test.compiler.message.Top;
+import io.spine.type.TypeName;
+import org.junit.Test;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.gradle.compiler.message.MessageDeclarations.find;
+import static java.util.Collections.singleton;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Grankin
+ */
+public class MessageDeclarationsShould {
+
+    private static final FileDescriptorProto TEST_FILE_DESCRIPTOR = Top.getDescriptor()
+                                                                       .getFile()
+                                                                       .toProto();
+
+    @Test
+    public void search_nested_declarations_recursively() {
+        final Descriptor nestedForNested = Top.NestedForTop.NestedForNested.getDescriptor();
+        final TypeName expectedTypeName = TypeName.from(nestedForNested);
+        final MessageDeclaration result = findDeclaration(expectedTypeName.getSimpleName());
+        assertEquals(expectedTypeName, result.getTypeName());
+    }
+
+    private static MessageDeclaration findDeclaration(String name) {
+        final Predicate<DescriptorProto> predicate = new MessageWithName(name);
+        final Collection<MessageDeclaration> searchResult = find(singleton(TEST_FILE_DESCRIPTOR),
+                                                                 predicate);
+        assertEquals(searchResult.size(), 1);
+        return searchResult.iterator()
+                           .next();
+    }
+
+    private static class MessageWithName implements Predicate<DescriptorProto> {
+
+        private final String name;
+
+        private MessageWithName(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public boolean apply(@Nullable DescriptorProto input) {
+            checkNotNull(input);
+            final String messageName = input.getName();
+            return messageName.equals(name);
+        }
+    }
+}

--- a/gradle-plugins/model-compiler/src/test/proto/spine/message/message_declarations_test.proto
+++ b/gradle-plugins/model-compiler/src/test/proto/spine/message/message_declarations_test.proto
@@ -1,0 +1,44 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+syntax = "proto3";
+
+package spine.test.validate.msg;
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "MessageDeclarationsShouldProto";
+option java_package = "io.spine.test.compiler.message";
+
+import "spine/options.proto";
+
+// The test definitions for the `MessageDeclarations` tests.
+//
+// Use in `MessageDeclarationsShould` only.
+
+// A message to test recursive search among nested types.
+message Top {
+
+    message NestedForTop {
+
+        message NestedForNested {
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes work of `MessageDeclarations.find(...)`. Before the change, formation of returned declarations was incorrect.