### PR TITLE
Fix Validating Builder generation

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.9.78-SNAPSHOT'
+def final SPINE_VERSION = '0.9.79-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/MetadataAssembler.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/MetadataAssembler.java
@@ -21,29 +21,21 @@
 package io.spine.gradle.compiler.validate;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.Sets;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
-import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import io.spine.gradle.compiler.message.MessageTypeCache;
 import io.spine.gradle.compiler.util.DescriptorSetUtil;
-import io.spine.util.Exceptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.util.Collection;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.google.common.collect.Lists.newLinkedList;
 import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
-import static io.spine.gradle.compiler.message.fieldtype.FieldTypes.isMap;
-import static io.spine.gradle.compiler.message.fieldtype.FieldTypes.isMessage;
-import static io.spine.gradle.compiler.message.fieldtype.FieldTypes.trimTypeName;
 
 /**
  * Assembles the {@code VBMetadata}s from the Protobuf.
@@ -60,9 +52,6 @@ class MetadataAssembler {
 
     /** A map from Protobuf type name to Java class FQN. */
     private final MessageTypeCache messageTypeCache = new MessageTypeCache();
-
-    /** A map from Protobuf type name to Protobuf DescriptorProto. */
-    private final Map<String, DescriptorProto> allMessageDescriptors = newHashMap();
 
     /** A map from Protobuf type name to Protobuf FileDescriptorProto. */
     private final Map<DescriptorProto, FileDescriptorProto> descriptorCache = newHashMap();
@@ -97,25 +86,18 @@ class MetadataAssembler {
         final Set<VBMetadata> result = newHashSet();
         final Set<FileDescriptorProto> fileDescriptors = getProtoFileDescriptors(descriptorPath);
         final Set<VBMetadata> metadataItems = obtainFileMetadata(fileDescriptors);
-        final Set<VBMetadata> fieldMetadata = obtainFieldMetadata(metadataItems);
-        result.addAll(fieldMetadata);
         result.addAll(metadataItems);
         log().debug("The metadata is obtained, {} validating builder(s) will be generated.",
-                    fieldMetadata.size());
+                    result.size());
         return result;
     }
 
