### PR TITLE
Clean Spine directory

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,12 +25,12 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.55-SNAPSHOT'
+def final SPINE_VERSION = '0.9.56-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
 
-    spineCoreVersion = '0.9.55-SNAPSHOT'
+    spineCoreVersion = '0.9.60-SNAPSHOT'
 
     guavaVersion = '20.0'
     findBugsVersion = '3.0.0'
@@ -44,7 +44,7 @@ ext {
 
     // We use Spine tools and model compiler in the build process.
     spineToolsVersion = '0.9.51-SNAPSHOT'
-    spineModelCompilerVersion = '0.9.54-SNAPSHOT'
+    spineModelCompilerVersion = '0.9.55-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.3'
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -73,7 +73,7 @@ dependencies {
 
     compile project(':testutil-base')
     testCompile group: 'com.google.guava', name: 'guava-testlib', version: guavaVersion
-    compile group: 'org.hamcrest', name:'hamcrest-all', version: hamcrestVersion
+    testCompile group: 'org.hamcrest', name:'hamcrest-all', version: hamcrestVersion
     testCompile gradleTestKit()
     testCompile project(':plugin-base').sourceSets.test.output // Test classes of `plugin-base`
 

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -112,6 +112,7 @@ task prepareProtocConfig(type: Copy) {
                                    'gRPCVersion': "'$project.gRpcVersion'".toString(),
                                    'spineDir': "'.spine'".toString()])
     // TODO:2017-08-31:dmytro.dashenkov: Replace ".spine" with "Extension.SPINE_BUILD_ARTIFACT_STORAGE_DIR".
+    // https://github.com/SpineEventEngine/base/issues/51
 
     outputs.upToDateWhen { false }
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -73,6 +73,7 @@ dependencies {
 
     compile project(':testutil-base')
     testCompile group: 'com.google.guava', name: 'guava-testlib', version: guavaVersion
+    compile group: 'org.hamcrest', name:'hamcrest-all', version: hamcrestVersion
     testCompile gradleTestKit()
     testCompile project(':plugin-base').sourceSets.test.output // Test classes of `plugin-base`
 

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -1,9 +1,7 @@
-import io.spine.gradle.compiler.Extension
 import org.apache.tools.ant.filters.ReplaceTokens
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
-
 //
 // Copyright 2017, TeamDev Ltd. All rights reserved.
 //
@@ -112,7 +110,8 @@ task prepareProtocConfig(type: Copy) {
     filter(ReplaceTokens, tokens: ['baseVersion': "'$project.spineVersion'".toString(),
                                    'pbVersion': "'$project.protobufVersion'".toString(),
                                    'gRPCVersion': "'$project.gRpcVersion'".toString(),
-                                   'spineDir': "'${Extension.SPINE_BUILD_ARTIFACT_STORAGE_DIR}'".toString()])
+                                   'spineDir': "'.spine'".toString()])
+    // TODO:2017-08-31:dmytro.dashenkov: Replace ".spine" with "Extension.SPINE_BUILD_ARTIFACT_STORAGE_DIR".
 
     outputs.upToDateWhen { false }
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -1,3 +1,6 @@
+import io.spine.gradle.compiler.Extension
+import org.apache.tools.ant.filters.ReplaceTokens
+
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
 
@@ -102,13 +105,14 @@ protobuf {
  */
 task prepareProtocConfig(type: Copy) {
     description = "Prepares the spine_protoc.gradle file"
-    
+
     from "./spine_protoc.gradle"
     into "./src/main/resources"
 
-    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: ['baseVersion': "'$project.spineVersion'".toString(),
-                                                                'pbVersion': "'$project.protobufVersion'".toString(),
-                                                                'gRPCVersion': "'$project.gRpcVersion'".toString()])
+    filter(ReplaceTokens, tokens: ['baseVersion': "'$project.spineVersion'".toString(),
+                                   'pbVersion': "'$project.protobufVersion'".toString(),
+                                   'gRPCVersion': "'$project.gRpcVersion'".toString(),
+                                   'spineDir': "'${Extension.SPINE_BUILD_ARTIFACT_STORAGE_DIR}'".toString()])
 
     outputs.upToDateWhen { false }
 }

--- a/gradle-plugins/model-compiler/spine_protoc.gradle
+++ b/gradle-plugins/model-compiler/spine_protoc.gradle
@@ -25,6 +25,7 @@ import java.nio.file.StandardCopyOption
 final def spineModelCompilerVersion = @baseVersion@
 final def protobufVersion = @pbVersion@
 final def gRpcVersion = @gRPCVersion@
+final def spineFolderName = @spineDir@
 
 buildscript {
     ext {
@@ -55,8 +56,8 @@ dependencies {
 
 ext {
     runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
-    spineFolder = ("$project.projectDir/.spine" as File).toPath()
-    rootSpineFolder = ("$project.rootDir/.spine" as File).toPath()
+    spineFolder = ("$project.projectDir/.$spineFolderName" as File).toPath()
+    rootSpineFolder = ("$project.rootDir/.$spineFolderName" as File).toPath()
 }
 
 final def copyPluginJarAction = {

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
@@ -20,17 +20,22 @@
 package io.spine.gradle.compiler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.LinkedList;
 import java.util.List;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.gradle.compiler.ModelCompilerPlugin.SPINE_MODEL_COMPILER_EXTENSION_NAME;
-import static java.util.Collections.singletonList;
 
 /**
  * A configuration for the {@link ModelCompilerPlugin}.
@@ -41,6 +46,8 @@ import static java.util.Collections.singletonList;
 // as this is a Gradle extension.
 public class Extension {
 
+    @VisibleForTesting
+    static final String SPINE_BUILD_ARTIFACT_STORAGE_DIR = ".spine";
     private static final String DEFAULT_GEN_ROOT_DIR = "/generated";
 
     private static final String DEFAULT_MAIN_PROTO_SRC_DIR = "/src/main/proto";
@@ -280,20 +287,51 @@ public class Extension {
     }
 
     public static List<String> getDirsToClean(Project project) {
+        final List<String> dirsToClean = newLinkedList(spineDirs(project));
         log().debug("Finding the directories to clean");
         final List<String> dirs = spineProtobuf(project).dirsToClean;
+        final String singleDir = spineProtobuf(project).dirToClean;
         if (dirs.size() > 0) {
             log().error("Found {} directories to clean: {}", dirs.size(), dirs);
-            return ImmutableList.copyOf(dirs);
-        }
-        final String singleDir = spineProtobuf(project).dirToClean;
-        if (singleDir != null && !singleDir.isEmpty()) {
+            dirsToClean.addAll(dirs);
+        } else if (singleDir != null && !singleDir.isEmpty()) {
             log().debug("Found directory to clean: {}", singleDir);
-            return singletonList(singleDir);
+            dirsToClean.add(singleDir);
+        } else {
+            final String defaultValue = root(project) + DEFAULT_GEN_ROOT_DIR;
+            log().debug("Default directory to clean: {}", defaultValue);
+            dirsToClean.add(defaultValue);
         }
-        final String defaultValue = root(project) + DEFAULT_GEN_ROOT_DIR;
-        log().debug("Default directory to clean: {}", defaultValue);
-        return singletonList(defaultValue);
+        return ImmutableList.copyOf(dirsToClean);
+    }
+
+    private static Iterable<String> spineDirs(Project project) {
+        final List<String> spineDirs = newLinkedList();
+        final Optional<String> spineDir = spineDir(project);
+        final Optional<String> rootSpineDir = spineDir(project.getRootProject());
+        if (spineDir.isPresent()) {
+            spineDirs.add(spineDir.get());
+            if (rootSpineDir.isPresent() && !spineDir.equals(rootSpineDir)) {
+                spineDirs.add(rootSpineDir.get());
+            }
+        }
+        return spineDirs;
+    }
+
+    private static Optional<String> spineDir(Project project) {
+        final File projectDir;
+        try {
+            projectDir = project.getProjectDir().getCanonicalFile();
+        } catch (IOException e) {
+            throw new IllegalStateException("Project directory is invalid!", e);
+        }
+        final Path projectPath = projectDir.toPath();
+        final Path spinePath = projectPath.resolve(SPINE_BUILD_ARTIFACT_STORAGE_DIR);
+        if (Files.exists(spinePath)) {
+            return Optional.of(spinePath.toString());
+        } else {
+            return Optional.absent();
+        }
     }
 
     private static String root(Project project) {

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
@@ -22,6 +22,7 @@ package io.spine.gradle.compiler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import io.spine.annotation.Internal;
 import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,9 +47,17 @@ import static io.spine.gradle.compiler.ModelCompilerPlugin.SPINE_MODEL_COMPILER_
 // as this is a Gradle extension.
 public class Extension {
 
+    /**
+     * The Spine internal directory name for storing temporary build artifacts.
+     *
+     * <p>Spine Gradle tasks may write some temporary files into this directory.
+     *
+     * <p>The directory is deleted on {@code :pre-clean"}.
+     */
+    @Internal
     public static final String SPINE_BUILD_ARTIFACT_STORAGE_DIR = ".spine";
-    private static final String DEFAULT_GEN_ROOT_DIR = "/generated";
 
+    private static final String DEFAULT_GEN_ROOT_DIR = "/generated";
     private static final String DEFAULT_MAIN_PROTO_SRC_DIR = "/src/main/proto";
     private static final String DEFAULT_MAIN_GEN_RES_DIR = DEFAULT_GEN_ROOT_DIR + "/main/resources";
     private static final String DEFAULT_MAIN_GEN_DIR = DEFAULT_GEN_ROOT_DIR + "/main/java";

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
@@ -46,8 +46,7 @@ import static io.spine.gradle.compiler.ModelCompilerPlugin.SPINE_MODEL_COMPILER_
 // as this is a Gradle extension.
 public class Extension {
 
-    @VisibleForTesting
-    static final String SPINE_BUILD_ARTIFACT_STORAGE_DIR = ".spine";
+    public static final String SPINE_BUILD_ARTIFACT_STORAGE_DIR = ".spine";
     private static final String DEFAULT_GEN_ROOT_DIR = "/generated";
 
     private static final String DEFAULT_MAIN_PROTO_SRC_DIR = "/src/main/proto";

--- a/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/given/Given.java
+++ b/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/given/Given.java
@@ -20,9 +20,11 @@
 
 package io.spine.gradle.compiler.given;
 
+import com.google.common.io.Files;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
 
+import java.io.File;
 import java.util.UUID;
 
 import static io.spine.gradle.TaskName.CLASSES;
@@ -50,7 +52,19 @@ public class Given {
 
     /** Creates a project with all required tasks. */
     public static Project newProject() {
+        return newProject(Files.createTempDir());
+    }
+
+    /**
+     * Creates a project with all required tasks.
+     *
+     * <p>The project will be placed into the given directory.
+     *
+     * @param projectDir {@link Project#getProjectDir() Project.getProjectDir()} of the project
+     */
+    public static Project newProject(File projectDir) {
         final Project project = ProjectBuilder.builder()
+                                              .withProjectDir(projectDir)
                                               .build();
         project.task(CLEAN.getValue());
         project.task(GENERATE_PROTO.getValue());


### PR DESCRIPTION
In this PR:
 - `${projectDir}/.spine/` directory is included to the clean directories by default (fixes #47);
 - `GradleProject` API enhanced to make it possible to switch the debug mode if required.