### PR TITLE
Update and cleanup before `0.10.0` release

### DIFF
--- a/base/src/main/proto/spine/money/money.proto
+++ b/base/src/main/proto/spine/money/money.proto
@@ -178,8 +178,14 @@ enum Currency {
         numeric_code: 986,
         exponent_digits: 2 }];
 
-    // This identifier caused naming conflicts in C++ version of Spine client.
-    // Therefore it is now named with `_` suffix to avoid any confusion.
+    // This identifier previously caused naming conflict in C++ version of Spine client.
+    // Therefore it was renamed by appending `_` suffix to its name.
+    //
+    // In particular, in Unix-like operating systems a system header file `sys/param.h` often
+    // defines `BSD` as one of the system-specific constants.
+    //
+    // Therefore, the compilation of the C++ code, generated from the original `Currency.BSD`
+    // enum value, would always fail under these operating systems.
     BSD_ = 21 [(currency) = {
         name: "Bahamian Dollar",
         symbol: "B$",

--- a/base/src/main/proto/spine/money/money.proto
+++ b/base/src/main/proto/spine/money/money.proto
@@ -177,6 +177,9 @@ enum Currency {
         symbol: "R$",
         numeric_code: 986,
         exponent_digits: 2 }];
+
+    // This identifier caused naming conflicts in C++ version of Spine client.
+    // Therefore it is now named with `_` suffix to avoid any confusion.
     BSD_ = 21 [(currency) = {
         name: "Bahamian Dollar",
         symbol: "B$",

--- a/base/src/main/proto/spine/money/money.proto
+++ b/base/src/main/proto/spine/money/money.proto
@@ -177,7 +177,7 @@ enum Currency {
         symbol: "R$",
         numeric_code: 986,
         exponent_digits: 2 }];
-    BSD = 21 [(currency) = {
+    BSD_ = 21 [(currency) = {
         name: "Bahamian Dollar",
         symbol: "B$",
 		numeric_code: 44,

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.76-SNAPSHOT'
+def final SPINE_VERSION = '0.9.77-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,12 +25,10 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.56-SNAPSHOT'
+def final SPINE_VERSION = '0.9.76-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
-
-    spineCoreVersion = '0.9.60-SNAPSHOT'
 
     guavaVersion = '20.0'
     findBugsVersion = '3.0.0'


### PR DESCRIPTION
This PR updates the `base` version before the upcoming `0.10.0` release.

Also, it addresses an issue, raised in C++ Spine client library. `Currency.BSD` enum value causes a compile-time conflict with system header `sys/param.h`, which also defines `BSD` in some *nix operating systems. For instance:
```cpp
//...
#define	BSD	199103		/* March, 1991 system version (year & month) */
// ...
```
(_taken from a [random `sys/param.h`](http://unix.superglobalmegacorp.com/Net2/newsrc/sys/param.h.html) in illustrative purposes_)

Therefore `Currency.BSD` was renamed to `Currency.BSD_`.

The library version has been set to `0.9.77-SNAPSHOT`.