### PR TITLE
Fix Spine directory name

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.77-SNAPSHOT'
+def final SPINE_VERSION = '0.10.1-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.10.1-SNAPSHOT'
+def final SPINE_VERSION = '0.9.78-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/gradle-plugins/model-compiler/spine_protoc.gradle
+++ b/gradle-plugins/model-compiler/spine_protoc.gradle
@@ -56,8 +56,8 @@ dependencies {
 
 ext {
     runsOnWindows = org.gradle.internal.os.OperatingSystem.current().isWindows()
-    spineFolder = ("$project.projectDir/.$spineFolderName" as File).toPath()
-    rootSpineFolder = ("$project.rootDir/.$spineFolderName" as File).toPath()
+    spineFolder = ("$project.projectDir/$spineFolderName" as File).toPath()
+    rootSpineFolder = ("$project.rootDir/$spineFolderName" as File).toPath()
 }
 
 final def copyPluginJarAction = {

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/Extension.java
@@ -256,19 +256,19 @@ public class Extension {
 
     public static boolean isGenerateValidatingBuilders(Project project) {
         final boolean result = spineProtobuf(project).generateValidatingBuilders;
-        log().trace("The current validating builder generation setting is {}", result);
+        log().debug("The current validating builder generation setting is {}", result);
         return result;
     }
 
     public static Indent getIndent(Project project) {
         final Indent result = spineProtobuf(project).indent;
-        log().trace("The current indent is {}", result);
+        log().debug("The current indent is {}", result);
         return result;
     }
 
     public static boolean isGenerateValidatingBuildersFromClasspath(Project project) {
         final boolean result = spineProtobuf(project).generateBuildersFromClasspath;
-        log().trace("Validating builder are generated from  {}",
+        log().debug("Validating builder are generated from  {}",
                     (result ? "the classpath" : "this module only"));
         return result;
     }
@@ -277,7 +277,7 @@ public class Extension {
     @SuppressWarnings("InstanceMethodNamingConvention")
     public void setGenerateValidatingBuildersFromClasspath(boolean generateFromClasspath) {
         this.generateBuildersFromClasspath = generateFromClasspath;
-        log().trace("Validating builder are set to be generated from  {}",
+        log().debug("Validating builder are set to be generated from  {}",
                     (generateFromClasspath ? "the whole classpath" : "the current module only"));
     }
 
@@ -285,7 +285,7 @@ public class Extension {
     @SuppressWarnings("unused")
     public void setGenerateValidatingBuilders(boolean generateValidatingBuilders) {
         this.generateValidatingBuilders = generateValidatingBuilders;
-        log().trace("Validating builder generation has been {}",
+        log().debug("Validating builder generation has been {}",
                     (generateValidatingBuilders ? "enabled" : "disabled"));
     }
 

--- a/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/ModelCompilerPluginShould.java
+++ b/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/ModelCompilerPluginShould.java
@@ -82,7 +82,6 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_generateRejections() {
-
         final Task genRejections = task(GENERATE_REJECTIONS);
         assertNotNull(genRejections);
         assertTrue(dependsOn(genRejections, GENERATE_PROTO));

--- a/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/SpineProtocShould.java
+++ b/gradle-plugins/model-compiler/src/test/java/io/spine/gradle/compiler/SpineProtocShould.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.gradle.compiler;
+
+import io.spine.gradle.GradleProject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+
+import static io.spine.gradle.TaskName.BUILD;
+import static java.nio.file.Files.exists;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the {@code spine_protoc.gradle} plugin.
+ *
+ * @author Dmytro Dashenkov
+ */
+public class SpineProtocShould {
+
+    private static final String PROJECT_NAME = "empty-project";
+
+    private GradleProject project;
+
+    @Rule
+    public TemporaryFolder projectDir = new TemporaryFolder();
+
+    @Before
+    public void setUp() {
+        project = GradleProject.newBuilder()
+                               .setProjectFolder(projectDir)
+                               .setProjectName(PROJECT_NAME)
+                               .build();
+    }
+
+    @Test
+    public void create_spine_directory() {
+        project.executeTask(BUILD);
+        final Path spineDirPath = projectDir.getRoot()
+                                            .toPath()
+                                            .resolve(Extension.SPINE_BUILD_ARTIFACT_STORAGE_DIR);
+        assertTrue(exists(spineDirPath));
+    }
+}

--- a/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/GradleProjectShould.java
+++ b/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/GradleProjectShould.java
@@ -53,6 +53,8 @@ public class GradleProjectShould {
                      .setProjectName(PROJECT_NAME)
                      .addJavaFiles(files)
                      .build();
+        @SuppressWarnings("DuplicateStringLiteralInspection")
+            // "java" literal is copied with different semantics.
         final Path root = temporaryFolder.getRoot()
                                          .toPath()
                                          .resolve("src")

--- a/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/SpinePluginBuilderShould.java
+++ b/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/SpinePluginBuilderShould.java
@@ -41,6 +41,7 @@ import static io.spine.gradle.TaskName.GENERATE_PROTO;
 import static io.spine.gradle.TaskName.GENERATE_TEST_PROTO;
 import static io.spine.gradle.TaskName.PRE_CLEAN;
 import static io.spine.gradle.TaskName.VERIFY_MODEL;
+import static io.spine.gradle.given.Given.JAVA_PLUGIN_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -50,8 +51,6 @@ import static org.junit.Assert.assertTrue;
  * @author Dmytro Dashenkov
  */
 public class SpinePluginBuilderShould {
-
-    private static final String JAVA_PLUGIN_ID = "java";
 
     private Project project;
 

--- a/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/given/Given.java
+++ b/gradle-plugins/plugin-base/src/test/java/io/spine/gradle/given/Given.java
@@ -27,6 +27,9 @@ import org.gradle.api.Action;
  */
 public class Given {
 
+    @SuppressWarnings("DuplicateStringLiteralInspection") // Different semantics.
+    public static final String JAVA_PLUGIN_ID = "java";
+
     public enum NoOp implements Action<Object> {
         ACTION;
 


### PR DESCRIPTION
Fix the `.spine` directory generation name. Because of an error, it was generated as `..spine` (with 2 dot symbols instead of 1).

Also, in this PR we change the logging level in the `Extension` getters and setters from `trace` to `debug`, since `trace` is not visible from the command line.
