### PR TITLE
Add non-empty predicate to Messages

### DIFF
--- a/base/src/main/java/io/spine/protobuf/Messages.java
+++ b/base/src/main/java/io/spine/protobuf/Messages.java
@@ -19,7 +19,9 @@
  */
 package io.spine.protobuf;
 
+import com.google.common.base.Predicate;
 import com.google.protobuf.Any;
+import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 
@@ -123,5 +125,33 @@ public final class Messages {
             commandMessage = msgOrAny;
         }
         return commandMessage;
+    }
+
+    /**
+     * @return an instance of an {@linkplain NonEmpty non-empty predicate}
+     */
+    public static Predicate<Message> nonEmpty() {
+        return NonEmpty.INSTANCE;
+    }
+
+    /**
+     * A predicate checking that message is not {@linkplain Empty empty}.
+     */
+    private enum NonEmpty implements Predicate<Message> {
+
+        INSTANCE;
+
+        private static final Empty EMPTY = Empty.getDefaultInstance();
+
+        /**
+         * Checks that message is not {@linkplain Empty empty}.
+         *
+         * @param  message the message being checked
+         * @return {@code true} if the message is not empty, {@code false} otherwise 
+         */
+        @Override
+        public boolean apply(Message message) {
+            return !message.equals(EMPTY);
+        }
     }
 }

--- a/base/src/test/java/io/spine/protobuf/MessagesShould.java
+++ b/base/src/test/java/io/spine/protobuf/MessagesShould.java
@@ -21,6 +21,8 @@ package io.spine.protobuf;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
+import com.google.protobuf.Duration;
+import com.google.protobuf.Empty;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.Timestamp;
@@ -31,6 +33,7 @@ import org.junit.Test;
 
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.Messages.ensureMessage;
+import static io.spine.protobuf.Messages.nonEmpty;
 import static io.spine.protobuf.TypeConverter.toAny;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.Assert.assertEquals;
@@ -62,7 +65,8 @@ public class MessagesShould {
     public void return_builder_for_the_message() {
         final Message.Builder messageBuilder = Messages.builderFor(MessageWithStringValue.class);
         assertNotNull(messageBuilder);
-        assertEquals(MessageWithStringValue.class, messageBuilder.build().getClass());
+        assertEquals(MessageWithStringValue.class, messageBuilder.build()
+                                                                 .getClass());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -71,12 +75,12 @@ public class MessagesShould {
     }
 
     @Test
-    public void return_true_when_message_is_checked(){
+    public void return_true_when_message_is_checked() {
         assertTrue(Messages.isMessage(MessageWithStringValue.class));
     }
 
     @Test
-    public void return_false_when_not_message_is_checked(){
+    public void return_false_when_not_message_is_checked() {
         assertFalse(Messages.isMessage(getClass()));
     }
 
@@ -91,5 +95,23 @@ public class MessagesShould {
         final StringValue value = TestValues.newUuidValue();
         assertEquals(value, ensureMessage(AnyPacker.pack(value)));
         assertSame(value, ensureMessage(value));
+    }
+
+    @Test
+    public void return_true_for_an_empty_checked_using_predicate() {
+        final Message empty = Empty.getDefaultInstance();
+        assertFalse(nonEmpty().apply(empty));
+    }
+
+    @Test
+    public void return_false_for_a_non_empty_message_checked_using_predicate() {
+        final Message timestamp = Timestamp.getDefaultInstance();
+        assertTrue(nonEmpty().apply(timestamp));
+
+        final Message any = Any.getDefaultInstance();
+        assertTrue(nonEmpty().apply(any));
+
+        final Message duration = Duration.getDefaultInstance();
+        assertTrue(nonEmpty().apply(duration));
     }
 }

--- a/ext.gradle
+++ b/ext.gradle
@@ -38,7 +38,7 @@
  *
  * This is also the version which the artifacts are published with.
  */
-def final SPINE_VERSION = '0.10.34-SNAPSHOT'
+def final SPINE_VERSION = '0.10.35-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR adds a new member to `Messages` — `nonEmpty(Message)`.
The `nonEmpty` method returns a predicate checking if provided message is protobuf `Empty`.

Such a functionality is required by https://github.com/SpineEventEngine/core-java/pull/697.