### PR TITLE
Remove the unnecessary `final` keyword on local variables for the `plugin-testlib` module

### DIFF
--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
@@ -108,8 +108,8 @@ public final class GradleProject {
     private GradleRunner prepareRun(TaskName taskName) {
         String task = taskName.getValue();
         String[] args = debug
-                ? new String[]{task, STACKTRACE_CLI_OPTION, DEBUG_CLI_OPTION}
-                : new String[]{task, STACKTRACE_CLI_OPTION};
+                        ? new String[]{task, STACKTRACE_CLI_OPTION, DEBUG_CLI_OPTION}
+                        : new String[]{task, STACKTRACE_CLI_OPTION};
         return gradleRunner.withArguments(args);
     }
 
@@ -124,11 +124,11 @@ public final class GradleProject {
     private void writeFile(String fileName, String dir) throws IOException {
         String filePath = dir + fileName;
         Path resultingPath = gradleRunner.getProjectDir()
-                                               .toPath()
-                                               .resolve(filePath);
+                                         .toPath()
+                                         .resolve(filePath);
         String fullyQualifiedPath = name + '/' + filePath;
         InputStream fileContent = getClass().getClassLoader()
-                                                  .getResourceAsStream(fullyQualifiedPath);
+                                            .getResourceAsStream(fullyQualifiedPath);
         Files.createDirectories(resultingPath.getParent());
         Files.copy(fileContent, resultingPath);
     }
@@ -142,10 +142,10 @@ public final class GradleProject {
 
     private void writeBuildGradle() throws IOException {
         Path resultingPath = gradleRunner.getProjectDir()
-                                               .toPath()
-                                               .resolve(BUILD_GRADLE_NAME);
+                                         .toPath()
+                                         .resolve(BUILD_GRADLE_NAME);
         InputStream fileContent = getClass().getClassLoader()
-                                                  .getResourceAsStream(BUILD_GRADLE_NAME);
+                                            .getResourceAsStream(BUILD_GRADLE_NAME);
         Files.createDirectories(resultingPath.getParent());
         Files.copy(fileContent, resultingPath);
     }
@@ -306,7 +306,7 @@ public final class GradleProject {
          */
         public Builder createFile(String path, Iterable<String> lines) {
             Path sourcePath = folder.toPath()
-                                          .resolve(path);
+                                    .resolve(path);
             try {
                 Files.createDirectories(sourcePath.getParent());
                 Files.write(sourcePath, lines, Charset.forName("UTF-8"));

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
@@ -106,8 +106,8 @@ public final class GradleProject {
     }
 
     private GradleRunner prepareRun(TaskName taskName) {
-        final String task = taskName.getValue();
-        final String[] args = debug
+        String task = taskName.getValue();
+        String[] args = debug
                 ? new String[]{task, STACKTRACE_CLI_OPTION, DEBUG_CLI_OPTION}
                 : new String[]{task, STACKTRACE_CLI_OPTION};
         return gradleRunner.withArguments(args);
@@ -122,12 +122,12 @@ public final class GradleProject {
     }
 
     private void writeFile(String fileName, String dir) throws IOException {
-        final String filePath = dir + fileName;
-        final Path resultingPath = gradleRunner.getProjectDir()
+        String filePath = dir + fileName;
+        Path resultingPath = gradleRunner.getProjectDir()
                                                .toPath()
                                                .resolve(filePath);
-        final String fullyQualifiedPath = name + '/' + filePath;
-        final InputStream fileContent = getClass().getClassLoader()
+        String fullyQualifiedPath = name + '/' + filePath;
+        InputStream fileContent = getClass().getClassLoader()
                                                   .getResourceAsStream(fullyQualifiedPath);
         Files.createDirectories(resultingPath.getParent());
         Files.copy(fileContent, resultingPath);
@@ -141,10 +141,10 @@ public final class GradleProject {
     }
 
     private void writeBuildGradle() throws IOException {
-        final Path resultingPath = gradleRunner.getProjectDir()
+        Path resultingPath = gradleRunner.getProjectDir()
                                                .toPath()
                                                .resolve(BUILD_GRADLE_NAME);
-        final InputStream fileContent = getClass().getClassLoader()
+        InputStream fileContent = getClass().getClassLoader()
                                                   .getResourceAsStream(BUILD_GRADLE_NAME);
         Files.createDirectories(resultingPath.getParent());
         Files.copy(fileContent, resultingPath);
@@ -305,7 +305,7 @@ public final class GradleProject {
          * @param lines the content of the file
          */
         public Builder createFile(String path, Iterable<String> lines) {
-            final Path sourcePath = folder.toPath()
+            Path sourcePath = folder.toPath()
                                           .resolve(path);
             try {
                 Files.createDirectories(sourcePath.getParent());
@@ -337,7 +337,7 @@ public final class GradleProject {
     }
 
     private static IllegalStateException illegalStateWithCauseOf(Throwable throwable) {
-        final Throwable rootCause = getRootCause(throwable);
+        Throwable rootCause = getRootCause(throwable);
         throw new IllegalStateException(rootCause);
     }
 }

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
@@ -48,9 +48,9 @@ public class GradleProjectTest {
     @Test
     public void build_from_project_folder_and_project_name() {
         GradleProject project = GradleProject.newBuilder()
-                                                   .setProjectFolder(temporaryFolder.getRoot())
-                                                   .setProjectName(PROJECT_NAME)
-                                                   .build();
+                                             .setProjectFolder(temporaryFolder.getRoot())
+                                             .setProjectName(PROJECT_NAME)
+                                             .build();
         assertNotNull(project);
     }
 
@@ -67,10 +67,10 @@ public class GradleProjectTest {
         @SuppressWarnings("DuplicateStringLiteralInspection")
             // "java" literal is copied with different semantics.
         Path root = temporaryFolder.getRoot()
-                                         .toPath()
-                                         .resolve("src")
-                                         .resolve("main")
-                                         .resolve("java");
+                                   .toPath()
+                                   .resolve("src")
+                                   .resolve("main")
+                                   .resolve("java");
         for (String fileName : files) {
             assertTrue(Files.exists(root.resolve(fileName)));
         }
@@ -79,10 +79,10 @@ public class GradleProjectTest {
     @Test
     public void execute_faulty_build() {
         GradleProject project = GradleProject.newBuilder()
-                                                   .setProjectName(PROJECT_NAME)
-                                                   .setProjectFolder(temporaryFolder.getRoot())
-                                                   .addJavaFiles("Faulty.java")
-                                                   .build();
+                                             .setProjectName(PROJECT_NAME)
+                                             .setProjectFolder(temporaryFolder.getRoot())
+                                             .addJavaFiles("Faulty.java")
+                                             .build();
         BuildResult buildResult = project.executeAndFail(COMPILE_JAVA);
         assertNotNull(buildResult);
         BuildTask compileTask = buildResult.task(':' + COMPILE_JAVA.getValue());

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/GradleProjectTest.java
@@ -47,7 +47,7 @@ public class GradleProjectTest {
 
     @Test
     public void build_from_project_folder_and_project_name() {
-        final GradleProject project = GradleProject.newBuilder()
+        GradleProject project = GradleProject.newBuilder()
                                                    .setProjectFolder(temporaryFolder.getRoot())
                                                    .setProjectName(PROJECT_NAME)
                                                    .build();
@@ -58,7 +58,7 @@ public class GradleProjectTest {
         // OK for this test case; result of `build` it ignored.
     @Test
     public void write_given_java_files() {
-        final String[] files = {"Foo.java", "Bar.java"};
+        String[] files = {"Foo.java", "Bar.java"};
         GradleProject.newBuilder()
                      .setProjectFolder(temporaryFolder.getRoot())
                      .setProjectName(PROJECT_NAME)
@@ -66,7 +66,7 @@ public class GradleProjectTest {
                      .build();
         @SuppressWarnings("DuplicateStringLiteralInspection")
             // "java" literal is copied with different semantics.
-        final Path root = temporaryFolder.getRoot()
+        Path root = temporaryFolder.getRoot()
                                          .toPath()
                                          .resolve("src")
                                          .resolve("main")
@@ -78,14 +78,14 @@ public class GradleProjectTest {
 
     @Test
     public void execute_faulty_build() {
-        final GradleProject project = GradleProject.newBuilder()
+        GradleProject project = GradleProject.newBuilder()
                                                    .setProjectName(PROJECT_NAME)
                                                    .setProjectFolder(temporaryFolder.getRoot())
                                                    .addJavaFiles("Faulty.java")
                                                    .build();
-        final BuildResult buildResult = project.executeAndFail(COMPILE_JAVA);
+        BuildResult buildResult = project.executeAndFail(COMPILE_JAVA);
         assertNotNull(buildResult);
-        final BuildTask compileTask = buildResult.task(':' + COMPILE_JAVA.getValue());
+        BuildTask compileTask = buildResult.task(':' + COMPILE_JAVA.getValue());
         assertNotNull(compileTask);
         assertEquals(FAILED, compileTask.getOutcome());
     }


### PR DESCRIPTION
This PR provides the following changes for the `plugin-testlib` module:

- The `final` keyword on local variables was removed.