### PR TITLE
Protoc plugin module

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -5,3 +5,4 @@ exclude_paths:
   - "testutil-base/src/test/**/*.*"
   - "gradle-plugins/plugin-base/src/test/**/*.*"
   - "gradle-plugins/model-compiler/src/test/**/*.*"
+  - "protoc-plugin/src/test/**/*.*"

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ build/*
 # Class files produced by the IDE
 classes/*
 
+# Spine internal directory for storing intermediate artifacts
+/.spine/
+*/.spine/
+
 # Login details to Maven repository.
 # Each workstation should have developer's login defined in this file.
 credentials.properties

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -363,7 +363,18 @@ extend google.protobuf.MessageOptions {
     // release.
     bool beta_type = 73914;
 
-    // reserved 73915 to 73921 for future API annotation options.
+    // Specifies the name of a Java interface to be implemented by this message.
+    //
+    // The interface is generated into the Protobuf generation destination directory. The interface
+    // itself is a marker interface derived from `com.google.protobuf.Message`. Unless the interface
+    // is specified by it's FQN, it will have the same Java package as the message.
+    //
+    // To specify a marker interface for every message in a `.proto` file, use `(every_is)` file
+    // option. If both `(is)` and `(every_is)` options are found, `(is)` wins.
+    //
+    string is = 73915;
+
+    // reserved 73916 to 73921 for future API annotation options.
 
     // Enrichment Options
     //--------------------
@@ -467,7 +478,18 @@ extend google.protobuf.FileOptions {
     // release.
     bool beta_all = 73945;
 
-    // reserved 73946 to 73970 for future use.
+    // Specifies the name of a Java interface to be implemented by all the messages in this file.
+    //
+    // The interface is generated into the Protobuf generation destination directory. The interface
+    // itself is a marker interface derived from `com.google.protobuf.Message`. Unless the interface
+    // is specified by it's FQN, it will have the same Java package as the message.
+    //
+    // To specify a marker interface a single message, use `(is)` message option. If both `(is)`
+    // and `(every_is)` options are found, `(is)` wins.
+    //
+    string every_is = 73946;
+
+    // reserved 73947 to 73970 for future use.
 }
 
 extend google.protobuf.ServiceOptions {

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.51-SNAPSHOT'
+def final SPINE_VERSION = '0.9.52-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
@@ -41,7 +41,7 @@ ext {
 
     // We use Spine tools and model compiler in the build process.
     spineToolsVersion = '0.9.41-SNAPSHOT'
-    spineModelCompilerVersion = '0.9.49-SNAPSHOT'
+    spineModelCompilerVersion = '0.9.51-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.1'
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -43,5 +43,7 @@ ext {
     spineToolsVersion = '0.9.41-SNAPSHOT'
     spineModelCompilerVersion = '0.9.51-SNAPSHOT'
 
-    protobufGradlePluginVerison = '0.8.1'
+    protobufGradlePluginVerison = '0.8.3'
+
+    javaPoetVersion = '1.8.0'
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     compile project(':plugin-base')
     compile project(':base')
 
-    compile group: 'com.squareup', name: 'javapoet', version: '1.8.0'
+    compile group: 'com.squareup', name: 'javapoet', version: javaPoetVersion
     compile group: 'com.google.template', name: 'soy', version: '2017-02-01'
     compile group: 'com.google.guava', name: 'guava', version: guavaVersion
     compile group: 'com.google.protobuf', name: 'protobuf-java', version: protobufVersion

--- a/protoc-plugin/build.gradle
+++ b/protoc-plugin/build.gradle
@@ -1,0 +1,119 @@
+import java.nio.file.Files
+
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+apply plugin: 'com.google.protobuf'
+
+buildscript {
+    repositories {
+        mavenCentral()
+        maven {
+            url = googleMavenCentralMirror
+        }
+    }
+    dependencies {
+        classpath(group: 'com.google.protobuf',
+                name: 'protobuf-gradle-plugin',
+                version: protobufGradlePluginVerison) {
+            // exclude an old Guava version
+            exclude group: 'com.google.guava'
+        }
+    }
+}
+
+group 'io.spine.tools'
+
+dependencies {
+    compile project(':base')
+
+    compile group: "com.google.protobuf", name: "protobuf-java", version: protobufVersion
+    compile group: 'com.squareup', name: 'javapoet', version: javaPoetVersion
+}
+
+protobuf {
+    generatedFilesBaseDir = generatedRootDir
+    protoc {
+        artifact = protobufDependency
+    }
+}
+
+jar {
+    manifest {
+        attributes 'Main-Class': 'io.spine.tools.protoc.Plugin'
+    }
+    // Assemble "Fat-JAR" artifact containing all the dependencies.
+    from {
+        configurations.compile.collect {
+            it.isDirectory() ? it : zipTree(it)
+        }
+    }
+}
+
+final def shellRunner = injectVersion(file('plugin_runner.sh'))
+final def batchRunner = injectVersion(file('plugin_runner.bat'))
+
+artifacts {
+    archives shellRunner
+    archives batchRunner
+}
+
+publishing {
+    publications {
+        runnerScript(MavenPublication) {
+            from components.java
+            groupId = "${group}"
+            artifactId = "spine-protoc-plugin"
+            version = "${version}"
+
+            [shellRunner, batchRunner].each { final script ->
+                final def path = script.getAbsolutePath()
+                final def ext = path.substring(path.lastIndexOf('.') + 1)
+                artifact(path) {
+                    classifier "script"
+                    extension ext
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Inserts the current Spine version into the given file replacing the {@code {@literal {version}}}
+ * string.
+ *
+ * <p>This insertion point is conventional for the runner scripts for the Spine protoc plugin.
+ *
+ * <p>Before the runner script is published, the version must be injected into it.
+ *
+ * <p>The standard Grade filtering mechanism (involving the Copy task) cannot be used in this case
+ * since the injection should be performed on the configuration stage.
+ *
+ * @param scriptFile the script file to modify
+ * @return the new script file to publish
+ */
+def injectVersion(File scriptFile) {
+    def text = scriptFile.text
+    text = text.replace("{version}", project.version)
+    final def tempFile = Files.createTempFile("build", scriptFile.name.endsWith(".sh") ? ".sh" : ".bat")
+    tempFile.text = text
+    final result = file(tempFile.toAbsolutePath())
+    return result
+}

--- a/protoc-plugin/plugin_runner.bat
+++ b/protoc-plugin/plugin_runner.bat
@@ -1,0 +1,3 @@
+@echo off
+
+java -jar ./.spine/spine-protoc-plugin-{version}.jar

--- a/protoc-plugin/plugin_runner.sh
+++ b/protoc-plugin/plugin_runner.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(pwd)"
+
+java -jar "${CURRENT_DIR}"/.spine/spine-protoc-plugin-{version}.jar

--- a/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceGenerator.java
+++ b/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceGenerator.java
@@ -1,0 +1,367 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import com.google.common.base.Optional;
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.Extension;
+import com.google.protobuf.GeneratedMessageV3.ExtendableMessage;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import com.squareup.javapoet.JavaFile;
+import io.spine.option.UnknownOptions;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Set;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableSet.of;
+import static io.spine.option.OptionsProto.everyIs;
+import static io.spine.option.OptionsProto.is;
+import static io.spine.tools.protoc.MarkerInterfaces.create;
+import static java.lang.String.format;
+
+/**
+ * The {@link SpineProtoGenerator} implementation generating the specific interfaces implemented by
+ * some message types.
+ *
+ * <p>The generator produces two types of {@link File CodeGeneratorResponse.File} instances
+ * representing:
+ * <ul>
+ *     <li>the marker interfaces derived from
+ *         {@link com.google.protobuf.Message com.google.protobuf.Message} (see
+ *         {@link MarkerInterfaces});
+ *     <li>the insertion entries to the existing messages (see
+ *         {@link File#getInsertionPoint() CodeGeneratorResponse.File.insertionPoint}).
+ * </ul>
+ *
+ * @author Dmytro Dashenkov
+ */
+public class MarkerInterfaceGenerator extends SpineProtoGenerator {
+
+    @VisibleForTesting
+    static final String INSERTION_POINT_IMPLEMENTS = "message_implements:%s";
+    private static final String PACKAGE_DELIMITER = ".";
+
+    private MarkerInterfaceGenerator() {
+        super();
+        // Prevent singleton class instantiation.
+    }
+
+    /**
+     * Retrieves the single instance of the {@link MarkerInterfaceGenerator} type.
+     */
+    public static SpineProtoGenerator instance() {
+        return Singleton.INSTANCE.value;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>The {@code MarkerInterfaceGenerator} implementation performs the message processing
+     * as follows:
+     * <ol>
+     *     <li>Checks the message has {@code (is)} option. If it does, the marker interface name is
+     *         extracted from it and both the marker interface and the message insertion point are
+     *         generated.
+     *     <li>Checks the message file has {@code (every_is)} option. If it does, the marker
+     *         interface name is extracted from it and both the marker interface and the message
+     *         insertion point are generated.
+     *     <li>Otherwise, no compiler response is generated for this message type.
+     * </ol>
+     */
+    @Override
+    protected Collection<File> processMessage(FileDescriptorProto file, DescriptorProto message) {
+        final Optional<MessageAndInterface> fromMsgOption = scanMsgOption(file, message);
+        if (fromMsgOption.isPresent()) {
+            return fromMsgOption.get().asSet();
+        }
+        final Optional<MessageAndInterface> fromFileOption = scanFileOption(file, message);
+        if (fromFileOption.isPresent()) {
+            return fromFileOption.get().asSet();
+        }
+        return of();
+    }
+
+    /**
+     * Scans the given {@linkplain FileDescriptorProto file} for the {@code (every_is)} option.
+     */
+    private static Optional<MessageAndInterface> scanFileOption(FileDescriptorProto file,
+                                                                DescriptorProto msg) {
+        final Optional<String> everyIs = getEveryIs(file);
+        if (everyIs.isPresent()) {
+            final MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
+            return Optional.of(resultingFile);
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    /**
+     * Scans the given {@linkplain DescriptorProto message} for the {@code (is)} option.
+     */
+    private static Optional<MessageAndInterface> scanMsgOption(FileDescriptorProto file,
+                                                               DescriptorProto msg) {
+        final Optional<String> everyIs = getIs(msg);
+        if (everyIs.isPresent()) {
+            final MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
+            return Optional.of(resultingFile);
+        } else {
+            return Optional.absent();
+        }
+    }
+
+    private static MessageAndInterface generateFile(FileDescriptorProto file,
+                                                    DescriptorProto msg,
+                                                    String optionValue) {
+        final String fileName = file.getOptions()
+                                    .getJavaMultipleFiles()
+                ? msg.getName()
+                : resolveName(file);
+        final String javaPackage = resolvePackage(file);
+        final File.Builder srcFile = prepareFile(fileName, javaPackage);
+        final MarkerInterfaceSpec interfaceSpec = prepareInterfaceFqn(optionValue, file);
+        final String messageFqn = file.getPackage() + PACKAGE_DELIMITER + msg.getName();
+        final File messageFile = implementInterface(srcFile,
+                                                    interfaceSpec.getFqn(),
+                                                    messageFqn);
+        final JavaFile interfaceContent = create(interfaceSpec.getPackageName(),
+                                                 interfaceSpec.getName());
+        final File interfaceFile = File.newBuilder()
+                                       .setName(toFileName(interfaceSpec.getPackageName(),
+                                                           interfaceSpec.getName()))
+                                       .setContent(interfaceContent.toString())
+                                       .build();
+        final MessageAndInterface result = new MessageAndInterface(messageFile, interfaceFile);
+        return result;
+    }
+
+    private static Optional<String> getEveryIs(FileDescriptorProto descriptor) {
+        final String value = UnknownOptions.getUnknownOptionValue(descriptor, everyIs.getNumber());
+        return getOptionalOption(value, descriptor.getOptions(), everyIs);
+    }
+
+    private static Optional<String> getIs(DescriptorProto descriptor) {
+        final String value = UnknownOptions.getUnknownOptionValue(descriptor, is.getNumber());
+        return getOptionalOption(value, descriptor.getOptions(), is);
+    }
+
+    /**
+     * Retrieves the value of the specified extension option.
+     *
+     * <p>The {@linkplain com.google.protobuf.DescriptorProtos proto descriptor API} behaves
+     * differently at the Protobuf compile time and at runtime. Thus, the method receives the value
+     * retrieved by the {@link UnknownOptions} utility. If the value is absent, the method ties to
+     * get the option value as a value of a resolved extension option, which is the runtime way.
+     *
+     * @param initialValue the value parsed from the options unknown fields
+     * @param options      the container of the options to get the value from
+     * @param option       the desired option
+     * @param <O>          the type of the options container
+     * @return the value of the option
+     *         {@linkplain com.google.common.base.Strings#isNullOrEmpty if any} or
+     *         {@link Optional#absent() Optional.absent()} otherwise
+     */
+    private static <O extends ExtendableMessage<O>> Optional<String>
+    getOptionalOption(@Nullable String initialValue, O options, Extension<O, String> option) {
+        if (isNullOrEmpty(initialValue)) {
+            return getResolvedOption(options, option);
+        } else {
+            return Optional.of(initialValue);
+        }
+    }
+
+    private static <O extends ExtendableMessage<O>> Optional<String>
+    getResolvedOption(O options, Extension<O, String> resolvedOption) {
+        final String value = options.getExtension(resolvedOption);
+        if (isNullOrEmpty(value)) {
+            return Optional.absent();
+        } else {
+            return Optional.of(value);
+        }
+    }
+
+    private static File implementInterface(File.Builder srcFile,
+                                           String interfaceTypeName,
+                                           String messageTypeName) {
+        final String insertionPoint = format(INSERTION_POINT_IMPLEMENTS, messageTypeName);
+        final File result = srcFile.setInsertionPoint(insertionPoint)
+                                   .setContent(interfaceTypeName + ',')
+                                   .build();
+        return result;
+    }
+
+    private static MarkerInterfaceSpec prepareInterfaceFqn(String optionValue,
+                                                           FileDescriptorProto srcFile) {
+        final MarkerInterfaceSpec spec;
+        if (optionValue.contains(PACKAGE_DELIMITER)) {
+            spec = MarkerInterfaceSpec.from(optionValue);
+        } else {
+            final String javaPackage = resolvePackage(srcFile);
+            spec = MarkerInterfaceSpec.newInstance(javaPackage, optionValue);
+        }
+        return spec;
+    }
+
+    private static String resolvePackage(FileDescriptorProto fileDescriptor) {
+        String javaPackage = fileDescriptor.getOptions()
+                                           .getJavaPackage();
+        if (isNullOrEmpty(javaPackage)) {
+            javaPackage = fileDescriptor.getPackage();
+        }
+        return javaPackage;
+    }
+
+    private static String resolveName(FileDescriptorProto fileDescriptor) {
+        String name = fileDescriptor.getOptions()
+                                    .getJavaOuterClassname();
+        if (isNullOrEmpty(name)) {
+            name = fileDescriptor.getName();
+        }
+        return name;
+    }
+
+    private static File.Builder prepareFile(String messageName, String javaPackage) {
+        final String nameFqn = toFileName(javaPackage, messageName);
+        final File.Builder srcFile = File.newBuilder()
+                                         .setName(nameFqn);
+        return srcFile;
+    }
+
+    private static String toFileName(String javaPackage, String typename) {
+        return (javaPackage + PACKAGE_DELIMITER + typename).replace('.', '/') + ".java";
+    }
+
+    /**
+     * The specification of the marker interface to be produces by the generator.
+     *
+     * <p>The specification includes the package name and the type name.
+     */
+    private static final class MarkerInterfaceSpec {
+
+        private final String packageName;
+        private final String name;
+
+        private MarkerInterfaceSpec(String packageName, String name) {
+            this.packageName = packageName;
+            this.name = name;
+        }
+
+        private static MarkerInterfaceSpec newInstance(String packageName, String name) {
+            return new MarkerInterfaceSpec(packageName, name);
+        }
+
+        /**
+         * Parses a {@code MarkerInterfaceSpec} from the given type fully qualified name.
+         */
+        private static MarkerInterfaceSpec from(String fullName) {
+            final int index = fullName.lastIndexOf(PACKAGE_DELIMITER);
+            final String name = fullName.substring(index + 1);
+            final String packageName = fullName.substring(0, index);
+            return new MarkerInterfaceSpec(packageName, name);
+        }
+
+        public String getPackageName() {
+            return packageName;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public String getFqn() {
+            return packageName + PACKAGE_DELIMITER + name;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MarkerInterfaceSpec that = (MarkerInterfaceSpec) o;
+            return Objects.equal(getPackageName(), that.getPackageName()) &&
+                    Objects.equal(getName(), that.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(getPackageName(), getName());
+        }
+
+        @Override
+        public String toString() {
+            return getFqn();
+        }
+    }
+
+    /**
+     * A tuple of two {@link File} instances representing a message and the marker interface
+     * resolved for that message.
+     */
+    private static final class MessageAndInterface {
+
+        private final File messageFile;
+        private final File interfaceFile;
+
+        private MessageAndInterface(File messageFile, File interfaceFile) {
+            this.messageFile = messageFile;
+            this.interfaceFile = interfaceFile;
+        }
+
+        /**
+         * Produces an immutable {@link Set} from this tuple.
+         */
+        private Set<File> asSet() {
+            return of(messageFile, interfaceFile);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            MessageAndInterface that = (MessageAndInterface) o;
+            return Objects.equal(messageFile, that.messageFile) &&
+                    Objects.equal(interfaceFile, that.interfaceFile);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(messageFile, interfaceFile);
+        }
+    }
+
+    private enum Singleton {
+        INSTANCE;
+
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final SpineProtoGenerator value = new MarkerInterfaceGenerator();
+    }
+}

--- a/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaces.java
+++ b/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaces.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.protobuf.Message;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.TypeSpec;
+
+import javax.annotation.Generated;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static javax.lang.model.element.Modifier.PUBLIC;
+
+/**
+ * A factory for {@link Message} derived marker interfaces extracted from {@code .proto} files.
+ *
+ * <p>Each interface is marked with {@link Generated @Generated} annotation. No more additional
+ * declarations are made.
+ *
+ * @author Dmytro Dashenkov
+ */
+final class MarkerInterfaces {
+
+    private static final AnnotationSpec GENERATED;
+    private static final String GENERATED_FIELD_NAME = "value";
+
+    static {
+        final CodeBlock generatedByDescription = CodeBlock.of("\"by Spine protoc plugin\"");
+        GENERATED = AnnotationSpec.builder(Generated.class)
+                                  .addMember(GENERATED_FIELD_NAME, generatedByDescription)
+                                  .build();
+    }
+
+    private MarkerInterfaces() {
+        // Prevent utility class instantiation.
+    }
+
+    /**
+     * Generates a marker interface with the given name and package.
+     *
+     * @param packageName the name of the package of the required interface
+     * @param typeName    the name of the required interface
+     * @return {@link JavaFile} instance representing the desired interface
+     */
+    static JavaFile create(String packageName, String typeName) {
+        checkNotNull(packageName);
+        checkNotNull(typeName);
+        final TypeSpec spec = TypeSpec.interfaceBuilder(typeName)
+                                      .addSuperinterface(Message.class)
+                                      .addModifiers(PUBLIC)
+                                      .addAnnotation(GENERATED)
+                                      .build();
+        final JavaFile javaFile = JavaFile.builder(packageName, spec)
+                                          .build();
+        return javaFile;
+    }
+}

--- a/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
+++ b/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.protobuf.CodedInputStream;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A Protobuf Compiler ({@literal a.k.a.} {@code protoc}) plugin.
+ *
+ * <p>The program reads a {@link CodeGeneratorRequest} from {@code System.in} and writes
+ * a {@link CodeGeneratorResponse} into the {@code System.out}.
+ *
+ * <p>For the description of the plugin behavior see {@link MarkerInterfaceGenerator}.
+ *
+ * <p>For the plugin mechanism see <a href="SpineProtoGenerator.html#contract">{@code SpineProtoGenerator}</a>.
+ *
+ * @author Dmytro Dashenkov
+ */
+public class Plugin {
+
+    private Plugin() {
+        // Prevent instantiation.
+    }
+
+    /**
+     * The entry point of the program.
+     */
+    public static void main(String[] args) {
+        final CodeGeneratorRequest request = readRequest();
+        final SpineProtoGenerator generator = MarkerInterfaceGenerator.instance();
+        final CodeGeneratorResponse response = generator.process(request);
+        writeResponse(response);
+    }
+
+    private static CodeGeneratorRequest readRequest() {
+        final CodedInputStream stream = CodedInputStream.newInstance(System.in);
+        try {
+            final CodeGeneratorRequest request = CodeGeneratorRequest.parseFrom(stream);
+            return request;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static void writeResponse(CodeGeneratorResponse response) {
+        checkNotNull(response);
+        @SuppressWarnings("UseOfSystemOutOrSystemErr") // Required by the protoc API.
+        final CodedOutputStream stream = CodedOutputStream.newInstance(System.out);
+        try {
+            response.writeTo(stream);
+            stream.flush();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/protoc-plugin/src/main/java/io/spine/tools/protoc/SpineProtoGenerator.java
+++ b/protoc-plugin/src/main/java/io/spine/tools/protoc/SpineProtoGenerator.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import com.google.protobuf.compiler.PluginProtos.Version;
+
+import java.util.Collection;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.collect.Sets.newHashSet;
+
+/**
+ * An abstract base for the Protobuf code generator.
+ *
+ * <p>A generator consumes a {@link DescriptorProto} for each message type and optionally generates
+ * some Java code in response to it regarding {@linkplain FileDescriptorProto its file}.
+ *
+ * <a name="contract"></a>
+ * <p>Each message type is processed separately. As the result of processing, a generator may
+ * produce instances of {@link File CodeGeneratorResponse.File}.
+ *
+ * <p>The {@code CodeGeneratorResponse.File} has three fields: {@code name}, {@code insertionPoint}
+ * and {@code content}.
+ *
+ * <p>The {@code name} field represents the name of the file to generate. The name is relative to
+ * the output directory and should not contain {@code ./} or {@code ../} prefixes.
+ *
+ * <p>The {@code content} field represents the code snippet to write into the file. This field is
+ * required.
+ *
+ * <p>To make the {@code protoc} generate a new file from the scratch, the the generator should
+ * produce {@code CodeGeneratorResponse.File} instance with the {@code name} and {@code content}
+ * fields. The {@code insertionPoint} field is omitted in this case.
+ *
+ * <p>To extend an existing {@code protoc} plugin (e.g. built-in {@code java} plugin), use
+ * {@code insertionPoint} field. The value of the field must correspond to an existing insertion
+ * point declared by the extended plugin. The insertion points are declared in the generated code
+ * as follows:
+ * {@code @@protoc_insertion_point(NAME)}, where {@code NAME} is value to set into the field.
+ *
+ * <p>If the {@code insertionPoint} field is present, the {@code name} field must also be present.
+ * The {@code content} field contains the value to insert into the insertion point is this case.
+ *
+ * @author Dmytro Dashenkov
+ */
+public abstract class SpineProtoGenerator {
+
+    protected SpineProtoGenerator() {
+        super();
+    }
+
+    /**
+     * Processes a single message type and generates from zero to many {@link File} instances in
+     * response to the message type.
+     *
+     * <p>The output {@linkplain File Files} may:
+     * <ul>
+     *     <li>contain the {@linkplain File#getInsertionPoint() insertion points};
+     *     <li>be empty;
+     *     <li>contain extra types to generate for the given message declaration.
+     * </ul>
+     *
+     * <p>Note that this method may produce identical {@link File CodeGeneratorResponse.File}
+     * instances (i.e. equal in terms of {@link Object#equals(Object) equals()} method), but should
+     * not produce non-equal instances with the same value of
+     * {@code CodeGeneratorResponse.File.name} field. Such entries cause {@code protoc} to fail
+     * and should be filtered on the early stage.
+     *
+     * @param file    the message type enclosing file
+     * @param message the message type to process
+     * @return optionally a {@link Collection} of {@linkplain File Files} to generate or an empty
+     * {@code Collection}
+     */
+    protected abstract Collection<File> processMessage(FileDescriptorProto file,
+                                                       DescriptorProto message);
+
+    /**
+     * Processes the given compiler request and generates the response to the compiler.
+     *
+     * <p>Each {@linkplain FileDescriptorProto .proto file} may cause none, one or many
+     * generated {@link File CodeGeneratorResponse.File} instances.
+     *
+     * <p>Note: there are several preconditions for this method to run successfully:
+     * <ul>
+     *     <li>since Spine relies on 3rd version of Protobuf, the Proto compiler version should be
+     *         {@code 3.x.x} or greater;
+     *     <li>there must be at least one {@code .proto} file in the {@link CodeGeneratorRequest}.
+     * </ul>
+     *
+     * @param request the compiler request
+     * @return the response to the compiler
+     * @see #processMessage(FileDescriptorProto, DescriptorProto) for more detaineed behavior
+     *                                                            description
+     */
+    public final CodeGeneratorResponse process(CodeGeneratorRequest request) {
+        checkNotNull(request);
+        checkNotNull(request);
+        final Version protocVersion = request.getCompilerVersion();
+        checkArgument(protocVersion.getMajor() >= 3,
+                      "Use protoc of version 3.X.X or higher to generate the Spine sources.");
+        final List<FileDescriptorProto> descriptors = request.getProtoFileList();
+        checkArgument(!descriptors.isEmpty(), "No files to generate provided.");
+        final CodeGeneratorResponse response = scan(descriptors);
+        return response;
+    }
+
+    private CodeGeneratorResponse scan(Iterable<FileDescriptorProto> files) {
+        final Collection<File> generatedFiles = newHashSet();
+        for (FileDescriptorProto file : files) {
+            generatedFiles.addAll(scanFile(file));
+        }
+        final CodeGeneratorResponse response = CodeGeneratorResponse.newBuilder()
+                                                                    .addAllFile(generatedFiles)
+                                                                    .build();
+        return response;
+    }
+
+    private Collection<File> scanFile(FileDescriptorProto file) {
+        final Collection<File> result = newHashSet();
+        for (DescriptorProto message : file.getMessageTypeList()) {
+            final Collection<File> processedFile = processMessage(file, message);
+            result.addAll(processedFile);
+        }
+        return result;
+    }
+}

--- a/protoc-plugin/src/main/java/io/spine/tools/protoc/package-info.java
+++ b/protoc-plugin/src/main/java/io/spine/tools/protoc/package-info.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This package contains the basic mechanism of building the {@code protoc} plugins.
+ *
+ * <p>See <a href="https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.compiler.plugin.pb">
+ *    Google documentation</a> for more info about the {@code protoc} plugins
+ */
+
+@ParametersAreNonnullByDefault
+package io.spine.tools.protoc;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorShould.java
+++ b/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorShould.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.common.testing.NullPointerTester;
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
+import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
+import com.google.protobuf.compiler.PluginProtos.Version;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static io.spine.tools.protoc.MarkerInterfaceGenerator.INSERTION_POINT_IMPLEMENTS;
+import static java.lang.String.format;
+import static java.util.regex.Pattern.compile;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class MarkerInterfaceGeneratorShould {
+
+    private static final String PROTO_PACKAGE = "spine.tools.protoc.";
+
+    private static final String PACKAGE_PATH =
+            MarkerInterfaceGeneratorShould.class.getPackage()
+                                                .getName()
+                                                .replace('.', '/');
+    private static final Pattern CUSTOMER_EVENT_INTERFACE_PATTERN =
+            compile("^\\s*io\\.spine\\.tools\\.protoc\\.ProtocCustomerEvent\\s*,\\s*$");
+
+    private static final Pattern CUSTOMER_EVENT_INTERFACE_DECL_PATTERN =
+            compile("public\\s+interface\\s+ProtocCustomerEvent\\s*extends\\s+Message\\s*\\{\\s*}");
+
+
+    private static final Pattern CUSTOMER_EVENT_OR_COMMAND =
+            compile("Customer(Command|Event)");
+
+    private SpineProtoGenerator codeGenerator;
+
+    @Before
+    public void setUp() {
+        codeGenerator = MarkerInterfaceGenerator.instance();
+    }
+
+    @Test
+    public void not_accept_nulls() {
+        new NullPointerTester()
+                .setDefault(CodeGeneratorRequest.class, CodeGeneratorRequest.getDefaultInstance())
+                .testAllPublicStaticMethods(MarkerInterfaceGenerator.class);
+    }
+
+    @Test
+    public void generate_insertion_point_contents_for_EveryIs_option() {
+        // Sample path; never resolved
+        final String filePath = "/proto/spine/tools/protoc/every_is_test.proto";
+
+        final FileDescriptorProto descriptor = EveryIsTestProto.getDescriptor().toProto();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version())
+                                                                 .addFileToGenerate(filePath)
+                                                                 .addProtoFile(descriptor)
+                                                                 .build();
+        final CodeGeneratorResponse response = codeGenerator.process(request);
+        assertNotNull(response);
+        final List<File> files = response.getFileList();
+        assertEquals(3, files.size());
+        for (File file : files) {
+            final String name = file.getName();
+            assertTrue(name.startsWith(PACKAGE_PATH));
+
+            final String insertionPoint = file.getInsertionPoint();
+            if (!insertionPoint.isEmpty()) {
+                final String messageName = PROTO_PACKAGE + name.substring(name.lastIndexOf('/') + 1,
+                                                                          name.lastIndexOf('.'));
+                assertEquals(insertionPoint, format(INSERTION_POINT_IMPLEMENTS, messageName));
+
+                final String content = file.getContent();
+                final Matcher matcher = CUSTOMER_EVENT_INTERFACE_PATTERN.matcher(content);
+                assertTrue(matcher.matches());
+            } else {
+                final String content = file.getContent();
+                final Matcher matcher = CUSTOMER_EVENT_INTERFACE_DECL_PATTERN.matcher(content);
+                assertTrue(matcher.find());
+            }
+        }
+    }
+
+    @Test
+    public void generate_insertion_point_contents_for_Is_option() {
+        // Sample path; never resolved
+        final String filePath = "/proto/spine/tools/protoc/is_test.proto";
+
+        final FileDescriptorProto descriptor = IsTestProto.getDescriptor().toProto();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version())
+                                                                 .addFileToGenerate(filePath)
+                                                                 .addProtoFile(descriptor)
+                                                                 .build();
+        final CodeGeneratorResponse response = codeGenerator.process(request);
+        assertNotNull(response);
+        final List<File> files = response.getFileList();
+        assertEquals(4, files.size());
+        for (File file : files) {
+            final String name = file.getName();
+            assertTrue(name.startsWith(PACKAGE_PATH));
+
+            final String insertionPoint = file.getInsertionPoint();
+            if (!insertionPoint.isEmpty()) {
+                final String messageName = PROTO_PACKAGE + name.substring(name.lastIndexOf('/') + 1, name.lastIndexOf('.'));
+                assertEquals(format(INSERTION_POINT_IMPLEMENTS, messageName), insertionPoint);
+            }
+
+            final String content = file.getContent();
+            if (name.endsWith("ProtocNameUpdated.java")) {
+                assertTrue(content.contains("Event,"));
+            } else if (name.endsWith("ProtocUpdateName.java")) {
+                assertTrue(content.contains("Command,"));
+            } else {
+                assertTrue(CUSTOMER_EVENT_OR_COMMAND.matcher(name).find());
+            }
+        }
+    }
+
+    @Test
+    public void generate_insertion_point_contents_for_EveryIs_in_single_file() {
+        // Sample path; never resolved
+        final String filePath = "/proto/spine/tools/protoc/every_is_in_one_file.proto";
+
+        final FileDescriptorProto descriptor = EveryIsInOneFileProto.getDescriptor().toProto();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version())
+                                                                 .addFileToGenerate(filePath)
+                                                                 .addProtoFile(descriptor)
+                                                                 .build();
+        final CodeGeneratorResponse response = codeGenerator.process(request);
+        assertNotNull(response);
+        final List<File> files = response.getFileList();
+        assertEquals(3, files.size());
+        for (File file : files) {
+            if (!file.getName().equals("io/spine/tools/protoc/ProtocCustomerEvent.java")) {
+                final String name = file.getName();
+                assertEquals(PACKAGE_PATH + "/EveryIsInOneFileProto.java", name);
+
+                final String insertionPoint = file.getInsertionPoint();
+                assertTrue(insertionPoint.startsWith(format(INSERTION_POINT_IMPLEMENTS,
+                                                            PROTO_PACKAGE)));
+                final String content = file.getContent();
+                final Matcher matcher = CUSTOMER_EVENT_INTERFACE_PATTERN.matcher(content);
+                assertTrue(content, matcher.matches());
+            }
+        }
+    }
+
+    @Test
+    public void generate_insertion_point_contents_for_Is_in_single_file() {
+        // Sample path; never resolved
+        final String filePath = "/proto/spine/tools/protoc/is_in_one_file.proto";
+
+        final FileDescriptorProto descriptor = IsInOneFileProto.getDescriptor().toProto();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version())
+                                                                 .addFileToGenerate(filePath)
+                                                                 .addProtoFile(descriptor)
+                                                                 .build();
+        final CodeGeneratorResponse response = codeGenerator.process(request);
+        assertNotNull(response);
+        final List<File> files = response.getFileList();
+        assertEquals(3, files.size());
+        for (File file : files) {
+            if (file.getName().endsWith("Event.java")) {
+                assertFalse(file.hasInsertionPoint());
+            } else {
+                final String name = file.getName();
+                assertEquals(PACKAGE_PATH + "/IsInOneFileProto.java", name);
+
+                final String insertionPoint = file.getInsertionPoint();
+                assertTrue(insertionPoint.startsWith(format(INSERTION_POINT_IMPLEMENTS,
+                                                            PROTO_PACKAGE)));
+                final String content = file.getContent();
+                final Matcher matcher = CUSTOMER_EVENT_INTERFACE_PATTERN.matcher(content);
+                assertTrue(format("Unexpected inserted content: %s", content), matcher.matches());
+            }
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void not_accept_requests_from_old_compiler() {
+        final Version version = Version.newBuilder()
+                                       .setMajor(2)
+                                       .build();
+        final FileDescriptorProto stubFile = FileDescriptorProto.getDefaultInstance();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version)
+                                                                 .addProtoFile(stubFile)
+                                                                 .build();
+        codeGenerator.process(request);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void not_accept_empty_requests() {
+        final Version version = Version.newBuilder()
+                                       .setMajor(3)
+                                       .build();
+        final CodeGeneratorRequest request = CodeGeneratorRequest.newBuilder()
+                                                                 .setCompilerVersion(version)
+                                                                 .build();
+        codeGenerator.process(request);
+    }
+
+    private static Version version() {
+        return Version.newBuilder()
+                      .setMajor(3)
+                      .setMinor(3)
+                      .setPatch(0)
+                      .build();
+    }
+}

--- a/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfacesShould.java
+++ b/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfacesShould.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.protoc;
+
+import com.google.common.testing.NullPointerTester;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.JavaFile;
+import org.junit.Test;
+
+import javax.annotation.Generated;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Dmytro Dashenkov
+ */
+public class MarkerInterfacesShould {
+
+    @Test
+    public void not_accept_nulls_on_construction() {
+        new NullPointerTester().testAllPublicConstructors(MarkerInterfaces.class);
+    }
+
+    @Test
+    public void not_accept_nulls() {
+        new NullPointerTester().testAllPublicStaticMethods(MarkerInterfaces.class);
+    }
+
+    @Test
+    public void generate_interfaces() {
+        final String packageName = "io.spine.test";
+        final String interfaceName = "CustomerEvent";
+        final JavaFile javaFile = MarkerInterfaces.create(packageName, interfaceName);
+
+        final AnnotationSpec generated = javaFile.typeSpec.annotations.get(0);
+        assertEquals(Generated.class.getName(), generated.type.toString());
+
+        assertEquals(packageName, javaFile.packageName);
+        assertEquals(interfaceName, javaFile.typeSpec.name);
+    }
+}

--- a/protoc-plugin/src/test/proto/spine/tools/protoc/every_is_in_one_file.proto
+++ b/protoc-plugin/src/test/proto/spine/tools/protoc/every_is_in_one_file.proto
@@ -1,0 +1,46 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_generate_equals_and_hash = true;
+option java_multiple_files = false;
+option java_outer_classname = "EveryIsInOneFileProto";
+option java_package = "io.spine.tools.protoc";
+
+option (every_is) = "io.spine.tools.protoc.ProtocCustomerEvent";
+
+import "google/protobuf/descriptor.proto";
+
+message ProtocCustomerNotified {
+
+    string uid = 1;
+    string email_content = 2;
+}
+
+message ProtocCustomerEmailRecieved {
+
+    string uid = 1;
+    string email_content = 2;
+}

--- a/protoc-plugin/src/test/proto/spine/tools/protoc/every_is_test.proto
+++ b/protoc-plugin/src/test/proto/spine/tools/protoc/every_is_test.proto
@@ -1,0 +1,44 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_generate_equals_and_hash = true;
+option java_multiple_files = true;
+option java_outer_classname = "EveryIsTestProto";
+option java_package = "io.spine.tools.protoc";
+
+option (every_is) = "io.spine.tools.protoc.ProtocCustomerEvent";
+
+import "google/protobuf/descriptor.proto";
+
+message ProtocCustomerCreated {
+
+    string uid = 1;
+}
+
+message ProtocCustomerDeleted {
+
+    string uid = 1;
+}

--- a/protoc-plugin/src/test/proto/spine/tools/protoc/is_in_one_file.proto
+++ b/protoc-plugin/src/test/proto/spine/tools/protoc/is_in_one_file.proto
@@ -1,0 +1,51 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_generate_equals_and_hash = true;
+option java_multiple_files = false;
+option java_outer_classname = "IsInOneFileProto";
+option java_package = "io.spine.tools.protoc";
+
+message ProtocAddressUpdated {
+    option (is) = "io.spine.tools.protoc.ProtocCustomerEvent";
+
+    string uid = 1;
+    string new_address = 2;
+}
+
+message ProtocPlanUpdated {
+    option (is) = "io.spine.tools.protoc.ProtocCustomerEvent";
+
+    string uid = 1;
+    Plan new_plan = 2;
+}
+
+enum Plan {
+    PLAN_UNDEFINED = 0;
+    FREE = 1;
+    TRIAL = 2;
+    FULL = 3;
+}

--- a/protoc-plugin/src/test/proto/spine/tools/protoc/is_test.proto
+++ b/protoc-plugin/src/test/proto/spine/tools/protoc/is_test.proto
@@ -1,0 +1,50 @@
+//
+// Copyright 2017, TeamDev Ltd. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_generate_equals_and_hash = true;
+option java_multiple_files = true;
+option java_outer_classname = "IsTestProto";
+option java_package = "io.spine.tools.protoc";
+
+import "google/protobuf/descriptor.proto";
+
+message ProtocNameUpdated {
+    option (is) = "io.spine.tools.protoc.ProtocCustomerEvent";
+
+    string uid = 1;
+    Name new_name = 2;
+}
+
+message ProtocUpdateName {
+    option (is) = "io.spine.tools.protoc.ProtocCustomerCommand";
+
+    string uid = 1;
+    Name new_name = 2;
+}
+
+message Name {
+    string value = 1;
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,3 +9,4 @@ project(':model-compiler').projectDir = new File('./gradle-plugins/model-compile
 include 'base'
 include 'testutil-base'
 
+include 'protoc-plugin'


### PR DESCRIPTION
This PR is a part of #43 PR which introduces the marker interface generation upon `(is)` and `(every_is)` options.

In order to be run and tested on CI properly, it is split into two separate pull requests.