### PR TITLE
Update dependencies

### DIFF
--- a/base/src/main/java/io/spine/option/UnknownOptions.java
+++ b/base/src/main/java/io/spine/option/UnknownOptions.java
@@ -237,11 +237,11 @@ public class UnknownOptions {
     }
 
     /**
-     * Checks if the is a field with such {@code tag} in the given {@code unknownFields} set.
+     * Checks if there is a field with such {@code tag} in the given {@code unknownFields} set.
      *
      * @param unknownFields the {@link UnknownFieldSet} to check
      * @param tag           the field number (tag) to look for
-     * @return {@code true} if the value is present in the unknown fields set, {@code false}
+     * @return {@code true} if the value is present in the "unknown" options set, {@code false}
      *         otherwise
      */
     private static boolean containsField(UnknownFieldSet unknownFields, int tag) {
@@ -251,8 +251,8 @@ public class UnknownOptions {
     }
 
     /**
-     * Extracts the values of unknown options of a message as a {@code Map} of the field number to
-     * it's string representation.
+     * Extracts the values of "unknown" options as a {@code Map} of the field number to the field
+     * string representation.
      *
      * @param unknownFields the {@link UnknownFieldSet} to extract the values from
      * @return a map of the field numbers to the field values
@@ -268,7 +268,7 @@ public class UnknownOptions {
     }
 
     /**
-     * Parses the given string representation of the Protobuf unknown options.
+     * Parses the given string representation of the Protobuf "unknown" options.
      *
      * <p>This method expects the passed string to adhere a certain protocol. It's not recommended
      * to call it directly (even within {@code UnknownOptions} class).

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,24 +25,24 @@
  *  as we want to manage the versions in a single source.
  */
 
-def final SPINE_VERSION = '0.10.0'
+def final SPINE_VERSION = '0.10.1-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION
 
     guavaVersion = '20.0'
-    findBugsVersion = '3.0.0'
-    protobufVersion = '3.3.0'
-    gRpcVersion = '1.5.0'
+    findBugsVersion = '3.0.1'
+    protobufVersion = '3.5.0'
+    gRpcVersion = '1.8.0'
     slf4JVersion = '1.7.25'
     jUnitVersion = '4.12'
-    mockitoVersion = '2.7.22'
+    mockitoVersion = '2.12.0'
     hamcrestVersion = '1.3'
-    javaPoetVersion = '1.8.0'
+    javaPoetVersion = '1.9.0'
 
     // We use Spine tools and model compiler in the build process.
     spineToolsVersion = '0.9.51-SNAPSHOT'
-    spineModelCompilerVersion = '0.9.79-SNAPSHOT'
+    spineModelCompilerVersion = '0.10.0'
 
     protobufGradlePluginVerison = '0.8.3'
 }

--- a/gradle-plugins/model-compiler/build.gradle
+++ b/gradle-plugins/model-compiler/build.gradle
@@ -23,7 +23,7 @@ import java.nio.file.StandardCopyOption
 //
 
 ext {
-    roasterVersion = '2.20.0.Final'
+    roasterVersion = '2.20.1.Final'
     spineFolder = "${project.projectDir}/.spine" as File
     protocPluginDependency = null
 }

--- a/gradle-plugins/plugin-base/build.gradle
+++ b/gradle-plugins/plugin-base/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     testCompile project(':testutil-base')
 
     testCompile group: 'junit', name: 'junit', version: jUnitVersion
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.9.0'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
     testCompile gradleTestKit()
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-bin.zip


### PR DESCRIPTION
In this PR we update the third-party dependencies.

Since the Protobuf runtime implementation details have been changed, we also update the `UnknownOptions` utility.

The library version is increased to `0.10.1-SNAPSHOT`.

| Dependency | Before | After |
|-----|----------|---------| 
| Protobuf | `3.3.0` | `3.5.0` |
| gRPC | `1.5.0` | `1.8.0` |
| FindBugs | `3.0.0` | `3.0.1` |
| JavaPoet | `1.8.0` | `1.9.0` |
| Roaster | `2.20.0.Final` | `2.20.1.Final` |
| Mockito | `2.7.22` | `2.12.0` |

The Gradle version was migrated from `4.1` to `4.3.1`.