-    @SuppressWarnings("MethodWithMultipleLoops")    // It's fine, as for the utility plugin.
     private Set<VBMetadata> obtainFileMetadata(Iterable<FileDescriptorProto> fileDescriptors) {
         log().trace("Obtaining the file-level metadata for the validating builders.");
         final Set<VBMetadata> result = newHashSet();
         for (FileDescriptorProto fileDescriptor : fileDescriptors) {
             final List<DescriptorProto> messageDescriptors = fileDescriptor.getMessageTypeList();
-            final Set<VBMetadata> metadataSet =
-                    constructMessageFieldMetadata(messageDescriptors);
-            for (VBMetadata metadata : metadataSet) {
-                metadata.setSourceProtoFilePath(fileDescriptor.getName());
-            }
+            final Set<VBMetadata> metadataSet = createMetadata(messageDescriptors, fileDescriptor);
             result.addAll(metadataSet);
 
         }
@@ -123,135 +105,27 @@ class MetadataAssembler {
         return result;
     }
 
-    @SuppressWarnings("MethodWithMultipleLoops")    // It's fine, as for the utility plugin.
-    private Set<VBMetadata> obtainFieldMetadata(Iterable<VBMetadata> metadataSet) {
-        log().trace("Obtaining the metadata for the validating builders, " +
-                            "which will be generated for the Message fields.");
-        final Set<VBMetadata> result = newHashSet();
-
-        for (VBMetadata metadata : metadataSet) {
-            if (metadata.getJavaPackage()
-                        .contains(PROTOBUF_PACKAGE_NAME)) {
-                continue;
-            }
-            final DescriptorProto msgDescriptor = metadata.getMsgDescriptor();
-            log().trace("Analyzing the descriptors for {}", metadata);
-            final Set<DescriptorProto> unfiltered = getDescriptorsRecursively(msgDescriptor);
-            final Set<DescriptorProto> collectedDescriptors =
-                    Sets.filter(unfiltered, isNotProtoLangMessage);
-
-            final Set<VBMetadata> fieldMetadataSet =
-                    constructMessageFieldMetadata(collectedDescriptors);
-
-            if(metadata.getSourceProtoFilePath().isPresent()) {
-                for (VBMetadata fieldItem : fieldMetadataSet) {
-                    fieldItem.setSourceProtoFilePath(metadata.getSourceProtoFilePath()
-                                                             .get());
-                }
-            }
-            result.addAll(fieldMetadataSet);
-        }
-        log().trace("The metadata for the field validating builders is obtained.");
-        return result;
-    }
-
-    private Set<VBMetadata> constructMessageFieldMetadata(Iterable<DescriptorProto> descriptors) {
+    private Set<VBMetadata> createMetadata(Iterable<DescriptorProto> descriptors,
+                                           FileDescriptorProto fileDescriptor) {
         final Set<VBMetadata> result = newHashSet();
         for (DescriptorProto descriptorMsg : descriptors) {
             if (isNotProtoLangMessage.apply(descriptorMsg)) {
-                final VBMetadata metadata = createMetadata(descriptorMsg);
+                final VBMetadata metadata = createMetadata(descriptorMsg, fileDescriptor);
                 result.add(metadata);
             }
         }
         return result;
     }
 
-    private VBMetadata createMetadata(DescriptorProto msgDescriptor) {
+    private VBMetadata createMetadata(DescriptorProto msgDescriptor,
+                                      FileDescriptorProto fileDescriptor) {
         final String className = msgDescriptor.getName() + JAVA_CLASS_NAME_SUFFIX;
         final String javaPackage = getJavaPackage(msgDescriptor);
-        final VBMetadata result = new VBMetadata(javaPackage, className, msgDescriptor);
+        final VBMetadata result = new VBMetadata(javaPackage,
+                                                 className,
+                                                 msgDescriptor,
+                                                 fileDescriptor.getName());
         return result;
-    }
-
-    private Set<DescriptorProto> getDescriptorsRecursively(DescriptorProto msgDescriptor) {
-        log().trace("    Obtaining descriptors for {}", msgDescriptor.getName());
-
-        final Set<DescriptorProto> result = newHashSet();
-        final Set<String> processedTypeNames = newHashSet();
-        final Deque<FieldAndType> deque = newLinkedList();
-
-        addMembersToDeque(deque, msgDescriptor);
-
-        while(!deque.isEmpty()) {
-            final FieldAndType fieldAndType = deque.pollFirst();
-            final FieldDescriptorProto fieldDescriptor = fieldAndType.fieldDescriptor;
-
-            log().trace("        - Analyzing the field {}", fieldDescriptor.getName());
-            if (isMap(fieldDescriptor)) {
-                log().trace("        - It is a Map.");
-
-                final FieldDescriptorProto keyDescriptor = fieldAndType.fieldType.getField(0);
-                addToDeque(deque, keyDescriptor);
-                final FieldDescriptorProto valueDescriptor = fieldAndType.fieldType.getField(1);
-                addToDeque(deque, valueDescriptor);
-            } else {
-                final String fieldTypeName = trimTypeName(fieldDescriptor);
-                if(!processedTypeNames.contains(fieldTypeName)) {
-                    final DescriptorProto type = allMessageDescriptors.get(fieldTypeName);
-                    log().trace("        - It is not map. Adding {} to results.", type);
-
-                    result.add(type);
-                    processedTypeNames.add(fieldTypeName);
-                    addMembersToDeque(deque, type);
-                }
-            }
-        }
-        log().trace("    COMPLETED: obtaining descriptors for {}", msgDescriptor.getName());
-        return result;
-    }
-
-    private void addMembersToDeque(Deque<FieldAndType> deque,
-                                   @Nullable DescriptorProto msgDescriptor) {
-        if(msgDescriptor == null) {
-            return;
-        }
-
-        final List<FieldDescriptorProto> fieldList = msgDescriptor.getFieldList();
-        int nestedTypeIndex = 0;
-        for (FieldDescriptorProto fieldDescriptor : fieldList) {
-            if (!isMessage(fieldDescriptor)) {
-                continue;
-            }
-
-            try {
-                final DescriptorProto fieldType;
-                if (isMap(fieldDescriptor)) {
-                    fieldType = msgDescriptor.getNestedType(nestedTypeIndex);
-                    nestedTypeIndex++;
-                } else {
-                    final String typeName = trimTypeName(fieldDescriptor);
-                    fieldType = allMessageDescriptors.get(typeName);
-                }
-                final FieldAndType wrapper = new FieldAndType(fieldDescriptor, fieldType);
-                deque.add(wrapper);
-            } catch (RuntimeException e) {
-                log().error("Cannot process the field {} of message descriptor {}",
-                            fieldDescriptor.getTypeName(),
-                            msgDescriptor.getName());
-                throw Exceptions.illegalArgumentWithCauseOf(e);
-            }
-        }
-    }
-
-    private void addToDeque(Deque<FieldAndType> deque, FieldDescriptorProto fieldDescriptor) {
-
-        if (!isMessage(fieldDescriptor)) {
-            return;
-        }
-
-        final String typeName = trimTypeName(fieldDescriptor);
-        final DescriptorProto type = allMessageDescriptors.get(typeName);
-        deque.addLast(new FieldAndType(fieldDescriptor, type));
     }
 
     private String getJavaPackage(DescriptorProto msgDescriptor) {
@@ -268,7 +142,6 @@ class MetadataAssembler {
                 DescriptorSetUtil.getProtoFileDescriptors(descFilePath);
 
         for (FileDescriptorProto fileDescriptor : allDescriptors) {
-            cacheAllMessageDescriptors(fileDescriptor);
             cacheFileDescriptors(fileDescriptor);
             messageTypeCache.cacheTypes(fileDescriptor);
 
@@ -276,20 +149,6 @@ class MetadataAssembler {
             result.add(fileDescriptor);
         }
         log().trace("Found Message in files: {}", result);
-        return result;
-    }
-
-    private void cacheAllMessageDescriptors(FileDescriptorProto fileDescriptor) {
-        List<DescriptorProto> descriptors = fileDescriptor.getMessageTypeList();
-        for (DescriptorProto msgDescriptor : descriptors) {
-            final String messageFullName = getMessageFullName(fileDescriptor.getPackage(),
-                                                              msgDescriptor.getName());
-            allMessageDescriptors.put(messageFullName, msgDescriptor);
-        }
-    }
-
-    private static String getMessageFullName(String packageName, String className) {
-        final String result = packageName + '.' + className;
         return result;
     }
 
@@ -312,18 +171,5 @@ class MetadataAssembler {
 
     private static Logger log() {
         return LogSingleton.INSTANCE.value;
-    }
-
-    /**
-     * Utility class which holds a description of the field and its type.
-     */
-    private static class FieldAndType {
-        private final FieldDescriptorProto fieldDescriptor;
-        private final DescriptorProto fieldType;
-
-        private FieldAndType(FieldDescriptorProto fieldDescriptorProto, DescriptorProto fieldType) {
-            this.fieldDescriptor = fieldDescriptorProto;
-            this.fieldType = fieldType;
-        }
     }
 }

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/VBMetadata.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/VBMetadata.java
@@ -22,10 +22,7 @@ package io.spine.gradle.compiler.validate;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
-import com.google.common.base.Optional;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
-
-import javax.annotation.Nullable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -39,18 +36,21 @@ final class VBMetadata {
     private final String javaClass;
     private final String javaPackage;
     private final DescriptorProto msgDescriptor;
+    private final String sourceProtoFilePath;
 
-    @Nullable
-    private String sourceProtoFilePath;
-
-    VBMetadata(String javaPackage, String javaClass, DescriptorProto msgDescriptor) {
+    VBMetadata(String javaPackage,
+               String javaClass,
+               DescriptorProto msgDescriptor,
+               String sourceProtoFilePath) {
         checkNotNull(javaPackage);
         checkNotNull(javaClass);
         checkNotNull(msgDescriptor);
+        checkNotNull(sourceProtoFilePath);
 
         this.javaPackage = javaPackage;
         this.javaClass = javaClass;
         this.msgDescriptor = msgDescriptor;
+        this.sourceProtoFilePath = sourceProtoFilePath;
     }
 
     String getJavaPackage() {
@@ -65,13 +65,8 @@ final class VBMetadata {
         return msgDescriptor;
     }
 
-    Optional<String> getSourceProtoFilePath() {
-        return Optional.fromNullable(sourceProtoFilePath);
-    }
-
-    public void setSourceProtoFilePath(String sourceProtoFilePath) {
-        checkNotNull(sourceProtoFilePath);
-        this.sourceProtoFilePath = sourceProtoFilePath;
+    String getSourceProtoFilePath() {
+        return sourceProtoFilePath;
     }
 
     @Override

--- a/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderGenPlugin.java
+++ b/gradle-plugins/model-compiler/src/main/java/io/spine/gradle/compiler/validate/ValidatingBuilderGenPlugin.java
@@ -20,7 +20,6 @@
 
 package io.spine.gradle.compiler.validate;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
@@ -258,21 +257,8 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
             public boolean apply(@Nullable VBMetadata input) {
                 checkNotNull(input);
 
-                final Optional<String> optionalPath = input.getSourceProtoFilePath();
-
-                /*
-                 * In case it's not possible to determine the origin for this metadata,
-                 * let's think it is originated from the proper module.
-                 *
-                 * <p>Such a gentle approach is required in order not to lose any builder metadata
-                 * items. It's better to generate something and let the end-user decide,
-                 * than silently filter out the suspicious data.
-                 */
-                if (!optionalPath.isPresent()) {
-                    return true;
-                }
-                final String relativeProtoPath = optionalPath.get();
-                final File protoFile = new File(rootPath + relativeProtoPath);
+                final String path = input.getSourceProtoFilePath();
+                final File protoFile = new File(rootPath + path);
                 final boolean belongsToModule = protoFile.exists();
                 return belongsToModule;
             }


### PR DESCRIPTION
Before this PR we generated the `ValidatingBuilder`s for both the types from `.proto` definitions and from types of fields in that definitions. Now it's only the `.proto` definitions.

This is done to ensure unambiguity of the resulting `...VBuilder` class.