### PR TITLE
Change `GradleProject` to accept `File` as project directory

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.44-SNAPSHOT'
+final def SPINE_VERSION = '0.10.45-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
@@ -82,7 +82,7 @@ public final class ProtoJavadocPluginTestEnv {
         GradleProject project = GradleProject
                 .newBuilder()
                 .setProjectName("proto-javadoc-test")
-                .setProjectFolder(folder)
+                .setProjectFolder(folder.getRoot())
                 .createFile(filePath, of(fileContent))
                 .build();
         project.executeTask(FORMAT_PROTO_DOC);

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ProtoAnnotatorPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ProtoAnnotatorPluginShould.java
@@ -248,7 +248,7 @@ public class ProtoAnnotatorPluginShould {
     private GradleProject newProjectWithFile(FileName protoFileName) {
         return GradleProject.newBuilder()
                             .setProjectName(PROJECT_NAME)
-                            .setProjectFolder(testProjectDir)
+                            .setProjectFolder(testProjectDir.getRoot())
                             .addProtoFile(protoFileName.value())
                             .build();
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
@@ -55,7 +55,7 @@ public class RejectionGenPluginShould {
                                                        "deps/deps.proto");
         final GradleProject project = GradleProject.newBuilder()
                                                    .setProjectName("rejections-gen-plugin-test")
-                                                   .setProjectFolder(testProjectDir)
+                                                   .setProjectFolder(testProjectDir.getRoot())
                                                    .addProtoFiles(files)
                                                    .build();
         project.executeTask(COMPILE_JAVA);

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
@@ -50,7 +50,7 @@ public class SpineProtocShould {
     @Before
     public void setUp() {
         project = GradleProject.newBuilder()
-                               .setProjectFolder(projectDir)
+                               .setProjectFolder(projectDir.getRoot())
                                .setProjectName(PROJECT_NAME)
                                .build();
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPluginShould.java
@@ -49,7 +49,7 @@ public class ValidatingBuilderGenPluginShould {
         GradleProject project =
                 GradleProject.newBuilder()
                              .setProjectName(PROJECT_NAME)
-                             .setProjectFolder(testProjectDir)
+                             .setProjectFolder(testProjectDir.getRoot())
                              .addProtoFiles(PROTO_FILES)
                              .build();
         project.executeTask(COMPILE_JAVA);

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
@@ -89,7 +89,7 @@ public class ValidationRulesLookupPluginShould {
     private GradleProject newProjectWithFile(String protoFileName, List<String> protoFileLines) {
         return GradleProject.newBuilder()
                             .setProjectName(PROJECT_NAME)
-                            .setProjectFolder(testProjectDir)
+                            .setProjectFolder(testProjectDir.getRoot())
                             .createProto(protoFileName, protoFileLines)
                             .build();
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
@@ -58,7 +58,7 @@ public class RejectionTestEnv {
     public static GradleProject newProjectWithRejectionsJavadoc(TemporaryFolder projectFolder) {
         return GradleProject.newBuilder()
                             .setProjectName("rejections-javadoc")
-                            .setProjectFolder(projectFolder)
+                            .setProjectFolder(projectFolder.getRoot())
                             .createProto("javadoc_rejections.proto", rejectionWithJavadoc())
                             .build();
     }

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
@@ -26,6 +26,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.junit.rules.TemporaryFolder;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -76,7 +77,7 @@ public final class GradleProject {
         this.name = builder.name;
         this.debug = builder.debug;
         this.gradleRunner = GradleRunner.create()
-                                        .withProjectDir(builder.folder.getRoot())
+                                        .withProjectDir(builder.folder)
                                         .withDebug(builder.debug);
         writeGradleScripts();
         writeProtoFiles(builder.protoFileNames);
@@ -236,7 +237,7 @@ public final class GradleProject {
     public static class Builder {
 
         private String name;
-        private TemporaryFolder folder;
+        private File folder;
 
         /**
          * Determines whether the code can be debugged.
@@ -259,7 +260,7 @@ public final class GradleProject {
             return this;
         }
 
-        public Builder setProjectFolder(TemporaryFolder folder) {
+        public Builder setProjectFolder(File folder) {
             this.folder = checkNotNull(folder);
             return this;
         }
@@ -305,8 +306,7 @@ public final class GradleProject {
          * @param lines the content of the file
          */
         public Builder createFile(String path, Iterable<String> lines) {
-            final Path sourcePath = folder.getRoot()
-                                          .toPath()
+            final Path sourcePath = folder.toPath()
                                           .resolve(path);
             try {
                 Files.createDirectories(sourcePath.getParent());

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
@@ -24,7 +24,6 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.gradle.api.Action;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
-import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
@@ -49,8 +48,8 @@ import static java.util.Arrays.asList;
 /**
  * {@code GradleProject} for the test needs.
  *
- * <p>{@code GradleProject} sets up {@linkplain TemporaryFolder test project directory}
- * and allows to execute Gradle tasks.
+ * <p>{@code GradleProject} operates in the given {@linkplain File test project directory} and
+ * allows to execute Gradle tasks.
  *
  * @author Dmytro Grankin
  * @author Dmytro Dashenkov

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
@@ -45,13 +45,22 @@ public class GradleProjectTest {
     @Rule
     public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+    @Test
+    public void build_from_project_folder_and_project_name() {
+        final GradleProject project = GradleProject.newBuilder()
+                                                   .setProjectFolder(temporaryFolder.getRoot())
+                                                   .setProjectName(PROJECT_NAME)
+                                                   .build();
+        assertNotNull(project);
+    }
+
     @SuppressWarnings("ResultOfMethodCallIgnored")
         // OK for this test case; result of `build` it ignored.
     @Test
     public void write_given_java_files() {
         final String[] files = {"Foo.java", "Bar.java"};
         GradleProject.newBuilder()
-                     .setProjectFolder(temporaryFolder)
+                     .setProjectFolder(temporaryFolder.getRoot())
                      .setProjectName(PROJECT_NAME)
                      .addJavaFiles(files)
                      .build();
@@ -71,7 +80,7 @@ public class GradleProjectTest {
     public void execute_faulty_build() {
         final GradleProject project = GradleProject.newBuilder()
                                                    .setProjectName(PROJECT_NAME)
-                                                   .setProjectFolder(temporaryFolder)
+                                                   .setProjectFolder(temporaryFolder.getRoot())
                                                    .addJavaFiles("Faulty.java")
                                                    .build();
         final BuildResult buildResult = project.executeAndFail(COMPILE_JAVA);


### PR DESCRIPTION
Previously, the `GradleProject` test tool accepted only JUnit 4 [`TemporaryFolder`](https://junit.org/junit4/javadoc/4.12/org/junit/rules/TemporaryFolder.html) as the project directory. This caused problems for the tests which were already migrated to the JUnit 5 API.

Now, the interface of the `GradleProject` is changed to accept more generic `File` as the project directory, thus enabling it to be used in both JUnit 4 and JUnit 5 tests.

The Spine version advances to `0.10.45-SNAPSHOT`.