### PR TITLE
Create tasks for usage in `protobuf-javadoc-plugin`

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.48-SNAPSHOT'
+def final SPINE_VERSION = '0.9.49-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
@@ -41,7 +41,7 @@ ext {
 
     // We use Spine tools and model compiler in the build process.
     spineToolsVersion = '0.9.41-SNAPSHOT'
-    spineModelCompilerVersion = '0.9.47-SNAPSHOT'
+    spineModelCompilerVersion = '0.9.48-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.1'
 }

--- a/gradle-plugins/plugin-base/src/main/java/io/spine/gradle/TaskName.java
+++ b/gradle-plugins/plugin-base/src/main/java/io/spine/gradle/TaskName.java
@@ -28,7 +28,7 @@ import com.google.common.base.MoreObjects;
  *
  * @author Alex Tymchenko
  */
-//@SuppressWarnings("unused") // These are used after deployment.
+@SuppressWarnings("unused") // These are used after deployment.
 public enum TaskName {
 
     /*
@@ -166,7 +166,23 @@ public enum TaskName {
      *
      * <p>Handles the {@code test} classes and resources scope.
      */
-    ANNOTATE_TEST_PROTO("annotateTestProto");
+    ANNOTATE_TEST_PROTO("annotateTestProto"),
+
+    /**
+     * The name of the task, that formats Javadocs in sources generated from {@code .proto}
+     * files, added to the Gradle lifecycle.
+     *
+     * <p>Handles the {@code main} classes and resources scope.
+     */
+    FORMAT_PROTO_DOC("formatProtoDoc"),
+
+    /**
+     * The name of the task, that formats Javadocs in sources generated from {@code .proto}
+     * files, added to the Gradle lifecycle.
+     *
+     * <p>Handles the {@code test} classes and resources scope.
+     */
+    FORMAT_TEST_PROTO_DOC("formatTestProtoDoc");
 
     private final String value;
 


### PR DESCRIPTION
This PR adds the tasks in `TaskName` enumeration, that will be used in the plugin for formatting Javadocs in sources generated basing on Protobuf definitions.