### PR TITLE
Remove the unnecessary `final` keyword on local variables for the `plugin-base` module.

### DIFF
--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
@@ -180,22 +180,22 @@ public final class GradleTask {
          */
         @CanIgnoreReturnValue
         public GradleTask applyNowTo(Project project) {
-            final String errMsg = "Project is not specified for the new Gradle task: ";
+            String errMsg = "Project is not specified for the new Gradle task: ";
             checkNotNull(project, errMsg + name);
 
             if (followingTask == null
                     && previousTask == null
                     && previousTaskOfAllProjects == null) {
-                final String exceptionMsg =
+                String exceptionMsg =
                         "Either the previous or the following task must be set.";
                 throw new IllegalStateException(exceptionMsg);
             }
 
-            final Task newTask = project.task(name.getValue())
+            Task newTask = project.task(name.getValue())
                                         .doLast(action);
             dependTask(newTask, project);
             addTaskIO(newTask);
-            final GradleTask result = new GradleTask(name, project);
+            GradleTask result = new GradleTask(name, project);
             return result;
         }
 
@@ -204,20 +204,20 @@ public final class GradleTask {
                 task.dependsOn(previousTask.getValue());
             }
             if (followingTask != null) {
-                final TaskContainer existingTasks = project.getTasks();
+                TaskContainer existingTasks = project.getTasks();
                 existingTasks.getByPath(followingTask.getValue())
                              .dependsOn(task);
             }
             if (previousTaskOfAllProjects != null) {
-                final Project root = project.getRootProject();
+                Project root = project.getRootProject();
                 dependTaskOnAllProjects(task, root);
             }
         }
 
