### PR TITLE
Update dependencies versions

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -58,14 +58,14 @@ ext {
      *
      * This version is independent from the version of both `base` and `model-compiler`.
      */
-    spineToolsVersion = '0.9.52-SNAPSHOT'
+    spineToolsVersion = '0.10.29-SNAPSHOT'
 
     /**
      * The version of the Spine `model-compiler` plugin which is used to build `base`.
      *
      * Use the latest currently published version here.
      */
-    spineModelCompilerVersion = '0.10.1-SNAPSHOT'
+    spineModelCompilerVersion = '0.10.30-SNAPSHOT'
 
     protobufGradlePluginVerison = '0.8.4'
 }


### PR DESCRIPTION
In this PR we update the Spine plugin versions.

This PR overrides the `0.10.30-SNAPSHOT` version.