### PR TITLE
Remove the unnecessary `final` keyword on local variables for the `protoc-plugin` module.

### DIFF
--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceGenerator.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceGenerator.java
@@ -77,13 +77,13 @@ public class MarkerInterfaceGenerator extends SpineProtoGenerator {
      */
     @Override
     protected Collection<File> processMessage(FileDescriptorProto file, DescriptorProto message) {
-        final Optional<MessageAndInterface> fromMsgOption = scanMsgOption(file, message);
+        Optional<MessageAndInterface> fromMsgOption = scanMsgOption(file, message);
         if (fromMsgOption.isPresent()) {
             return fromMsgOption.get()
                                 .asSet();
         }
 
-        final Optional<MessageAndInterface> fromFileOption = scanFileOption(file, message);
+        Optional<MessageAndInterface> fromFileOption = scanFileOption(file, message);
         if (fromFileOption.isPresent()) {
             return fromFileOption.get()
                                  .asSet();

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceSpec.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceSpec.java
@@ -59,7 +59,7 @@ final class MarkerInterfaceSpec {
             spec = from(optionValue);
         } else {
             String javaPackage = PackageName.resolve(srcFile)
-                                                  .value();
+                                            .value();
             spec = new MarkerInterfaceSpec(javaPackage, optionValue);
         }
         return spec;
@@ -80,12 +80,12 @@ final class MarkerInterfaceSpec {
      */
     JavaFile toJavaCode() {
         TypeSpec spec = TypeSpec.interfaceBuilder(getName())
-                                      .addSuperinterface(Message.class)
-                                      .addModifiers(PUBLIC)
-                                      .addAnnotation(generatedBySpineModelCompiler())
-                                      .build();
+                                .addSuperinterface(Message.class)
+                                .addModifiers(PUBLIC)
+                                .addAnnotation(generatedBySpineModelCompiler())
+                                .build();
         JavaFile javaFile = JavaFile.builder(packageName, spec)
-                                          .build();
+                                    .build();
         return javaFile;
     }
 

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceSpec.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MarkerInterfaceSpec.java
@@ -54,11 +54,11 @@ final class MarkerInterfaceSpec {
 
     static MarkerInterfaceSpec prepareInterface(String optionValue,
                                                 FileDescriptorProto srcFile) {
-        final MarkerInterfaceSpec spec;
+        MarkerInterfaceSpec spec;
         if (optionValue.contains(DELIMITER)) {
             spec = from(optionValue);
         } else {
-            final String javaPackage = PackageName.resolve(srcFile)
+            String javaPackage = PackageName.resolve(srcFile)
                                                   .value();
             spec = new MarkerInterfaceSpec(javaPackage, optionValue);
         }
@@ -69,9 +69,9 @@ final class MarkerInterfaceSpec {
      * Parses a {@code MarkerInterfaceSpec} from the given type fully qualified name.
      */
     private static MarkerInterfaceSpec from(String fullName) {
-        final int index = fullName.lastIndexOf(DELIMITER);
-        final String name = fullName.substring(index + 1);
-        final String packageName = fullName.substring(0, index);
+        int index = fullName.lastIndexOf(DELIMITER);
+        String name = fullName.substring(index + 1);
+        String packageName = fullName.substring(0, index);
         return new MarkerInterfaceSpec(packageName, name);
     }
 
@@ -79,18 +79,18 @@ final class MarkerInterfaceSpec {
      * Converts the instance to {@link JavaFile}.
      */
     JavaFile toJavaCode() {
-        final TypeSpec spec = TypeSpec.interfaceBuilder(getName())
+        TypeSpec spec = TypeSpec.interfaceBuilder(getName())
                                       .addSuperinterface(Message.class)
                                       .addModifiers(PUBLIC)
                                       .addAnnotation(generatedBySpineModelCompiler())
                                       .build();
-        final JavaFile javaFile = JavaFile.builder(packageName, spec)
+        JavaFile javaFile = JavaFile.builder(packageName, spec)
                                           .build();
         return javaFile;
     }
 
     SourceFile toSourceFile() {
-        final SourceFile result = SourceFile.forType(packageName, name);
+        SourceFile result = SourceFile.forType(packageName, name);
         return result;
     }
 
@@ -120,7 +120,7 @@ final class MarkerInterfaceSpec {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final MarkerInterfaceSpec other = (MarkerInterfaceSpec) obj;
+        MarkerInterfaceSpec other = (MarkerInterfaceSpec) obj;
         return Objects.equals(this.packageName, other.packageName)
                 && Objects.equals(this.name, other.name);
     }

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MessageAndInterface.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MessageAndInterface.java
@@ -81,24 +81,24 @@ final class MessageAndInterface {
         File.Builder srcFile = prepareFile(file, msg);
         String messageFqn = file.getPackage() + DELIMITER + msg.getName();
         File messageFile = implementInterface(srcFile,
-                                                    interfaceSpec.getFqn(),
-                                                    messageFqn);
+                                              interfaceSpec.getFqn(),
+                                              messageFqn);
         JavaFile interfaceContent = interfaceSpec.toJavaCode();
         File interfaceFile = File.newBuilder()
-                                       .setName(interfaceSpec.toSourceFile()
-                                                             .toString())
-                                       .setContent(interfaceContent.toString())
-                                       .build();
+                                 .setName(interfaceSpec.toSourceFile()
+                                                       .toString())
+                                 .setContent(interfaceContent.toString())
+                                 .build();
         MessageAndInterface result = new MessageAndInterface(messageFile, interfaceFile);
         return result;
     }
 
     private static String toTypeName(FileDescriptorProto file, DescriptorProto msg) {
         boolean multipleFiles = file.getOptions()
-                                              .getJavaMultipleFiles();
+                                    .getJavaMultipleFiles();
         return multipleFiles
-                ? msg.getName()
-                : resolveName(file);
+               ? msg.getName()
+               : resolveName(file);
     }
 
     private static Optional<String> getEveryIs(FileDescriptorProto descriptor) {
@@ -111,8 +111,8 @@ final class MessageAndInterface {
                                            String messageTypeName) {
         String insertionPoint = format(INSERTION_POINT_IMPLEMENTS, messageTypeName);
         File result = srcFile.setInsertionPoint(insertionPoint)
-                                   .setContent(interfaceTypeName + ',')
-                                   .build();
+                             .setContent(interfaceTypeName + ',')
+                             .build();
         return result;
     }
 
@@ -127,13 +127,13 @@ final class MessageAndInterface {
 
     private static File.Builder prepareFile(FileDescriptorProto file, DescriptorProto msg) {
         String javaPackage = PackageName.resolve(file)
-                                              .value();
+                                        .value();
         String messageName = toTypeName(file, msg);
         String fileName = SourceFile.forType(javaPackage, messageName)
-                                          .toString();
+                                    .toString();
         String uriStyleName = fileName.replace('\\', '/');
         File.Builder srcFile = File.newBuilder()
-                                         .setName(uriStyleName);
+                                   .setName(uriStyleName);
         return srcFile;
     }
 

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MessageAndInterface.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/MessageAndInterface.java
@@ -65,9 +65,9 @@ final class MessageAndInterface {
      */
     static Optional<MessageAndInterface> scanFileOption(FileDescriptorProto file,
                                                         DescriptorProto msg) {
-        final Optional<String> everyIs = getEveryIs(file);
+        Optional<String> everyIs = getEveryIs(file);
         if (everyIs.isPresent()) {
-            final MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
+            MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
             return Optional.of(resultingFile);
         } else {
             return Optional.empty();
@@ -77,24 +77,24 @@ final class MessageAndInterface {
     private static MessageAndInterface generateFile(FileDescriptorProto file,
                                                     DescriptorProto msg,
                                                     String optionValue) {
-        final MarkerInterfaceSpec interfaceSpec = prepareInterface(optionValue, file);
-        final File.Builder srcFile = prepareFile(file, msg);
-        final String messageFqn = file.getPackage() + DELIMITER + msg.getName();
-        final File messageFile = implementInterface(srcFile,
+        MarkerInterfaceSpec interfaceSpec = prepareInterface(optionValue, file);
+        File.Builder srcFile = prepareFile(file, msg);
+        String messageFqn = file.getPackage() + DELIMITER + msg.getName();
+        File messageFile = implementInterface(srcFile,
                                                     interfaceSpec.getFqn(),
                                                     messageFqn);
-        final JavaFile interfaceContent = interfaceSpec.toJavaCode();
-        final File interfaceFile = File.newBuilder()
+        JavaFile interfaceContent = interfaceSpec.toJavaCode();
+        File interfaceFile = File.newBuilder()
                                        .setName(interfaceSpec.toSourceFile()
                                                              .toString())
                                        .setContent(interfaceContent.toString())
                                        .build();
-        final MessageAndInterface result = new MessageAndInterface(messageFile, interfaceFile);
+        MessageAndInterface result = new MessageAndInterface(messageFile, interfaceFile);
         return result;
     }
 
     private static String toTypeName(FileDescriptorProto file, DescriptorProto msg) {
-        final boolean multipleFiles = file.getOptions()
+        boolean multipleFiles = file.getOptions()
                                               .getJavaMultipleFiles();
         return multipleFiles
                 ? msg.getName()
@@ -102,15 +102,15 @@ final class MessageAndInterface {
     }
 
     private static Optional<String> getEveryIs(FileDescriptorProto descriptor) {
-        final Optional<String> value = Options.option(descriptor, everyIs);
+        Optional<String> value = Options.option(descriptor, everyIs);
         return value;
     }
 
     private static File implementInterface(File.Builder srcFile,
                                            String interfaceTypeName,
                                            String messageTypeName) {
-        final String insertionPoint = format(INSERTION_POINT_IMPLEMENTS, messageTypeName);
-        final File result = srcFile.setInsertionPoint(insertionPoint)
+        String insertionPoint = format(INSERTION_POINT_IMPLEMENTS, messageTypeName);
+        File result = srcFile.setInsertionPoint(insertionPoint)
                                    .setContent(interfaceTypeName + ',')
                                    .build();
         return result;
@@ -126,13 +126,13 @@ final class MessageAndInterface {
     }
 
     private static File.Builder prepareFile(FileDescriptorProto file, DescriptorProto msg) {
-        final String javaPackage = PackageName.resolve(file)
+        String javaPackage = PackageName.resolve(file)
                                               .value();
-        final String messageName = toTypeName(file, msg);
-        final String fileName = SourceFile.forType(javaPackage, messageName)
+        String messageName = toTypeName(file, msg);
+        String fileName = SourceFile.forType(javaPackage, messageName)
                                           .toString();
-        final String uriStyleName = fileName.replace('\\', '/');
-        final File.Builder srcFile = File.newBuilder()
+        String uriStyleName = fileName.replace('\\', '/');
+        File.Builder srcFile = File.newBuilder()
                                          .setName(uriStyleName);
         return srcFile;
     }
@@ -142,9 +142,9 @@ final class MessageAndInterface {
      */
     static Optional<MessageAndInterface> scanMsgOption(FileDescriptorProto file,
                                                        DescriptorProto msg) {
-        final Optional<String> everyIs = getIs(msg);
+        Optional<String> everyIs = getIs(msg);
         if (everyIs.isPresent()) {
-            final MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
+            MessageAndInterface resultingFile = generateFile(file, msg, everyIs.get());
             return Optional.of(resultingFile);
         } else {
             return Optional.empty();

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
@@ -52,9 +52,9 @@ public class Plugin {
      * The entry point of the program.
      */
     public static void main(String[] args) {
-        final CodeGeneratorRequest request = readRequest();
-        final SpineProtoGenerator generator = MarkerInterfaceGenerator.instance();
-        final CodeGeneratorResponse response = generator.process(request);
+        CodeGeneratorRequest request = readRequest();
+        SpineProtoGenerator generator = MarkerInterfaceGenerator.instance();
+        CodeGeneratorResponse response = generator.process(request);
         writeResponse(response);
     }
 
@@ -71,7 +71,7 @@ public class Plugin {
     private static void writeResponse(CodeGeneratorResponse response) {
         checkNotNull(response);
         @SuppressWarnings("UseOfSystemOutOrSystemErr") // Required by the protoc API.
-        final CodedOutputStream stream = CodedOutputStream.newInstance(System.out);
+        CodedOutputStream stream = CodedOutputStream.newInstance(System.out);
         try {
             response.writeTo(stream);
             stream.flush();

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/SpineProtoGenerator.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/SpineProtoGenerator.java
@@ -122,9 +122,9 @@ public abstract class SpineProtoGenerator {
     public final CodeGeneratorResponse process(CodeGeneratorRequest request) {
         checkNotNull(request);
         checkCompilerVersion(request);
-        final List<FileDescriptorProto> protoFiles = request.getProtoFileList();
+        List<FileDescriptorProto> protoFiles = request.getProtoFileList();
         checkArgument(!protoFiles.isEmpty(), "No files to generate provided.");
-        final CodeGeneratorResponse response = process(protoFiles);
+        CodeGeneratorResponse response = process(protoFiles);
         return response;
     }
 
@@ -132,7 +132,7 @@ public abstract class SpineProtoGenerator {
      * Ensures that the version of the Google Protobuf Compiler is 3.* or higher.
      */
     private void checkCompilerVersion(CodeGeneratorRequest request) {
-        final Version version = request.getCompilerVersion();
+        Version version = request.getCompilerVersion();
         checkArgument(version.getMajor() >= 3,
                       "Use protoc of version 3.* or higher to run %s",
                       getClass().getName());
@@ -142,12 +142,12 @@ public abstract class SpineProtoGenerator {
      * Processes all passed proto files.
      */
     private CodeGeneratorResponse process(Iterable<FileDescriptorProto> files) {
-        final Collection<File> generatedFiles = newHashSet();
+        Collection<File> generatedFiles = newHashSet();
         for (FileDescriptorProto file : files) {
-            final Collection<File> newFiles = generateForTypesIn(file);
+            Collection<File> newFiles = generateForTypesIn(file);
             generatedFiles.addAll(newFiles);
         }
-        final CodeGeneratorResponse response =
+        CodeGeneratorResponse response =
                 CodeGeneratorResponse.newBuilder()
                                      .addAllFile(generatedFiles)
                                      .build();
@@ -158,9 +158,9 @@ public abstract class SpineProtoGenerator {
      * Processes the passed proto file.
      */
     private Collection<File> generateForTypesIn(FileDescriptorProto file) {
-        final Collection<File> result = newHashSet();
+        Collection<File> result = newHashSet();
         for (DescriptorProto message : file.getMessageTypeList()) {
-            final Collection<File> processedFile = processMessage(file, message);
+            Collection<File> processedFile = processMessage(file, message);
             result.addAll(processedFile);
         }
         return result;

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorShould.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorShould.java
@@ -211,7 +211,7 @@ public class MarkerInterfaceGeneratorShould {
                                     .addFileToGenerate(filePath)
                                     .addProtoFile(descriptor)
                                     .build();
-        final CodeGeneratorResponse response = codeGenerator.process(request);
+        CodeGeneratorResponse response = codeGenerator.process(request);
         assertNotNull(response);
         List<File> files = response.getFileList();
         assertEquals(3, files.size());
@@ -220,14 +220,14 @@ public class MarkerInterfaceGeneratorShould {
                     .endsWith("Event.java")) {
                 assertFalse(file.hasInsertionPoint());
             } else {
-                final String name = file.getName();
+                String name = file.getName();
                 assertEquals(PACKAGE_PATH + "/IsInOneFileProto.java", name);
 
-                final String insertionPoint = file.getInsertionPoint();
+                String insertionPoint = file.getInsertionPoint();
                 assertTrue(insertionPoint.startsWith(format(INSERTION_POINT_IMPLEMENTS,
                                                             PROTO_PACKAGE)));
-                final String content = file.getContent();
-                final Matcher matcher = CUSTOMER_EVENT_INTERFACE_PATTERN.matcher(content);
+                String content = file.getContent();
+                Matcher matcher = CUSTOMER_EVENT_INTERFACE_PATTERN.matcher(content);
                 assertTrue(format("Unexpected inserted content: %s", content), matcher.matches());
             }
         }

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceSpecShould.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceSpecShould.java
@@ -35,11 +35,11 @@ public class MarkerInterfaceSpecShould {
 
     @Test
     public void generate_interfaces() {
-        final String packageName = "io.spine.test";
-        final String interfaceName = "CustomerEvent";
-        final JavaFile javaFile = new MarkerInterfaceSpec(packageName, interfaceName).toJavaCode();
+        String packageName = "io.spine.test";
+        String interfaceName = "CustomerEvent";
+        JavaFile javaFile = new MarkerInterfaceSpec(packageName, interfaceName).toJavaCode();
 
-        final AnnotationSpec generated = javaFile.typeSpec.annotations.get(0);
+        AnnotationSpec generated = javaFile.typeSpec.annotations.get(0);
         assertEquals(Generated.class.getName(), generated.type.toString());
 
         assertEquals(packageName, javaFile.packageName);


### PR DESCRIPTION
This PR provides the following changes for the `protoc-plugin` module:

- The `final` keyword on local variables was removed.