### PR TITLE
Add class storing common display names for JUnit 5 tests

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -38,7 +38,7 @@
  *
  * This is also the version which the artifacts are published with.
  */
-def final SPINE_VERSION = '0.10.39-SNAPSHOT'
+def final SPINE_VERSION = '0.10.40-SNAPSHOT'
 
 ext {
     // Repositories for specific purposes.

--- a/testlib/src/main/java/io/spine/test/DisplayNames.java
+++ b/testlib/src/main/java/io/spine/test/DisplayNames.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.test;
+
+/**
+ * A storage for the common JUnit 5 test
+ * <a href="https://junit.org/junit5/docs/5.0.3/api/org/junit/jupiter/api/DisplayName.html">
+ * display names</a>.
+ *
+ * <p>This class can be used to avoid string literal duplication when assigning {@code DisplayName}
+ * to the common test cases.
+ *
+ * @author Dmytro Kuzmin
+ */
+public class DisplayNames {
+
+    /**
+     * A name for the test cases checking that a class has private parameterless (aka "utility")
+     * constructor.
+     */
+    public static final String HAVE_PARAMETERLESS_CTOR = "have private parameterless constructor";
+
+    /**
+     * A name for the test cases checking that class methods do not accept {@code null} for their
+     * non-{@linkplain javax.annotation.Nullable nullable} arguments.
+     */
+    public static final String NOT_ACCEPT_NULLS =
+            "not accept nulls for non-Nullable method arguments";
+
+    /**
+     * Prevents instantiation of this class.
+     */
+    private DisplayNames() {
+    }
+}
+

--- a/testlib/src/main/java/io/spine/test/DisplayNames.java
+++ b/testlib/src/main/java/io/spine/test/DisplayNames.java
@@ -51,4 +51,3 @@ public class DisplayNames {
     private DisplayNames() {
     }
 }
-

--- a/testlib/src/test/java/io/spine/test/DisplayNamesShould.java
+++ b/testlib/src/test/java/io/spine/test/DisplayNamesShould.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.test;
+
+import org.junit.Test;
+
+import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+
+/**
+ * @author Dmytro Kuzmin
+ */
+public class DisplayNamesShould {
+
+    @Test
+    public void have_utility_ctor() {
+        assertHasPrivateParameterlessCtor(DisplayNames.class);
+    }
+}


### PR DESCRIPTION
This PR adds storage for the common JUnit 5 test [display names](https://junit.org/junit5/docs/5.0.3/api/org/junit/jupiter/api/DisplayName.html) to the `testlib` module.

This class can provide assistance in avoiding string literal duplication when assigning `@DisplayName` to the common test cases like null tolerance check or utility constructor check.

`DisplayNames` is represented as a class and not an enumeration because `@DisplayName` annotation requires constant `String` expression as its parameter, so we can't retrieve such expression from enum constant in any reasonable way.

Spine version advances to `0.10.40-SNAPSHOT`.
