### PR TITLE
Protoc plugin integration tests

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.53-SNAPSHOT'
+def final SPINE_VERSION = '0.9.54-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
@@ -42,7 +42,7 @@ ext {
 
     // We use Spine tools and model compiler in the build process.
     spineToolsVersion = '0.9.41-SNAPSHOT'
-    spineModelCompilerVersion = '0.9.52-SNAPSHOT'
+    spineModelCompilerVersion = '0.9.53-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.3'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,4 @@ project(':model-compiler').projectDir = new File('./gradle-plugins/model-compile
 include 'base'
 include 'testutil-base'
 include 'protoc-plugin'
-
-// To be re-enabled in 0.9.54-SNAPSHOT
-//include 'protoc-plugin-tests'
+include 'protoc-plugin-tests'


### PR DESCRIPTION
This PR brings the integration tests for the `protoc-plugin` module.

The codebase is already present in `master`. Now we only update the `settings.gradle` to include that code into the build.