### PR TITLE
Publish `plugin-testlib`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ ext {
         'reflections-plugin',
         'model-compiler',
 
+        'plugin-testlib',
+
         // Protoc compiler plugin
         'protoc-plugin'
     ]

--- a/tools/plugin-testlib/build.gradle
+++ b/tools/plugin-testlib/build.gradle
@@ -18,6 +18,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+group = 'io.spine'
+
 dependencies {
     implementation project(':plugin-base')
     implementation project(':testlib')

--- a/tools/plugin-testlib/build.gradle
+++ b/tools/plugin-testlib/build.gradle
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-group = 'io.spine'
+group = 'io.spine.tools'
 
 dependencies {
     implementation project(':plugin-base')


### PR DESCRIPTION
In this PR we configure the `plugin-testlib` module to be published to the Maven repository.
This is required for the tests in `core-java`.