-        private void dependTaskOnAllProjects(final Task task, Project rootProject) {
-            final String prevTaskName = previousTaskOfAllProjects.getValue();
+        private void dependTaskOnAllProjects(Task task, Project rootProject) {
+            String prevTaskName = previousTaskOfAllProjects.getValue();
             ProjectHierarchy.applyToAll(rootProject, project -> {
-                final Task existingTask = project.getTasks().findByName(prevTaskName);
+                Task existingTask = project.getTasks().findByName(prevTaskName);
                 if (existingTask != null) {
                     task.dependsOn(existingTask);
                 }
@@ -257,7 +257,7 @@ public final class GradleTask {
         if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-        final GradleTask other = (GradleTask) obj;
+        GradleTask other = (GradleTask) obj;
         return Objects.equals(this.name, other.name)
                 && Objects.equals(this.project, other.project);
     }

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
@@ -192,7 +192,7 @@ public final class GradleTask {
             }
 
             Task newTask = project.task(name.getValue())
-                                        .doLast(action);
+                                  .doLast(action);
             dependTask(newTask, project);
             addTaskIO(newTask);
             GradleTask result = new GradleTask(name, project);
@@ -217,7 +217,8 @@ public final class GradleTask {
         private void dependTaskOnAllProjects(Task task, Project rootProject) {
             String prevTaskName = previousTaskOfAllProjects.getValue();
             ProjectHierarchy.applyToAll(rootProject, project -> {
-                Task existingTask = project.getTasks().findByName(prevTaskName);
+                Task existingTask = project.getTasks()
+                                           .findByName(prevTaskName);
                 if (existingTask != null) {
                     task.dependsOn(existingTask);
                 }

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/ProjectHierarchy.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/ProjectHierarchy.java
@@ -57,9 +57,9 @@ public final class ProjectHierarchy {
                       "Passed project %s is not the root project. ",
                       rootProject.getPath());
         action.execute(rootProject);
-        final Deque<Project> subprojects = newLinkedList(rootProject.getSubprojects());
+        Deque<Project> subprojects = newLinkedList(rootProject.getSubprojects());
         while (!subprojects.isEmpty()) {
-            final Project current = subprojects.poll();
+            Project current = subprojects.poll();
             checkNotNull(current);
             action.execute(current);
             subprojects.addAll(current.getSubprojects());

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/SpinePlugin.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/SpinePlugin.java
@@ -49,7 +49,7 @@ public abstract class SpinePlugin implements Plugin<Project> {
      * @see GradleTask.Builder#applyNowTo(Project)
      */
     protected GradleTask.Builder newTask(TaskName name, Action<Task> action) {
-        final GradleTask.Builder result = new GradleTask.Builder(name, action);
+        GradleTask.Builder result = new GradleTask.Builder(name, action);
         return result;
     }
 

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskDependencies.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskDependencies.java
@@ -44,7 +44,7 @@ public class TaskDependencies {
      * Checks whether a given Gradle task depends on another Gradle task with the specified name.
      */
     public static boolean dependsOn(Task task, TaskName ontoTaskWithName) {
-        final String taskName = ontoTaskWithName.getValue();
+        String taskName = ontoTaskWithName.getValue();
         return dependsOn(task, taskName);
     }
 
@@ -54,7 +54,7 @@ public class TaskDependencies {
      */
     @SuppressWarnings("ChainOfInstanceofChecks")
     private static boolean dependsOn(Task task, String ontoTaskWithName) {
-        final Set<Object> dependsOn = task.getDependsOn();
+        Set<Object> dependsOn = task.getDependsOn();
 
         boolean contains = false;
         for (Object anObject : dependsOn) {
@@ -62,7 +62,7 @@ public class TaskDependencies {
                 contains = contains || ontoTaskWithName.equals(anObject);
             }
             if (anObject instanceof Task) {
-                final Task objectAsTask = (Task) anObject;
+                Task objectAsTask = (Task) anObject;
                 contains = contains || ontoTaskWithName.equals(objectAsTask.getName());
             }
         }

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/ProjectHierarchyShould.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/ProjectHierarchyShould.java
@@ -57,11 +57,11 @@ public class ProjectHierarchyShould {
 
     @Test
     public void traverse_hierarchy_in_bf_ordering() {
-        final Project root = mock(Project.class);
-        final Project sub1 = mock(Project.class);
-        final Project sub2 = mock(Project.class);
-        final Project subsub1 = mock(Project.class);
-        final Project subsub2 = mock(Project.class);
+        Project root = mock(Project.class);
+        Project sub1 = mock(Project.class);
+        Project sub2 = mock(Project.class);
+        Project subsub1 = mock(Project.class);
+        Project subsub2 = mock(Project.class);
 
         when(root.getSubprojects()).thenReturn(newHashSet(sub1, sub2));
         when(sub1.getSubprojects()).thenReturn(newHashSet(subsub1, subsub2));
@@ -71,7 +71,7 @@ public class ProjectHierarchyShould {
 
         when(root.getRootProject()).thenReturn(root);
 
-        final Set<Project> visited = newHashSet();
+        Set<Project> visited = newHashSet();
         ProjectHierarchy.applyToAll(root, project -> {
             assertFalse(visited.contains(project));
             for (Project child : project.getSubprojects()) {
@@ -86,7 +86,7 @@ public class ProjectHierarchyShould {
 
     @Test(expected = IllegalArgumentException.class)
     public void not_accept_non_root_projects() {
-        final Project project = mock(Project.class);
+        Project project = mock(Project.class);
         when(project.getRootProject()).thenReturn(mock(Project.class)); // other instance
         ProjectHierarchy.applyToAll(project, GradleProject.NoOp.<Project>action());
     }

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/SpinePluginBuilderShould.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/SpinePluginBuilderShould.java
@@ -64,20 +64,20 @@ public class SpinePluginBuilderShould {
 
     @Test
     public void create_task_dependant_on_all_tasks_of_given_name() {
-        final Project subProject = ProjectBuilder.builder()
+        Project subProject = ProjectBuilder.builder()
                                                  .withParent(project)
                                                  .build();
         subProject.getPluginManager()
                   .apply(GradleProject.JAVA_PLUGIN_ID);
-        final SpinePlugin plugin = TestPlugin.INSTANCE;
-        final GradleTask task = plugin.newTask(ANNOTATE_PROTO, NoOp.action())
+        SpinePlugin plugin = TestPlugin.INSTANCE;
+        GradleTask task = plugin.newTask(ANNOTATE_PROTO, NoOp.action())
                                       .insertAfterAllTasks(COMPILE_JAVA)
                                       .applyNowTo(subProject);
-        final TaskContainer subProjectTasks = subProject.getTasks();
-        final Task newTask = subProjectTasks.findByName(task.getName()
+        TaskContainer subProjectTasks = subProject.getTasks();
+        Task newTask = subProjectTasks.findByName(task.getName()
                                                             .getValue());
         assertNotNull(newTask);
-        final Collection<?> dependencies = newTask.getDependsOn();
+        Collection<?> dependencies = newTask.getDependsOn();
         assertTrue(dependencies.contains(subProjectTasks.findByName(COMPILE_JAVA.getValue())));
         assertTrue(dependencies.contains(project.getTasks()
                                                 .findByName(COMPILE_JAVA.getValue())));
@@ -85,14 +85,14 @@ public class SpinePluginBuilderShould {
 
     @Test
     public void create_task_and_insert_before_other() {
-        final SpinePlugin plugin = TestPlugin.INSTANCE;
+        SpinePlugin plugin = TestPlugin.INSTANCE;
         plugin.newTask(VERIFY_MODEL, NoOp.action())
               .insertBeforeTask(CLASSES)
               .applyNowTo(project);
-        final TaskContainer tasks = project.getTasks();
-        final Task classes = tasks.findByName(CLASSES.getValue());
+        TaskContainer tasks = project.getTasks();
+        Task classes = tasks.findByName(CLASSES.getValue());
         assertNotNull(classes);
-        final Task verifyModel = tasks.findByName(VERIFY_MODEL.getValue());
+        Task verifyModel = tasks.findByName(VERIFY_MODEL.getValue());
         assertTrue(classes.getDependsOn()
                           .contains(verifyModel));
     }

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/SpinePluginBuilderShould.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/SpinePluginBuilderShould.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.gradle;
 
-import io.spine.tools.gradle.GradleProject;
 import io.spine.tools.gradle.GradleProject.NoOp;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -65,17 +64,17 @@ public class SpinePluginBuilderShould {
     @Test
     public void create_task_dependant_on_all_tasks_of_given_name() {
         Project subProject = ProjectBuilder.builder()
-                                                 .withParent(project)
-                                                 .build();
+                                           .withParent(project)
+                                           .build();
         subProject.getPluginManager()
                   .apply(GradleProject.JAVA_PLUGIN_ID);
         SpinePlugin plugin = TestPlugin.INSTANCE;
         GradleTask task = plugin.newTask(ANNOTATE_PROTO, NoOp.action())
-                                      .insertAfterAllTasks(COMPILE_JAVA)
-                                      .applyNowTo(subProject);
+                                .insertAfterAllTasks(COMPILE_JAVA)
+                                .applyNowTo(subProject);
         TaskContainer subProjectTasks = subProject.getTasks();
         Task newTask = subProjectTasks.findByName(task.getName()
-                                                            .getValue());
+                                                      .getValue());
         assertNotNull(newTask);
         Collection<?> dependencies = newTask.getDependsOn();
         assertTrue(dependencies.contains(subProjectTasks.findByName(COMPILE_JAVA.getValue())));


### PR DESCRIPTION
This PR provides the following changes for the `plugin-base` module:

- The `final` keyword on local variables was removed.