### PR TITLE
Replacement of optional for the `model-compiler` module

### DIFF
--- a/base/src/main/java/io/spine/code/java/PrimitiveType.java
+++ b/base/src/main/java/io/spine/code/java/PrimitiveType.java
@@ -20,8 +20,9 @@
 
 package io.spine.code.java;
 
-import com.google.common.base.Optional;
 import io.spine.code.proto.ScalarType;
+
+import java.util.Optional;
 
 import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
 
@@ -50,7 +51,7 @@ public enum PrimitiveType {
      * Returns the boxed {@link Class} for the Protobuf scalar primitive name.
      *
      * @param primitiveType the primitive type name
-     * @return the wrapper class or {@link Optional#absent() Optional.absent()}
+     * @return the wrapper class or {@link Optional#empty() Optional.empty()}
      * if the specified primitive name does not belong to {@link ScalarType}.
      */
     public static Optional<? extends Class<?>> getWrapperClass(String primitiveType) {
@@ -61,7 +62,7 @@ public enum PrimitiveType {
             }
         }
 
-        return Optional.absent();
+        return Optional.empty();
     }
 
     boolean matchesName(String typeName) {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/DirectoryCleaner.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/DirectoryCleaner.java
@@ -45,11 +45,11 @@ public class DirectoryCleaner extends SimpleFileVisitor<Path> {
 
     public static void deleteDirs(List<String> dirs) {
         for (String dirPath : dirs) {
-            final File file = new File(dirPath);
+            File file = new File(dirPath);
             if (file.exists() && file.isDirectory()) {
                 deleteRecursively(file.toPath());
             } else {
-                final String msg = "Trying to delete '{}' which is not a directory";
+                String msg = "Trying to delete '{}' which is not a directory";
                 log().warn(msg, file.getAbsolutePath());
             }
         }
@@ -57,7 +57,7 @@ public class DirectoryCleaner extends SimpleFileVisitor<Path> {
 
     private static void deleteRecursively(Path path) {
         try {
-            final SimpleFileVisitor<Path> visitor = new DirectoryCleaner();
+            SimpleFileVisitor<Path> visitor = new DirectoryCleaner();
             log().debug("Starting to delete the files recursively in {}", path.toString());
             Files.walkFileTree(path, visitor);
         } catch (IOException e) {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/MessageTypeCache.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/MessageTypeCache.java
@@ -56,26 +56,26 @@ public class MessageTypeCache {
     public void cacheTypes(FileDescriptorProto fileDescriptor) {
         log().debug("Caching all the types declared in the file: {}", fileDescriptor.getName());
 
-        final FileOptions options = fileDescriptor.getOptions();
+        FileOptions options = fileDescriptor.getOptions();
 
-        final String sourceProtoPackage = fileDescriptor.getPackage();
-        final String protoPackage = !sourceProtoPackage.isEmpty()
+        String sourceProtoPackage = fileDescriptor.getPackage();
+        String protoPackage = !sourceProtoPackage.isEmpty()
                                     ? (sourceProtoPackage + '.')
                                     : "";
-        final String sourceJavaPackage = options.getJavaPackage();
-        final StringBuilder javaPackage =
+        String sourceJavaPackage = options.getJavaPackage();
+        StringBuilder javaPackage =
                 new StringBuilder(!sourceJavaPackage.isEmpty()
                                           ? sourceJavaPackage + '.'
                                           : "");
 
         if (!options.getJavaMultipleFiles()) {
-            final String singleFileSuffix = SimpleClassName.outerOf(fileDescriptor)
+            String singleFileSuffix = SimpleClassName.outerOf(fileDescriptor)
                                                            .value();
             javaPackage.append(singleFileSuffix)
                        .append('.');
         }
 
-        final String pkgValue = javaPackage.toString();
+        String pkgValue = javaPackage.toString();
         cacheMessageTypes(fileDescriptor, protoPackage, pkgValue);
         cacheEnumTypes(fileDescriptor, protoPackage, pkgValue);
     }
@@ -103,21 +103,21 @@ public class MessageTypeCache {
      * @return current cache contents
      */
     public Map<String, String> getCachedTypes() {
-        final ImmutableMap<String, String> immutable = ImmutableMap.copyOf(cachedMessageTypes);
+        ImmutableMap<String, String> immutable = ImmutableMap.copyOf(cachedMessageTypes);
         return immutable;
     }
 
     //It's fine, as we are caching multiple nested types per message descriptor.
     @SuppressWarnings("MethodWithMultipleLoops")
     private void cacheMessageType(DescriptorProto msg, String protoPrefix, String javaPrefix) {
-        final String msgName = msg.getName();
-        final String key = protoPrefix + msgName;
-        final String value = javaPrefix + msgName;
+        String msgName = msg.getName();
+        String key = protoPrefix + msgName;
+        String value = javaPrefix + msgName;
         log().debug("Caching message type {}", msgName);
         cachedMessageTypes.put(key, value);
         if (msg.getNestedTypeCount() > 0 || msg.getEnumTypeCount() > 0) {
-            final String nestedProtoPrefix = protoPrefix + msgName + '.';
-            final String nestedJavaPrefix = javaPrefix + msgName + '.';
+            String nestedProtoPrefix = protoPrefix + msgName + '.';
+            String nestedJavaPrefix = javaPrefix + msgName + '.';
             for (DescriptorProto nestedMsg : msg.getNestedTypeList()) {
                 cacheMessageType(nestedMsg, nestedProtoPrefix, nestedJavaPrefix);
             }
@@ -130,10 +130,10 @@ public class MessageTypeCache {
     private void cacheEnumType(EnumDescriptorProto descriptor,
                                String protoPrefix,
                                String javaPrefix) {
-        final String name = descriptor.getName();
+        String name = descriptor.getName();
         log().debug("Caching enum type {}", name);
-        final String key = protoPrefix + name;
-        final String value = javaPrefix + name;
+        String key = protoPrefix + name;
+        String value = javaPrefix + name;
         cachedMessageTypes.put(key, value);
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/MessageTypeCache.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/MessageTypeCache.java
@@ -60,17 +60,17 @@ public class MessageTypeCache {
 
         String sourceProtoPackage = fileDescriptor.getPackage();
         String protoPackage = !sourceProtoPackage.isEmpty()
-                                    ? (sourceProtoPackage + '.')
-                                    : "";
+                              ? (sourceProtoPackage + '.')
+                              : "";
         String sourceJavaPackage = options.getJavaPackage();
         StringBuilder javaPackage =
                 new StringBuilder(!sourceJavaPackage.isEmpty()
-                                          ? sourceJavaPackage + '.'
-                                          : "");
+                                  ? sourceJavaPackage + '.'
+                                  : "");
 
         if (!options.getJavaMultipleFiles()) {
             String singleFileSuffix = SimpleClassName.outerOf(fileDescriptor)
-                                                           .value();
+                                                     .value();
             javaPackage.append(singleFileSuffix)
                        .append('.');
         }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
@@ -193,8 +193,8 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
     protected static <T extends JavaSource<T>> void rewriteSource(String sourcePathPrefix,
                                                                   SourceFile sourcePath,
                                                                   SourceVisitor<T> sourceVisitor) {
-        final AbstractJavaSource<T> javaSource;
-        final Path absoluteSourcePath = Paths.get(sourcePathPrefix, sourcePath.toString());
+        AbstractJavaSource<T> javaSource;
+        Path absoluteSourcePath = Paths.get(sourcePathPrefix, sourcePath.toString());
 
         if (!Files.exists(absoluteSourcePath)) {
             // Do nothing.
@@ -208,7 +208,7 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
         }
 
         sourceVisitor.apply(javaSource);
-        final String resultingSource = javaSource.toString();
+        String resultingSource = javaSource.toString();
         try {
             Files.write(absoluteSourcePath, resultingSource.getBytes(), TRUNCATE_EXISTING);
         } catch (IOException e) {
@@ -229,8 +229,8 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
             return;
         }
 
-        final String annotationFQN = annotation.getCanonicalName();
-        final AnnotationSource newAnnotation = source.addAnnotation();
+        String annotationFQN = annotation.getCanonicalName();
+        AnnotationSource newAnnotation = source.addAnnotation();
         newAnnotation.setName(annotationFQN);
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/AnnotatorFactory.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/AnnotatorFactory.java
@@ -92,9 +92,9 @@ public class AnnotatorFactory {
     public static void processDescriptorSetFile(File setFile,
                                                 String generatedProtoDir,
                                                 String generatedGrpcDir) {
-        final Collection<FileDescriptorProto> descriptors =
+        Collection<FileDescriptorProto> descriptors =
                 FileDescriptors.parseSkipStandard(setFile.getPath());
-        final AnnotatorFactory factory =
+        AnnotatorFactory factory =
                 new AnnotatorFactory(descriptors, generatedProtoDir, generatedGrpcDir);
 
         factory.createFileAnnotator(Experimental.class, experimentalAll)

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/EnumAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/EnumAnnotator.java
@@ -67,7 +67,7 @@ class EnumAnnotator extends TypeDefinitionAnnotator<EnumOptions, EnumDescriptorP
 
     @Override
     protected void annotateDefinition(EnumDescriptorProto enumType, FileDescriptorProto file) {
-        final SourceFile filePath = SourceFile.forEnum(enumType, file);
+        SourceFile filePath = SourceFile.forEnum(enumType, file);
         rewriteSource(filePath, new TypeDeclarationAnnotation());
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FieldAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FieldAnnotator.java
@@ -79,7 +79,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
             return;
         }
 
-        final SourceFile outerClass = SourceFile.forOuterClassOf(file);
+        SourceFile outerClass = SourceFile.forOuterClassOf(file);
         rewriteSource(outerClass, new FileFieldAnnotation<JavaClassSource>(file));
     }
 
@@ -87,9 +87,9 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
     protected void annotateMultipleFiles(FileDescriptorProto file) {
         for (DescriptorProto messageType : file.getMessageTypeList()) {
             if (shouldAnnotate(messageType)) {
-                final SourceVisitor<JavaClassSource> annotation =
+                SourceVisitor<JavaClassSource> annotation =
                         new MessageFieldAnnotation<>(file, messageType);
-                final SourceFile filePath = SourceFile.forMessage(messageType, false, file);
+                SourceFile filePath = SourceFile.forMessage(messageType, false, file);
                 rewriteSource(filePath, annotation);
             }
         }
@@ -102,8 +102,8 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
 
     @VisibleForTesting
     static JavaClassSource getBuilder(JavaSource messageSource) {
-        final JavaClassSource messageClass = asClassSource(messageSource);
-        final JavaSource builderSource = messageClass.getNestedType(SimpleClassName.ofBuilder()
+        JavaClassSource messageClass = asClassSource(messageSource);
+        JavaSource builderSource = messageClass.getNestedType(SimpleClassName.ofBuilder()
                                                                                    .value());
         return asClassSource(builderSource);
     }
@@ -117,7 +117,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
      */
     private static JavaClassSource asClassSource(JavaType<?> javaType) {
         if (!javaType.isClass()) {
-            final String errMsg = format("`%s expected to be a class.",
+            String errMsg = format("`%s expected to be a class.",
                                          javaType.getQualifiedName());
             throw new IllegalStateException(errMsg);
         }
@@ -153,7 +153,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
         public @Nullable Void apply(@Nullable AbstractJavaSource<T> input) {
             checkNotNull(input);
             for (DescriptorProto messageType : fileDescriptor.getMessageTypeList()) {
-                final Iterable<String> unannotatableFields = getNotAnnotatableFields(messageType);
+                Iterable<String> unannotatableFields = getNotAnnotatableFields(messageType);
                 processMessageDescriptor(input, messageType, unannotatableFields);
             }
             return null;
@@ -164,7 +164,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
                                               Iterable<String> unannotatableFields) {
             for (FieldDescriptorProto field : messageType.getFieldList()) {
                 if (shouldAnnotate(field)) {
-                    final JavaSource message = findNestedType(input, messageType.getName());
+                    JavaSource message = findNestedType(input, messageType.getName());
                     annotateMessageField(asClassSource(message), field, unannotatableFields);
                 }
             }
@@ -206,7 +206,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
         @Override
         public @Nullable Void apply(@Nullable AbstractJavaSource<T> input) {
             checkNotNull(input);
-            final Iterable<String> fieldsToSkip = getNotAnnotatableFields(message);
+            Iterable<String> fieldsToSkip = getNotAnnotatableFields(message);
             for (FieldDescriptorProto field : message.getFieldList()) {
                 if (shouldAnnotate(field)) {
                     annotateMessageField(asClassSource(input), field, fieldsToSkip);
@@ -229,9 +229,9 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
     private void annotateMessageField(JavaClassSource message,
                                       FieldDescriptorProto field,
                                       Iterable<String> skipFields) {
-        final String capitalizedFieldName = FieldName.of(field)
+        String capitalizedFieldName = FieldName.of(field)
                                                      .toCamelCase();
-        final JavaClassSource messageBuilder = getBuilder(message);
+        JavaClassSource messageBuilder = getBuilder(message);
 
         annotateAccessors(message, capitalizedFieldName, skipFields);
         annotateAccessors(messageBuilder, capitalizedFieldName, skipFields);
@@ -251,7 +251,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
                                    String capitalizedFieldName,
                                    Iterable<String> skipFields) {
         for (MethodSource method : javaSource.getMethods()) {
-            final boolean shouldAnnotate =
+            boolean shouldAnnotate =
                     shouldAnnotateMethod(method.getName(), capitalizedFieldName, skipFields);
             if (method.isPublic() && shouldAnnotate) {
                 addAnnotation(method);
@@ -277,7 +277,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
         }
 
         for (String unannotatableField : unannotatableFields) {
-            final boolean isDebatableMethod =
+            boolean isDebatableMethod =
                     unannotatableField.length() > capitalizedFieldName.length();
             if (isDebatableMethod && methodName.contains(unannotatableField)) {
                 return false;
@@ -296,10 +296,10 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
      * @see #shouldAnnotate(com.google.protobuf.GeneratedMessageV3)
      */
     private Iterable<String> getNotAnnotatableFields(DescriptorProto messageDescriptor) {
-        final Collection<String> fieldNames = newLinkedList();
+        Collection<String> fieldNames = newLinkedList();
         for (FieldDescriptorProto fieldDescriptor : messageDescriptor.getFieldList()) {
             if (shouldAnnotate(fieldDescriptor)) {
-                final String capitalizedFieldName = FieldName.of(fieldDescriptor)
+                String capitalizedFieldName = FieldName.of(fieldDescriptor)
                                                              .toCamelCase();
                 fieldNames.add(capitalizedFieldName);
             }
@@ -347,7 +347,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
      * @param expectedValue  the expected value for the {@code java_multiple_files}.
      */
     private static void checkMultipleFilesOption(FileDescriptorProto file, boolean expectedValue) {
-        final boolean actualValue = file.getOptions()
+        boolean actualValue = file.getOptions()
                                         .hasJavaMultipleFiles();
         if (actualValue != expectedValue) {
             throw newIllegalStateException("`java_multiple_files` should be `%s`, but was `%s`.",

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FieldAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FieldAnnotator.java
@@ -104,7 +104,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
     static JavaClassSource getBuilder(JavaSource messageSource) {
         JavaClassSource messageClass = asClassSource(messageSource);
         JavaSource builderSource = messageClass.getNestedType(SimpleClassName.ofBuilder()
-                                                                                   .value());
+                                                                             .value());
         return asClassSource(builderSource);
     }
 
@@ -118,7 +118,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
     private static JavaClassSource asClassSource(JavaType<?> javaType) {
         if (!javaType.isClass()) {
             String errMsg = format("`%s expected to be a class.",
-                                         javaType.getQualifiedName());
+                                   javaType.getQualifiedName());
             throw new IllegalStateException(errMsg);
         }
 
@@ -187,7 +187,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
 
         private MessageFieldAnnotation(FileDescriptorProto file, DescriptorProto message) {
             if (!file.getMessageTypeList()
-                               .contains(message)) {
+                     .contains(message)) {
                 throw newIllegalStateException(
                         "Specified message `%s` does not belong to the file `%s`.",
                         message, file);
@@ -230,7 +230,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
                                       FieldDescriptorProto field,
                                       Iterable<String> skipFields) {
         String capitalizedFieldName = FieldName.of(field)
-                                                     .toCamelCase();
+                                               .toCamelCase();
         JavaClassSource messageBuilder = getBuilder(message);
 
         annotateAccessors(message, capitalizedFieldName, skipFields);
@@ -300,7 +300,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
         for (FieldDescriptorProto fieldDescriptor : messageDescriptor.getFieldList()) {
             if (shouldAnnotate(fieldDescriptor)) {
                 String capitalizedFieldName = FieldName.of(fieldDescriptor)
-                                                             .toCamelCase();
+                                                       .toCamelCase();
                 fieldNames.add(capitalizedFieldName);
             }
         }
@@ -348,7 +348,7 @@ class FieldAnnotator extends Annotator<FieldOptions, FieldDescriptorProto> {
      */
     private static void checkMultipleFilesOption(FileDescriptorProto file, boolean expectedValue) {
         boolean actualValue = file.getOptions()
-                                        .hasJavaMultipleFiles();
+                                  .hasJavaMultipleFiles();
         if (actualValue != expectedValue) {
             throw newIllegalStateException("`java_multiple_files` should be `%s`, but was `%s`.",
                                            expectedValue, actualValue);

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FileAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/FileAnnotator.java
@@ -91,7 +91,7 @@ class FileAnnotator extends Annotator<FileOptions, FileDescriptorProto> {
      * @see #annotateServices(FileDescriptorProto)
      */
     private void annotateNestedTypes(FileDescriptorProto file) {
-        final SourceFile filePath = SourceFile.forOuterClassOf(file);
+        SourceFile filePath = SourceFile.forOuterClassOf(file);
         rewriteSource(filePath, new SourceVisitor<JavaClassSource>() {
             @Nullable
             @Override
@@ -115,11 +115,11 @@ class FileAnnotator extends Annotator<FileOptions, FileDescriptorProto> {
      */
     private void annotateMessages(FileDescriptorProto file) {
         for (DescriptorProto messageType : file.getMessageTypeList()) {
-            final SourceFile messageClass =
+            SourceFile messageClass =
                     SourceFile.forMessage(messageType, false, file);
             rewriteSource(messageClass, new TypeDeclarationAnnotation());
 
-            final SourceFile messageOrBuilderClass =
+            SourceFile messageOrBuilderClass =
                     SourceFile.forMessage(messageType, true, file);
             rewriteSource(messageOrBuilderClass, new TypeDeclarationAnnotation());
         }
@@ -135,7 +135,7 @@ class FileAnnotator extends Annotator<FileOptions, FileDescriptorProto> {
      */
     private void annotateEnums(FileDescriptorProto file) {
         for (EnumDescriptorProto enumType : file.getEnumTypeList()) {
-            final SourceFile filePath = SourceFile.forEnum(enumType, file);
+            SourceFile filePath = SourceFile.forEnum(enumType, file);
             rewriteSource(filePath, new TypeDeclarationAnnotation());
         }
     }
@@ -151,7 +151,7 @@ class FileAnnotator extends Annotator<FileOptions, FileDescriptorProto> {
      */
     private void annotateServices(FileDescriptorProto file) {
         for (ServiceDescriptorProto serviceDescriptor : file.getServiceList()) {
-            final SourceFile serviceClass = SourceFile.forService(serviceDescriptor, file);
+            SourceFile serviceClass = SourceFile.forService(serviceDescriptor, file);
             rewriteSource(genGrpcDir, serviceClass, new TypeDeclarationAnnotation());
         }
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/MessageAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/MessageAnnotator.java
@@ -63,10 +63,10 @@ class MessageAnnotator extends TypeDefinitionAnnotator<MessageOptions, Descripto
     @Override
     protected void annotateDefinition(DescriptorProto definition,
                                       FileDescriptorProto file) {
-        final SourceFile messageClass = SourceFile.forMessage(definition, false, file);
+        SourceFile messageClass = SourceFile.forMessage(definition, false, file);
         rewriteSource(messageClass, new TypeDeclarationAnnotation());
 
-        final SourceFile messageOrBuilderClass = SourceFile.forMessage(definition, true, file);
+        SourceFile messageOrBuilderClass = SourceFile.forMessage(definition, true, file);
         rewriteSource(messageOrBuilderClass, new TypeDeclarationAnnotation());
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ServiceAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ServiceAnnotator.java
@@ -69,7 +69,7 @@ class ServiceAnnotator extends Annotator<ServiceOptions, ServiceDescriptorProto>
     private void annotateServices(FileDescriptorProto file) {
         for (ServiceDescriptorProto serviceDescriptor : file.getServiceList()) {
             if (shouldAnnotate(serviceDescriptor)) {
-                final SourceFile serviceClass = SourceFile.forService(serviceDescriptor, file);
+                SourceFile serviceClass = SourceFile.forService(serviceDescriptor, file);
                 rewriteSource(serviceClass, new TypeDeclarationAnnotation());
             }
         }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/TypeDefinitionAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/TypeDefinitionAnnotator.java
@@ -64,8 +64,8 @@ abstract class TypeDefinitionAnnotator<L extends ExtendableMessage, D extends Ge
     }
 
     @Override
-    protected final void annotateOneFile(final FileDescriptorProto file) {
-        final SourceFile outerClass = SourceFile.forOuterClassOf(file);
+    protected final void annotateOneFile(FileDescriptorProto file) {
+        SourceFile outerClass = SourceFile.forOuterClassOf(file);
         rewriteSource(outerClass, new AnnotateNestedType(file));
     }
 
@@ -115,7 +115,7 @@ abstract class TypeDefinitionAnnotator<L extends ExtendableMessage, D extends Ge
             }
         }
 
-        final String errMsg = format("Nested type `%s` is not defined in `%s`.",
+        String errMsg = format("Nested type `%s` is not defined in `%s`.",
                                      typeName, enclosingClass.getName());
         throw new IllegalStateException(errMsg);
     }
@@ -137,13 +137,13 @@ abstract class TypeDefinitionAnnotator<L extends ExtendableMessage, D extends Ge
             checkNotNull(input);
             for (D definition : getDefinitions(file)) {
                 if (shouldAnnotate(definition)) {
-                    final String messageName = getDefinitionName(definition);
-                    final JavaSource message = findNestedType(input, messageName);
+                    String messageName = getDefinitionName(definition);
+                    JavaSource message = findNestedType(input, messageName);
                     addAnnotation(message);
 
-                    final String javaType = SimpleClassName.messageOrBuilder(messageName)
+                    String javaType = SimpleClassName.messageOrBuilder(messageName)
                                                            .value();
-                    final JavaSource messageOrBuilder = findNestedType(input, javaType);
+                    JavaSource messageOrBuilder = findNestedType(input, javaType);
                     addAnnotation(messageOrBuilder);
                 }
             }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/TypeDefinitionAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/TypeDefinitionAnnotator.java
@@ -116,7 +116,7 @@ abstract class TypeDefinitionAnnotator<L extends ExtendableMessage, D extends Ge
         }
 
         String errMsg = format("Nested type `%s` is not defined in `%s`.",
-                                     typeName, enclosingClass.getName());
+                               typeName, enclosingClass.getName());
         throw new IllegalStateException(errMsg);
     }
 
@@ -142,7 +142,7 @@ abstract class TypeDefinitionAnnotator<L extends ExtendableMessage, D extends Ge
                     addAnnotation(message);
 
                     String javaType = SimpleClassName.messageOrBuilder(messageName)
-                                                           .value();
+                                                     .value();
                     JavaSource messageOrBuilder = findNestedType(input, javaType);
                     addAnnotation(messageOrBuilder);
                 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/ByOption.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/ByOption.java
@@ -55,7 +55,8 @@ class ByOption {
     }
 
     static boolean isSetFor(FieldDescriptorProto field) {
-        return Options.option(field, by).isPresent();
+        return Options.option(field, by)
+                      .isPresent();
     }
 
     Map.Entry<String, String> collect() {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/ByOption.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/ByOption.java
@@ -59,8 +59,8 @@ class ByOption {
     }
 
     Map.Entry<String, String> collect() {
-        final Collection<String> eventNamesFromBy = parse();
-        final Map.Entry<String, String> result = group(eventNamesFromBy);
+        Collection<String> eventNamesFromBy = parse();
+        Map.Entry<String, String> result = group(eventNamesFromBy);
         return result;
     }
 
@@ -69,9 +69,9 @@ class ByOption {
      * the given field.
      */
     private List<String> parse() {
-        final List<FieldReference> fieldRefs = FieldReference.allFrom(field);
+        List<FieldReference> fieldRefs = FieldReference.allFrom(field);
 
-        final ImmutableList.Builder<String> result = ImmutableList.builder();
+        ImmutableList.Builder<String> result = ImmutableList.builder();
         for (FieldReference fieldRef : fieldRefs) {
             if (fieldRef.isWildcard() && fieldRefs.size() > 1) {
                 // Multiple argument `by` annotation can not contain wildcard reference onto
@@ -84,7 +84,7 @@ class ByOption {
                 continue;
             }
 
-            final String fullTypeName = fieldRef.getType();
+            String fullTypeName = fieldRef.getType();
             result.add(fullTypeName);
         }
 
@@ -92,10 +92,10 @@ class ByOption {
     }
 
     private Map.Entry<String, String> group(Collection<String> events) {
-        final String enrichment = message.getName();
-        final String fieldName = field.getName();
-        final Logger log = log();
-        final Collection<String> eventGroup = new HashSet<>(events.size());
+        String enrichment = message.getName();
+        String fieldName = field.getName();
+        Logger log = log();
+        Collection<String> eventGroup = new HashSet<>(events.size());
         for (String eventName : events) {
             if (eventName == null || eventName.trim()
                                               .isEmpty()) {
@@ -111,9 +111,9 @@ class ByOption {
             }
             eventGroup.add(eventName);
         }
-        final String enrichmentName = packagePrefix + enrichment;
-        final String eventGroupString = TypeNameParser.joiner.join(eventGroup);
-        final Map.Entry<String, String> result =
+        String enrichmentName = packagePrefix + enrichment;
+        String eventGroupString = TypeNameParser.joiner.join(eventGroup);
+        Map.Entry<String, String> result =
                 new AbstractMap.SimpleEntry<>(enrichmentName, eventGroupString);
 
         return result;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentFinder.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentFinder.java
@@ -53,13 +53,13 @@ class EnrichmentFinder {
      * @return a map from enrichment type name to event to enrich type name
      */
     Map<String, String> findAll() {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Looking up for the enrichments in {}", file.getName());
 
-        final List<DescriptorProto> messages = file.getMessageTypeList();
-        final String packagePrefix = file.getPackage() + TypeName.PACKAGE_SEPARATOR;
-        final EnrichmentMap map = new EnrichmentMap(packagePrefix);
-        final Map<String, String> result = map.allOf(messages);
+        List<DescriptorProto> messages = file.getMessageTypeList();
+        String packagePrefix = file.getPackage() + TypeName.PACKAGE_SEPARATOR;
+        EnrichmentMap map = new EnrichmentMap(packagePrefix);
+        Map<String, String> result = map.allOf(messages);
 
         log.debug("Found {} enrichments", result.size());
         return result;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentLookup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentLookup.java
@@ -53,9 +53,9 @@ public class EnrichmentLookup {
      * specified directory.
      */
     public static void processDescriptorSetFile(File setFile, String targetDir) {
-        final Collection<FileDescriptorProto> files = parseSkipStandard(setFile.getPath());
+        Collection<FileDescriptorProto> files = parseSkipStandard(setFile.getPath());
 
-        final Map<String, String> propsMap = findAll(files);
+        Map<String, String> propsMap = findAll(files);
 
         if (propsMap.isEmpty()) {
             log().debug("Enrichment lookup complete. No enrichments found.");
@@ -66,10 +66,10 @@ public class EnrichmentLookup {
     }
 
     private static Map<String, String> findAll(Iterable<FileDescriptorProto> files) {
-        final Map<String, String> propsMap = newHashMap();
+        Map<String, String> propsMap = newHashMap();
         for (FileDescriptorProto file : files) {
-            final EnrichmentFinder lookup = new EnrichmentFinder(file);
-            final Map<String, String> enrichments = lookup.findAll();
+            EnrichmentFinder lookup = new EnrichmentFinder(file);
+            Map<String, String> enrichments = lookup.findAll();
             propsMap.putAll(enrichments);
         }
         return propsMap;
@@ -78,7 +78,7 @@ public class EnrichmentLookup {
     private static void writeTo(Map<String, String> propsMap, String targetDir) {
         log().debug("Writing the enrichment description to {}/{}",
                     targetDir, Resources.ENRICHMENTS);
-        final PropertiesWriter writer = new PropertiesWriter(targetDir, Resources.ENRICHMENTS);
+        PropertiesWriter writer = new PropertiesWriter(targetDir, Resources.ENRICHMENTS);
         writer.write(propsMap);
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentMap.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/EnrichmentMap.java
@@ -191,7 +191,6 @@ class EnrichmentMap {
         return enrichmentsMap;
     }
 
-
     @SuppressWarnings("MethodWithMultipleLoops")    // It's fine in this case.
     private Map.Entry<String, String> scanInnerMessages(DescriptorProto msg) {
         Logger log = log();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/FieldReference.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/FieldReference.java
@@ -69,7 +69,7 @@ class FieldReference extends StringTypeValue {
 
     private static String[] parse(FieldDescriptorProto field) {
         String byArgument = field.getOptions()
-                                       .getExtension(by);
+                                 .getExtension(by);
         if (isNullOrEmpty(byArgument)) {
             throw newIllegalArgumentException("There is no `by` option in the passed field %s",
                                               field.getName());
@@ -77,8 +77,8 @@ class FieldReference extends StringTypeValue {
 
         String[] result;
         result = byArgument.contains(PIPE_SEPARATOR)
-                ? PATTERN_PIPE_SEPARATOR.split(byArgument)
-                : new String[]{byArgument};
+                 ? PATTERN_PIPE_SEPARATOR.split(byArgument)
+                 : new String[]{byArgument};
         return result;
     }
 
@@ -100,7 +100,7 @@ class FieldReference extends StringTypeValue {
         int index = value.lastIndexOf(FieldName.TYPE_SEPARATOR);
         checkState(index > 0, "The field reference does not have the type (`%s`)", value);
         String result = value.substring(0, index)
-                                   .trim();
+                             .trim();
         return result;
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/FieldReference.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/FieldReference.java
@@ -58,9 +58,9 @@ class FieldReference extends StringTypeValue {
     }
 
     static List<FieldReference> allFrom(FieldDescriptorProto field) {
-        final String[] found = parse(field);
+        String[] found = parse(field);
 
-        final ImmutableList.Builder<FieldReference> result = ImmutableList.builder();
+        ImmutableList.Builder<FieldReference> result = ImmutableList.builder();
         for (String ref : found) {
             result.add(new FieldReference(ref));
         }
@@ -68,14 +68,14 @@ class FieldReference extends StringTypeValue {
     }
 
     private static String[] parse(FieldDescriptorProto field) {
-        final String byArgument = field.getOptions()
+        String byArgument = field.getOptions()
                                        .getExtension(by);
         if (isNullOrEmpty(byArgument)) {
             throw newIllegalArgumentException("There is no `by` option in the passed field %s",
                                               field.getName());
         }
 
-        final String[] result;
+        String[] result;
         result = byArgument.contains(PIPE_SEPARATOR)
                 ? PATTERN_PIPE_SEPARATOR.split(byArgument)
                 : new String[]{byArgument};
@@ -83,12 +83,12 @@ class FieldReference extends StringTypeValue {
     }
 
     boolean isWildcard() {
-        final boolean result = value().startsWith(ANY_BY_OPTION_TARGET);
+        boolean result = value().startsWith(ANY_BY_OPTION_TARGET);
         return result;
     }
 
     boolean isInner() {
-        final boolean result = !value().contains(FieldName.TYPE_SEPARATOR);
+        boolean result = !value().contains(FieldName.TYPE_SEPARATOR);
         return result;
     }
 
@@ -96,10 +96,10 @@ class FieldReference extends StringTypeValue {
      * Obtains the type name from the reference.
      */
     String getType() {
-        final String value = value();
-        final int index = value.lastIndexOf(FieldName.TYPE_SEPARATOR);
+        String value = value();
+        int index = value.lastIndexOf(FieldName.TYPE_SEPARATOR);
         checkState(index > 0, "The field reference does not have the type (`%s`)", value);
-        final String result = value.substring(0, index)
+        String result = value.substring(0, index)
                                    .trim();
         return result;
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/TypeNameParser.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/TypeNameParser.java
@@ -92,8 +92,8 @@ final class TypeNameParser {
 
     @VisibleForTesting
     TypeName parseTypeName(String value) {
-        final boolean isFqn = value.contains(valueOf(TypeName.PACKAGE_SEPARATOR));
-        final String typeNameValue = isFqn
+        boolean isFqn = value.contains(valueOf(TypeName.PACKAGE_SEPARATOR));
+        String typeNameValue = isFqn
                                      ? value
                                      : packagePrefix + value;
         return TypeName.of(typeNameValue);

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/TypeNameParser.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/enrichment/TypeNameParser.java
@@ -94,8 +94,8 @@ final class TypeNameParser {
     TypeName parseTypeName(String value) {
         boolean isFqn = value.contains(valueOf(TypeName.PACKAGE_SEPARATOR));
         String typeNameValue = isFqn
-                                     ? value
-                                     : packagePrefix + value;
+                               ? value
+                               : packagePrefix + value;
         return TypeName.of(typeNameValue);
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypeFactory.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypeFactory.java
@@ -68,7 +68,7 @@ public class FieldTypeFactory {
         if (isMap(field)) {
             return new MapFieldType(getEntryTypeNames(field));
         } else {
-            final String fieldTypeName = getFieldTypeName(field);
+            String fieldTypeName = getFieldTypeName(field);
             return isRepeated(field)
                    ? new RepeatedFieldType(fieldTypeName)
                    : new SingularFieldType(fieldTypeName);
@@ -78,8 +78,8 @@ public class FieldTypeFactory {
     private String getFieldTypeName(FieldDescriptorProto field) {
         if (field.getType() == Type.TYPE_MESSAGE
                 || field.getType() == Type.TYPE_ENUM) {
-            final String typeName = trimTypeName(field);
-            final String result = messageTypeMap.get(typeName);
+            String typeName = trimTypeName(field);
+            String result = messageTypeMap.get(typeName);
             checkNotNull(result,
                          "Cannot find the field type name for %s of type %s",
                          typeName, field.getType());
@@ -101,13 +101,13 @@ public class FieldTypeFactory {
             throw new IllegalStateException(MAP_EXPECTED_ERROR_MESSAGE);
         }
 
-        final int keyFieldIndex = 0;
-        final int valueFieldIndex = 1;
+        int keyFieldIndex = 0;
+        int valueFieldIndex = 1;
 
-        final DescriptorProto mapEntryDescriptor = getDescriptorForMapField(map);
-        final TypeName keyTypeName =
+        DescriptorProto mapEntryDescriptor = getDescriptorForMapField(map);
+        TypeName keyTypeName =
                 create(mapEntryDescriptor.getField(keyFieldIndex)).getTypeName();
-        final TypeName valueTypeName =
+        TypeName valueTypeName =
                 create(mapEntryDescriptor.getField(valueFieldIndex)).getTypeName();
 
         return new AbstractMap.SimpleEntry<>(keyTypeName, valueTypeName);
@@ -127,7 +127,7 @@ public class FieldTypeFactory {
             throw new IllegalStateException(MAP_EXPECTED_ERROR_MESSAGE);
         }
 
-        final String entryName = getEntryNameFor(mapField);
+        String entryName = getEntryNameFor(mapField);
         for (DescriptorProto nestedType : messageNestedTypes) {
             if (nestedType.getName()
                           .equals(entryName)) {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypes.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypes.java
@@ -57,7 +57,7 @@ public class FieldTypes {
     public static boolean isMap(FieldDescriptorProto field) {
         checkNotNull(field);
         boolean result = field.getTypeName()
-                                    .endsWith('.' + getEntryNameFor(field));
+                              .endsWith('.' + getEntryNameFor(field));
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypes.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/FieldTypes.java
@@ -44,7 +44,7 @@ public class FieldTypes {
      */
     public static boolean isRepeated(FieldDescriptorProto field) {
         checkNotNull(field);
-        final boolean result = field.getLabel() == FieldDescriptorProto.Label.LABEL_REPEATED;
+        boolean result = field.getLabel() == FieldDescriptorProto.Label.LABEL_REPEATED;
         return result;
     }
 
@@ -56,7 +56,7 @@ public class FieldTypes {
      */
     public static boolean isMap(FieldDescriptorProto field) {
         checkNotNull(field);
-        final boolean result = field.getTypeName()
+        boolean result = field.getTypeName()
                                     .endsWith('.' + getEntryNameFor(field));
         return result;
     }
@@ -77,9 +77,9 @@ public class FieldTypes {
     public static String getEntryNameFor(FieldDescriptorProto mapField) {
         checkNotNull(mapField);
 
-        final String jsonName = mapField.getJsonName();
-        final char capitalizedFirstSymbol = Character.toUpperCase(jsonName.charAt(0));
-        final String remainingPart = jsonName.substring(1);
+        String jsonName = mapField.getJsonName();
+        char capitalizedFirstSymbol = Character.toUpperCase(jsonName.charAt(0));
+        String remainingPart = jsonName.substring(1);
 
         return capitalizedFirstSymbol + remainingPart + ENTRY_SUFFIX;
     }
@@ -104,7 +104,7 @@ public class FieldTypes {
      * @return the type name without leading dot
      */
     public static String trimTypeName(FieldDescriptorProto fieldDescriptor) {
-        final String typeName = fieldDescriptor.getTypeName();
+        String typeName = fieldDescriptor.getTypeName();
         checkNotNull(typeName);
 
         if (typeName.isEmpty()) {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
@@ -67,13 +67,13 @@ public class RepeatedFieldType implements FieldType {
     }
 
     private static TypeName constructTypeNameFor(String componentTypeName) {
-        final Optional<? extends Class<?>> wrapperClass =
+        Optional<? extends Class<?>> wrapperClass =
                 PrimitiveType.getWrapperClass(componentTypeName);
 
-        final TypeName componentType = wrapperClass.isPresent()
+        TypeName componentType = wrapperClass.isPresent()
                                        ? TypeName.get(wrapperClass.get())
                                        : ClassName.bestGuess(componentTypeName);
-        final ParameterizedTypeName result =
+        ParameterizedTypeName result =
                 ParameterizedTypeName.get(ClassName.get(List.class), componentType);
         return result;
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
@@ -19,12 +19,12 @@
  */
 package io.spine.tools.compiler.fieldtype;
 
-import com.google.common.base.Optional;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import io.spine.code.java.PrimitiveType;
 
+import java.util.Optional;
 import java.util.List;
 
 /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/RepeatedFieldType.java
@@ -24,8 +24,8 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import io.spine.code.java.PrimitiveType;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents repeated {@linkplain FieldType field type}.
@@ -71,8 +71,8 @@ public class RepeatedFieldType implements FieldType {
                 PrimitiveType.getWrapperClass(componentTypeName);
 
         TypeName componentType = wrapperClass.isPresent()
-                                       ? TypeName.get(wrapperClass.get())
-                                       : ClassName.bestGuess(componentTypeName);
+                                 ? TypeName.get(wrapperClass.get())
+                                 : ClassName.bestGuess(componentTypeName);
         ParameterizedTypeName result =
                 ParameterizedTypeName.get(ClassName.get(List.class), componentType);
         return result;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/SingularFieldType.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/SingularFieldType.java
@@ -66,7 +66,7 @@ public class SingularFieldType implements FieldType {
     }
 
     private static TypeName constructTypeNameFor(String name) {
-        final Optional<? extends Class<?>> boxedScalarPrimitive =
+        Optional<? extends Class<?>> boxedScalarPrimitive =
                 PrimitiveType.getWrapperClass(name);
 
         return boxedScalarPrimitive.isPresent()

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/SingularFieldType.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/fieldtype/SingularFieldType.java
@@ -19,10 +19,11 @@
  */
 package io.spine.tools.compiler.fieldtype;
 
-import com.google.common.base.Optional;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.TypeName;
 import io.spine.code.java.PrimitiveType;
+
+import java.util.Optional;
 
 /**
  * Represents singular {@linkplain FieldType field type}.

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.compiler.rejection;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
@@ -39,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -176,7 +176,7 @@ public class RejectionJavadoc {
         Location location = getLocation(locationPath);
         return location.hasLeadingComments()
                ? Optional.of(location.getLeadingComments())
-               : Optional.<String>absent();
+               : Optional.<String>empty();
     }
 
     /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
@@ -123,8 +123,8 @@ public class RejectionJavadoc {
                    .append(LINE_SEPARATOR);
             for (Entry<FieldDescriptorProto, String> commentedField : commentedFields.entrySet()) {
                 String fieldName = FieldName.of(commentedField.getKey()
-                                                                    .getName())
-                                                  .javaCase();
+                                                              .getName())
+                                            .javaCase();
                 int commentOffset = maxFieldLength - fieldName.length() + 1;
                 builder.append("@param ")
                        .append(fieldName)
@@ -169,7 +169,7 @@ public class RejectionJavadoc {
             String errMsg =
                     "To enable rejection generation, please configure the Gradle " +
                     "Protobuf plugin as follows: " +
-                            "`task.descriptorSetOptions.includeSourceInfo = true`.";
+                    "`task.descriptorSetOptions.includeSourceInfo = true`.";
             throw new IllegalStateException(errMsg);
         }
 
@@ -211,7 +211,7 @@ public class RejectionJavadoc {
 
     private int getTopLevelMessageIndex() {
         List<DescriptorProto> messages = declaration.getFile()
-                                                          .getMessageTypeList();
+                                                    .getMessageTypeList();
         for (DescriptorProto currentMessage : messages) {
             if (currentMessage.equals(declaration.getMessage())) {
                 return messages.indexOf(declaration.getMessage());
@@ -219,10 +219,10 @@ public class RejectionJavadoc {
         }
 
         String msg = format("The rejection file \"%s\" should contain \"%s\" rejection.",
-                                  declaration.getFile()
-                                             .getName(),
-                                  declaration.getMessage()
-                                             .getName());
+                            declaration.getFile()
+                                       .getName(),
+                            declaration.getMessage()
+                                       .getName());
         throw new IllegalStateException(msg);
     }
 
@@ -249,9 +249,9 @@ public class RejectionJavadoc {
         }
 
         String msg = format("The location with %s path should be present in \"%s\".",
-                                  locationPath,
-                                  declaration.getFile()
-                                             .getName());
+                            locationPath,
+                            declaration.getFile()
+                                       .getName());
         throw new IllegalStateException(msg);
     }
 
@@ -291,9 +291,9 @@ public class RejectionJavadoc {
                 checkNotNull(right);
 
                 int result = Ints.compare(left.getName()
-                                                    .length(),
-                                                right.getName()
-                                                     .length());
+                                              .length(),
+                                          right.getName()
+                                               .length());
                 return result;
             }
         };

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionJavadoc.java
@@ -86,8 +86,8 @@ public class RejectionJavadoc {
      * @return the class-level Javadoc content
      */
     public String forClass() {
-        final Optional<String> leadingComments = getRejectionLeadingComments();
-        final StringBuilder builder = new StringBuilder(256);
+        Optional<String> leadingComments = getRejectionLeadingComments();
+        StringBuilder builder = new StringBuilder(256);
 
         if (leadingComments.isPresent()) {
             builder.append(OPENING_PRE)
@@ -113,8 +113,8 @@ public class RejectionJavadoc {
      * @return the constructor Javadoc content
      */
     public String forConstructor() {
-        final StringBuilder builder = new StringBuilder("Creates a new instance.");
-        final Map<FieldDescriptorProto, String> commentedFields = getCommentedFields();
+        StringBuilder builder = new StringBuilder("Creates a new instance.");
+        Map<FieldDescriptorProto, String> commentedFields = getCommentedFields();
 
         if (!commentedFields.isEmpty()) {
             int maxFieldLength = getMaxFieldNameLength(commentedFields.keySet());
@@ -122,10 +122,10 @@ public class RejectionJavadoc {
             builder.append(LINE_SEPARATOR)
                    .append(LINE_SEPARATOR);
             for (Entry<FieldDescriptorProto, String> commentedField : commentedFields.entrySet()) {
-                final String fieldName = FieldName.of(commentedField.getKey()
+                String fieldName = FieldName.of(commentedField.getKey()
                                                                     .getName())
                                                   .javaCase();
-                final int commentOffset = maxFieldLength - fieldName.length() + 1;
+                int commentOffset = maxFieldLength - fieldName.length() + 1;
                 builder.append("@param ")
                        .append(fieldName)
                        .append(Strings.repeat(" ", commentOffset))
@@ -143,7 +143,7 @@ public class RejectionJavadoc {
      * @return the field leading comments or empty {@code Optional} if there are no such comments
      */
     private Optional<String> getFieldLeadingComments(FieldDescriptorProto field) {
-        final LocationPath fieldPath = getFieldLocationPath(field);
+        LocationPath fieldPath = getFieldLocationPath(field);
         return getLeadingComments(fieldPath);
     }
 
@@ -153,7 +153,7 @@ public class RejectionJavadoc {
      * @return the comments text or empty {@code Optional} if there are no such comments
      */
     private Optional<String> getRejectionLeadingComments() {
-        final LocationPath messagePath = getMessageLocationPath();
+        LocationPath messagePath = getMessageLocationPath();
         return getLeadingComments(messagePath);
     }
 
@@ -166,14 +166,14 @@ public class RejectionJavadoc {
     private Optional<String> getLeadingComments(LocationPath locationPath) {
         if (!declaration.getFile()
                         .hasSourceCodeInfo()) {
-            final String errMsg =
+            String errMsg =
                     "To enable rejection generation, please configure the Gradle " +
                     "Protobuf plugin as follows: " +
                             "`task.descriptorSetOptions.includeSourceInfo = true`.";
             throw new IllegalStateException(errMsg);
         }
 
-        final Location location = getLocation(locationPath);
+        Location location = getLocation(locationPath);
         return location.hasLeadingComments()
                ? Optional.of(location.getLeadingComments())
                : Optional.<String>absent();
@@ -201,7 +201,7 @@ public class RejectionJavadoc {
      * @return the field location path
      */
     private LocationPath getFieldLocationPath(FieldDescriptorProto field) {
-        final LocationPath locationPath = new LocationPath();
+        LocationPath locationPath = new LocationPath();
 
         locationPath.addAll(getMessageLocationPath());
         locationPath.add(DescriptorProto.FIELD_FIELD_NUMBER);
@@ -210,7 +210,7 @@ public class RejectionJavadoc {
     }
 
     private int getTopLevelMessageIndex() {
-        final List<DescriptorProto> messages = declaration.getFile()
+        List<DescriptorProto> messages = declaration.getFile()
                                                           .getMessageTypeList();
         for (DescriptorProto currentMessage : messages) {
             if (currentMessage.equals(declaration.getMessage())) {
@@ -218,7 +218,7 @@ public class RejectionJavadoc {
             }
         }
 
-        final String msg = format("The rejection file \"%s\" should contain \"%s\" rejection.",
+        String msg = format("The rejection file \"%s\" should contain \"%s\" rejection.",
                                   declaration.getFile()
                                              .getName(),
                                   declaration.getMessage()
@@ -248,7 +248,7 @@ public class RejectionJavadoc {
             }
         }
 
-        final String msg = format("The location with %s path should be present in \"%s\".",
+        String msg = format("The location with %s path should be present in \"%s\".",
                                   locationPath,
                                   declaration.getFile()
                                              .getName());
@@ -262,11 +262,11 @@ public class RejectionJavadoc {
      * @return the commented fields
      */
     private Map<FieldDescriptorProto, String> getCommentedFields() {
-        final Map<FieldDescriptorProto, String> commentedFields = Maps.newLinkedHashMap();
+        Map<FieldDescriptorProto, String> commentedFields = Maps.newLinkedHashMap();
 
         for (FieldDescriptorProto field : declaration.getMessage()
                                                      .getFieldList()) {
-            final Optional<String> leadingComments = getFieldLeadingComments(field);
+            Optional<String> leadingComments = getFieldLeadingComments(field);
             if (leadingComments.isPresent()) {
                 commentedFields.put(field, leadingComments.get());
             }
@@ -283,14 +283,14 @@ public class RejectionJavadoc {
      * @return the max name length
      */
     private static int getMaxFieldNameLength(Iterable<FieldDescriptorProto> fields) {
-        final Ordering<FieldDescriptorProto> ordering = new Ordering<FieldDescriptorProto>() {
+        Ordering<FieldDescriptorProto> ordering = new Ordering<FieldDescriptorProto>() {
             @Override
             public int compare(@Nullable FieldDescriptorProto left,
                                @Nullable FieldDescriptorProto right) {
                 checkNotNull(left);
                 checkNotNull(right);
 
-                final int result = Ints.compare(left.getName()
+                int result = Ints.compare(left.getName()
                                                     .length(),
                                                 right.getName()
                                                      .length());
@@ -298,7 +298,7 @@ public class RejectionJavadoc {
             }
         };
 
-        final FieldDescriptorProto longestNameField = ordering.max(fields);
+        FieldDescriptorProto longestNameField = ordering.max(fields);
         return longestNameField.getName()
                                .length();
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
@@ -91,7 +91,7 @@ public class RejectionWriter {
             Files.createDirectories(outputDirectory.toPath());
 
             String className = declaration.getSimpleJavaClassName()
-                                                .value();
+                                          .value();
             log.debug("Constructing class {}", className);
             TypeSpec rejection =
                     TypeSpec.classBuilder(className)
@@ -125,9 +125,9 @@ public class RejectionWriter {
                 .addModifiers(PUBLIC);
         for (Map.Entry<String, FieldType> field : fieldDeclarations().entrySet()) {
             TypeName parameterType = field.getValue()
-                                                .getTypeName();
+                                          .getTypeName();
             String parameterName = FieldName.of(field.getKey())
-                                                  .javaCase();
+                                            .javaCase();
             builder.addParameter(parameterType, parameterName);
         }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
@@ -86,14 +86,14 @@ public class RejectionWriter {
      */
     public void write() {
         try {
-            final Logger log = log();
+            Logger log = log();
             log.debug("Creating the output directory {}", outputDirectory.getPath());
             Files.createDirectories(outputDirectory.toPath());
 
-            final String className = declaration.getSimpleJavaClassName()
+            String className = declaration.getSimpleJavaClassName()
                                                 .value();
             log.debug("Constructing class {}", className);
-            final TypeSpec rejection =
+            TypeSpec rejection =
                     TypeSpec.classBuilder(className)
                             .addJavadoc(javadoc.forClass())
                             .addAnnotation(generatedBySpineModelCompiler())
@@ -103,7 +103,7 @@ public class RejectionWriter {
                             .addMethod(constructor())
                             .addMethod(getMessageThrown())
                             .build();
-            final JavaFile javaFile =
+            JavaFile javaFile =
                     JavaFile.builder(declaration.getJavaPackage()
                                                 .toString(),
                                      rejection)
@@ -120,13 +120,13 @@ public class RejectionWriter {
     private MethodSpec constructor() {
         log().debug("Creating the constructor for the type '{}'",
                     declaration.getSimpleJavaClassName());
-        final MethodSpec.Builder builder = constructorBuilder()
+        MethodSpec.Builder builder = constructorBuilder()
                 .addJavadoc(javadoc.forConstructor())
                 .addModifiers(PUBLIC);
         for (Map.Entry<String, FieldType> field : fieldDeclarations().entrySet()) {
-            final TypeName parameterType = field.getValue()
+            TypeName parameterType = field.getValue()
                                                 .getTypeName();
-            final String parameterName = FieldName.of(field.getKey())
+            String parameterName = FieldName.of(field.getKey())
                                                   .javaCase();
             builder.addParameter(parameterType, parameterName);
         }
@@ -136,14 +136,14 @@ public class RejectionWriter {
     }
 
     private String superStatement() {
-        final StringBuilder superStatement = new StringBuilder("super(");
+        StringBuilder superStatement = new StringBuilder("super(");
         superStatement.append(declaration.getOuterJavaClass())
                       .append('.')
                       .append(declaration.getSimpleJavaClassName())
                       .append(".newBuilder()");
 
         for (Map.Entry<String, FieldType> field : fieldDeclarations().entrySet()) {
-            final FieldName fieldName = FieldName.of(field.getKey());
+            FieldName fieldName = FieldName.of(field.getKey());
             superStatement.append('.')
                           .append(field.getValue()
                                        .getSetterPrefix())
@@ -158,10 +158,10 @@ public class RejectionWriter {
     }
 
     private MethodSpec getMessageThrown() {
-        final String methodSignature = getMessageThrown.signature();
+        String methodSignature = getMessageThrown.signature();
         log().debug("Constructing method {}", methodSignature);
 
-        final TypeName returnType =
+        TypeName returnType =
                 ClassName.get(declaration.getJavaPackage()
                                          .value(),
                               declaration.getOuterJavaClass()
@@ -191,10 +191,10 @@ public class RejectionWriter {
      * @return name-to-{@link FieldType} map
      */
     private Map<String, FieldType> fieldDeclarations() {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Reading all the field values from the descriptor: {}", declaration.getMessage());
 
-        final Map<String, FieldType> result = Maps.newLinkedHashMap();
+        Map<String, FieldType> result = Maps.newLinkedHashMap();
         for (FieldDescriptorProto field : declaration.getMessage()
                                                      .getFieldList()) {
             result.put(field.getName(), fieldTypeFactory.create(field));

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
@@ -63,16 +63,16 @@ final class ClassNames {
             return getJavaTypeForScalarType(field);
         }
         typeName = trimTypeName(field);
-        final String parameterType = cache.getCachedTypes()
+        String parameterType = cache.getCachedTypes()
                                           .get(typeName);
         return ClassName.bestGuess(parameterType);
     }
 
     private static ClassName getJavaTypeForScalarType(FieldDescriptorProto field) {
-        final FieldDescriptorProto.Type fieldType = field.getType();
-        final String scalarType = getJavaTypeName(fieldType);
+        FieldDescriptorProto.Type fieldType = field.getType();
+        String scalarType = getJavaTypeName(fieldType);
         try {
-            final Optional<? extends Class<?>> scalarPrimitive = getWrapperClass(scalarType);
+            Optional<? extends Class<?>> scalarPrimitive = getWrapperClass(scalarType);
             if (scalarPrimitive.isPresent()) {
                 return ClassName.get(scalarPrimitive.get());
             }
@@ -94,7 +94,7 @@ final class ClassNames {
     static ClassName getClassName(String javaPackage, String javaClass) {
         checkNotNull(javaPackage);
         checkNotNull(javaClass);
-        final ClassName className = ClassName.get(javaPackage, javaClass);
+        ClassName className = ClassName.get(javaPackage, javaClass);
         return className;
     }
 
@@ -114,15 +114,15 @@ final class ClassNames {
         checkNotNull(typeCache);
         checkNotNull(typeName);
 
-        final Collection<String> values = typeCache.getCachedTypes()
+        Collection<String> values = typeCache.getCachedTypes()
                                                    .values();
-        final String expectedClassName = javaPackage + '.' + typeName;
+        String expectedClassName = javaPackage + '.' + typeName;
         for (String value : values) {
             if (value.equals(expectedClassName)) {
                 return ClassName.get(javaPackage, typeName);
             }
         }
-        final String exMessage = format("The %s class is not found.", expectedClassName);
+        String exMessage = format("The %s class is not found.", expectedClassName);
         throw newIllegalArgumentException(exMessage);
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
@@ -20,12 +20,12 @@
 
 package io.spine.tools.compiler.validation;
 
-import com.google.common.base.Optional;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
 import com.squareup.javapoet.ClassName;
 import io.spine.tools.compiler.MessageTypeCache;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.tools.compiler.fieldtype.FieldTypes.trimTypeName;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ClassNames.java
@@ -28,9 +28,9 @@ import java.util.Collection;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.tools.compiler.fieldtype.FieldTypes.trimTypeName;
 import static io.spine.code.java.PrimitiveType.getWrapperClass;
 import static io.spine.code.proto.ScalarType.getJavaTypeName;
+import static io.spine.tools.compiler.fieldtype.FieldTypes.trimTypeName;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static java.lang.String.format;
 
@@ -64,7 +64,7 @@ final class ClassNames {
         }
         typeName = trimTypeName(field);
         String parameterType = cache.getCachedTypes()
-                                          .get(typeName);
+                                    .get(typeName);
         return ClassName.bestGuess(parameterType);
     }
 
@@ -115,7 +115,7 @@ final class ClassNames {
         checkNotNull(typeName);
 
         Collection<String> values = typeCache.getCachedTypes()
-                                                   .values();
+                                             .values();
         String expectedClassName = javaPackage + '.' + typeName;
         for (String value : values) {
             if (value.equals(expectedClassName)) {

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethodConstructor.java
@@ -120,7 +120,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
         String methodName = "get" + propertyName;
 
         String returnStatement = format("return %s.get%sMap()",
-                                              getMessageBuilder(), propertyName);
+                                        getMessageBuilder(), propertyName);
         MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
@@ -130,7 +130,6 @@ class MapFieldMethodConstructor implements MethodConstructor {
         log().debug("The getter construction for the map field is finished.");
         return methodSpec;
     }
-
 
     private List<MethodSpec> createRawMapMethods() {
         log().debug("The raw methods construction for the map field is started.");
@@ -158,7 +157,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
         String mapToValidate = MAP_TO_VALIDATE +
                 "$T.singletonMap(" + KEY + ", " + VALUE + ')';
         String putStatement = format("%s.put%s(%s, %s)",
-                                           getMessageBuilder(), propertyName, KEY, VALUE);
+                                     getMessageBuilder(), propertyName, KEY, VALUE);
         MethodSpec result =
                 MethodSpec.methodBuilder(methodName)
                           .returns(builderClassName)
@@ -183,7 +182,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
         String mapToValidate = MAP_TO_VALIDATE +
                 "$T.singletonMap(convertedKey, convertedValue)";
         String putStatement = format("%s.put%s(convertedKey, convertedValue)",
-                                           getMessageBuilder(), propertyName);
+                                     getMessageBuilder(), propertyName);
 
         MethodSpec result =
                 MethodSpec.methodBuilder(methodName)
@@ -211,67 +210,65 @@ class MapFieldMethodConstructor implements MethodConstructor {
     private MethodSpec createPutAllMethod() {
         String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
         String putAllStatement = format("%s.putAll%s(%s)",
-                                              getMessageBuilder(), propertyName, MAP_PARAM_NAME);
+                                        getMessageBuilder(), propertyName, MAP_PARAM_NAME);
         String methodName = fieldType.getSetterPrefix() + propertyName;
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .returns(builderClassName)
-                                            .addParameter(fieldType.getTypeName(), MAP_PARAM_NAME)
-                                            .addException(ValidationException.class)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(createValidateStatement(MAP_PARAM_NAME),
-                                                          javaFieldName)
-                                            .addStatement(putAllStatement)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .returns(builderClassName)
+                                      .addParameter(fieldType.getTypeName(), MAP_PARAM_NAME)
+                                      .addException(ValidationException.class)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(createValidateStatement(MAP_PARAM_NAME),
+                                                    javaFieldName)
+                                      .addStatement(putAllStatement)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createPutAllRawMethod() {
         String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
         String putAllStatement = format("%s.putAll%s(convertedValue)",
-                                              getMessageBuilder(), propertyName);
+                                        getMessageBuilder(), propertyName);
         String methodName = fieldType.getSetterPrefix() + rawSuffix() + propertyName;
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .returns(builderClassName)
-                                            .addParameter(String.class, MAP_PARAM_NAME)
-                                            .addException(ValidationException.class)
-                                            .addException(ConversionException.class)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(createGetConvertedMapValue(),
-                                                          Map.class, keyTypeName, valueTypeName,
-                                                          keyTypeName, valueTypeName)
-                                            .addStatement(putAllStatement)
-                                            .addStatement(returnThis())
-                                            .build();
-
-
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .returns(builderClassName)
+                                      .addParameter(String.class, MAP_PARAM_NAME)
+                                      .addException(ValidationException.class)
+                                      .addException(ConversionException.class)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(createGetConvertedMapValue(),
+                                                    Map.class, keyTypeName, valueTypeName,
+                                                    keyTypeName, valueTypeName)
+                                      .addStatement(putAllStatement)
+                                      .addStatement(returnThis())
+                                      .build();
 
         return result;
     }
 
     private MethodSpec createRemoveMethod() {
         String removeFromMap = format("%s.remove%s(%s)",
-                                            getMessageBuilder(), propertyName, KEY);
+                                      getMessageBuilder(), propertyName, KEY);
         MethodSpec result = MethodSpec.methodBuilder(removePrefix() + propertyName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .returns(builderClassName)
-                                            .addParameter(keyTypeName, KEY)
-                                            .addStatement(removeFromMap)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .returns(builderClassName)
+                                      .addParameter(keyTypeName, KEY)
+                                      .addStatement(removeFromMap)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createClearMethod() {
         String clearMap = format("%s.clear%s()", getMessageBuilder(), propertyName);
         MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + propertyName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .returns(builderClassName)
-                                            .addStatement(clearMap)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .returns(builderClassName)
+                                      .addStatement(clearMap)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethodConstructor.java
@@ -92,13 +92,13 @@ class MapFieldMethodConstructor implements MethodConstructor {
         super();
         this.fieldType = (MapFieldType) builder.getFieldType();
         this.fieldIndex = builder.getFieldIndex();
-        final FieldDescriptorProto fieldDescriptor = builder.getField();
+        FieldDescriptorProto fieldDescriptor = builder.getField();
         this.genericClassName = builder.getGenericClassName();
-        final FieldName fieldName = FieldName.of(fieldDescriptor);
+        FieldName fieldName = FieldName.of(fieldDescriptor);
         this.propertyName = fieldName.toCamelCase();
         this.javaFieldName = fieldName.javaCase();
-        final String javaClass = builder.getJavaClass();
-        final String javaPackage = builder.getJavaPackage();
+        String javaClass = builder.getJavaClass();
+        String javaPackage = builder.getJavaPackage();
         this.builderClassName = ClassNames.getClassName(javaPackage, javaClass);
         this.keyTypeName = fieldType.getKeyTypeName();
         this.valueTypeName = fieldType.getValueTypeName();
@@ -107,7 +107,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
     @Override
     public Collection<MethodSpec> construct() {
         log().debug("The methods construction for the map field {} is started.", javaFieldName);
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(createGetter());
         methods.addAll(createMapMethods());
         methods.addAll(createRawMapMethods());
@@ -117,11 +117,11 @@ class MapFieldMethodConstructor implements MethodConstructor {
 
     private MethodSpec createGetter() {
         log().debug("The getter construction for the map field is started.");
-        final String methodName = "get" + propertyName;
+        String methodName = "get" + propertyName;
 
-        final String returnStatement = format("return %s.get%sMap()",
+        String returnStatement = format("return %s.get%sMap()",
                                               getMessageBuilder(), propertyName);
-        final MethodSpec methodSpec =
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(fieldType.getTypeName())
@@ -134,7 +134,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
 
     private List<MethodSpec> createRawMapMethods() {
         log().debug("The raw methods construction for the map field is started.");
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(createPutRawMethod());
         methods.add(createPutAllRawMethod());
         log().debug("The raw methods construction for the map field is finished.");
@@ -143,7 +143,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
 
     private List<MethodSpec> createMapMethods() {
         log().debug("The methods construction for the map field is started.");
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(createPutMethod());
         methods.add(createClearMethod());
         methods.add(createPutAllMethod());
@@ -153,13 +153,13 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createPutMethod() {
-        final String methodName = "put" + propertyName;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
-        final String mapToValidate = MAP_TO_VALIDATE +
+        String methodName = "put" + propertyName;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
+        String mapToValidate = MAP_TO_VALIDATE +
                 "$T.singletonMap(" + KEY + ", " + VALUE + ')';
-        final String putStatement = format("%s.put%s(%s, %s)",
+        String putStatement = format("%s.put%s(%s, %s)",
                                            getMessageBuilder(), propertyName, KEY, VALUE);
-        final MethodSpec result =
+        MethodSpec result =
                 MethodSpec.methodBuilder(methodName)
                           .returns(builderClassName)
                           .addModifiers(Modifier.PUBLIC)
@@ -178,14 +178,14 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createPutRawMethod() {
-        final String methodName = "putRaw" + propertyName;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
-        final String mapToValidate = MAP_TO_VALIDATE +
+        String methodName = "putRaw" + propertyName;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
+        String mapToValidate = MAP_TO_VALIDATE +
                 "$T.singletonMap(convertedKey, convertedValue)";
-        final String putStatement = format("%s.put%s(convertedKey, convertedValue)",
+        String putStatement = format("%s.put%s(convertedKey, convertedValue)",
                                            getMessageBuilder(), propertyName);
 
-        final MethodSpec result =
+        MethodSpec result =
                 MethodSpec.methodBuilder(methodName)
                           .returns(builderClassName)
                           .addModifiers(Modifier.PUBLIC)
@@ -209,11 +209,11 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createPutAllMethod() {
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
-        final String putAllStatement = format("%s.putAll%s(%s)",
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
+        String putAllStatement = format("%s.putAll%s(%s)",
                                               getMessageBuilder(), propertyName, MAP_PARAM_NAME);
-        final String methodName = fieldType.getSetterPrefix() + propertyName;
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        String methodName = fieldType.getSetterPrefix() + propertyName;
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .returns(builderClassName)
                                             .addParameter(fieldType.getTypeName(), MAP_PARAM_NAME)
@@ -228,11 +228,11 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createPutAllRawMethod() {
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
-        final String putAllStatement = format("%s.putAll%s(convertedValue)",
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex, genericClassName);
+        String putAllStatement = format("%s.putAll%s(convertedValue)",
                                               getMessageBuilder(), propertyName);
-        final String methodName = fieldType.getSetterPrefix() + rawSuffix() + propertyName;
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        String methodName = fieldType.getSetterPrefix() + rawSuffix() + propertyName;
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .returns(builderClassName)
                                             .addParameter(String.class, MAP_PARAM_NAME)
@@ -252,9 +252,9 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createRemoveMethod() {
-        final String removeFromMap = format("%s.remove%s(%s)",
+        String removeFromMap = format("%s.remove%s(%s)",
                                             getMessageBuilder(), propertyName, KEY);
-        final MethodSpec result = MethodSpec.methodBuilder(removePrefix() + propertyName)
+        MethodSpec result = MethodSpec.methodBuilder(removePrefix() + propertyName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .returns(builderClassName)
                                             .addParameter(keyTypeName, KEY)
@@ -265,8 +265,8 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createClearMethod() {
-        final String clearMap = format("%s.clear%s()", getMessageBuilder(), propertyName);
-        final MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + propertyName)
+        String clearMap = format("%s.clear%s()", getMessageBuilder(), propertyName);
+        MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + propertyName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .returns(builderClassName)
                                             .addStatement(clearMap)
@@ -276,7 +276,7 @@ class MapFieldMethodConstructor implements MethodConstructor {
     }
 
     private static String createGetConvertedMapValue() {
-        final String result = "final $T<$T, $T> convertedValue = " +
+        String result = "final $T<$T, $T> convertedValue = " +
                 "convertToMap(map, $T.class, $T.class)";
         return result;
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodConstructors.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodConstructors.java
@@ -57,9 +57,9 @@ class MethodConstructors {
      */
     static String createDescriptorStatement(int index, ClassName messageClassName) {
         checkNotNull(messageClassName);
-        final SoyMapData mapData = new SoyMapData("fieldIndex", index,
+        SoyMapData mapData = new SoyMapData("fieldIndex", index,
                                                   "messageClassName", messageClassName.toString());
-        final String result = renderData(mapData, "io.spine.generation.descriptorStatement");
+        String result = renderData(mapData, "io.spine.generation.descriptorStatement");
         return result;
     }
 
@@ -71,8 +71,8 @@ class MethodConstructors {
      */
     static String createValidateStatement(String fieldValue) {
         checkNotNull(fieldValue);
-        final SoyMapData mapData = new SoyMapData("fieldValue", fieldValue);
-        final String result = renderData(mapData, "io.spine.generation.validateStatement");
+        SoyMapData mapData = new SoyMapData("fieldValue", fieldValue);
+        String result = renderData(mapData, "io.spine.generation.validateStatement");
         return result;
     }
 
@@ -85,11 +85,11 @@ class MethodConstructors {
     static String createConvertSingularValue(String value) {
         checkNotNull(value);
         // We pass capitalized name because this value is used with prefixes.
-        final String fieldName = FieldName.of(value)
+        String fieldName = FieldName.of(value)
                                           .toCamelCase();
-        final SoyMapData mapData = new SoyMapData("javaFieldName", fieldName,
+        SoyMapData mapData = new SoyMapData("javaFieldName", fieldName,
                                                   "valueToValidate", value);
-        final String result = renderData(mapData, "io.spine.generation.convertedValueStatement");
+        String result = renderData(mapData, "io.spine.generation.convertedValueStatement");
         return result;
     }
 
@@ -152,21 +152,21 @@ class MethodConstructors {
     }
 
     private static String renderData(SoyMapData mapData, String templateName) {
-        final String result = soyTofu.newRenderer(templateName)
+        String result = soyTofu.newRenderer(templateName)
                                      .setData(mapData)
                                      .render();
         return result;
     }
 
     private static SoyTofu getSoyTofu() {
-        final URL resource = MethodConstructors.class.getClassLoader()
+        URL resource = MethodConstructors.class.getClassLoader()
                                                      .getResource(TEMPLATE_PATH);
         if (resource == null) {
-            final String exMessage = format("The template file %s is not found.", TEMPLATE_PATH);
+            String exMessage = format("The template file %s is not found.", TEMPLATE_PATH);
             throw newIllegalStateException(exMessage);
         }
 
-        final SoyFileSet sfs = SoyFileSet.builder()
+        SoyFileSet sfs = SoyFileSet.builder()
                                          .add(resource)
                                          .build();
         return sfs.compileToTofu();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodConstructors.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodConstructors.java
@@ -58,7 +58,7 @@ class MethodConstructors {
     static String createDescriptorStatement(int index, ClassName messageClassName) {
         checkNotNull(messageClassName);
         SoyMapData mapData = new SoyMapData("fieldIndex", index,
-                                                  "messageClassName", messageClassName.toString());
+                                            "messageClassName", messageClassName.toString());
         String result = renderData(mapData, "io.spine.generation.descriptorStatement");
         return result;
     }
@@ -86,9 +86,9 @@ class MethodConstructors {
         checkNotNull(value);
         // We pass capitalized name because this value is used with prefixes.
         String fieldName = FieldName.of(value)
-                                          .toCamelCase();
+                                    .toCamelCase();
         SoyMapData mapData = new SoyMapData("javaFieldName", fieldName,
-                                                  "valueToValidate", value);
+                                            "valueToValidate", value);
         String result = renderData(mapData, "io.spine.generation.convertedValueStatement");
         return result;
     }
@@ -153,22 +153,22 @@ class MethodConstructors {
 
     private static String renderData(SoyMapData mapData, String templateName) {
         String result = soyTofu.newRenderer(templateName)
-                                     .setData(mapData)
-                                     .render();
+                               .setData(mapData)
+                               .render();
         return result;
     }
 
     private static SoyTofu getSoyTofu() {
         URL resource = MethodConstructors.class.getClassLoader()
-                                                     .getResource(TEMPLATE_PATH);
+                                               .getResource(TEMPLATE_PATH);
         if (resource == null) {
             String exMessage = format("The template file %s is not found.", TEMPLATE_PATH);
             throw newIllegalStateException(exMessage);
         }
 
         SoyFileSet sfs = SoyFileSet.builder()
-                                         .add(resource)
-                                         .build();
+                                   .add(resource)
+                                   .build();
         return sfs.compileToTofu();
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodGenerator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodGenerator.java
@@ -57,7 +57,7 @@ class MethodGenerator {
         this.javaPackage = type.getJavaPackage();
         this.message = type.getDescriptor();
         this.typeCache = typeCache;
-        final String className = message.getName();
+        String className = message.getName();
         this.builderGenericClassName =
                 getValidatorMessageClassName(javaPackage, typeCache, className);
     }
@@ -68,7 +68,7 @@ class MethodGenerator {
      * @return the generated methods
      */
     Collection<MethodSpec> createMethods() {
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
 
         methods.add(createPrivateConstructor());
         methods.add(createNewBuilderMethod());
@@ -78,15 +78,15 @@ class MethodGenerator {
     }
 
     private static MethodSpec createPrivateConstructor() {
-        final MethodSpec result = MethodSpec.constructorBuilder()
+        MethodSpec result = MethodSpec.constructorBuilder()
                                             .addModifiers(Modifier.PRIVATE)
                                             .build();
         return result;
     }
 
     private MethodSpec createNewBuilderMethod() {
-        final ClassName builderClass = ClassNames.getClassName(javaPackage, javaClass);
-        final MethodSpec buildMethod = MethodSpec.methodBuilder(Messages.METHOD_NEW_BUILDER)
+        ClassName builderClass = ClassNames.getClassName(javaPackage, javaClass);
+        MethodSpec buildMethod = MethodSpec.methodBuilder(Messages.METHOD_NEW_BUILDER)
                                                  .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                                                  .returns(builderClass)
                                                  .addStatement("return new $T()", builderClass)
@@ -95,12 +95,12 @@ class MethodGenerator {
     }
 
     private List<MethodSpec> createFieldMethods() {
-        final Factory factory = new Factory();
-        final ImmutableList.Builder<MethodSpec> result = ImmutableList.builder();
+        Factory factory = new Factory();
+        ImmutableList.Builder<MethodSpec> result = ImmutableList.builder();
         int index = 0;
         for (FieldDescriptorProto field : message.getFieldList()) {
-            final MethodConstructor method = factory.create(field, index);
-            final Collection<MethodSpec> methods = method.construct();
+            MethodConstructor method = factory.create(field, index);
+            Collection<MethodSpec> methods = method.construct();
             result.addAll(methods);
 
             ++index;
@@ -135,10 +135,10 @@ class MethodGenerator {
         private MethodConstructor doCreate(AbstractMethodConstructorBuilder builder,
                                            FieldDescriptorProto field,
                                            int fieldIndex) {
-            final FieldTypeFactory factory =
+            FieldTypeFactory factory =
                     new FieldTypeFactory(message, typeCache.getCachedTypes());
-            final FieldType fieldType = factory.create(field);
-            final MethodConstructor methodConstructor =
+            FieldType fieldType = factory.create(field);
+            MethodConstructor methodConstructor =
                     builder.setField(field)
                            .setFieldType(fieldType)
                            .setFieldIndex(fieldIndex)

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodGenerator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MethodGenerator.java
@@ -79,18 +79,18 @@ class MethodGenerator {
 
     private static MethodSpec createPrivateConstructor() {
         MethodSpec result = MethodSpec.constructorBuilder()
-                                            .addModifiers(Modifier.PRIVATE)
-                                            .build();
+                                      .addModifiers(Modifier.PRIVATE)
+                                      .build();
         return result;
     }
 
     private MethodSpec createNewBuilderMethod() {
         ClassName builderClass = ClassNames.getClassName(javaPackage, javaClass);
         MethodSpec buildMethod = MethodSpec.methodBuilder(Messages.METHOD_NEW_BUILDER)
-                                                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-                                                 .returns(builderClass)
-                                                 .addStatement("return new $T()", builderClass)
-                                                 .build();
+                                           .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                                           .returns(builderClass)
+                                           .addStatement("return new $T()", builderClass)
+                                           .build();
         return buildMethod;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethodConstructor.java
@@ -131,9 +131,9 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
         String methodName = "get" + methodNamePart;
         ClassName rawType = ClassName.get(List.class);
         ParameterizedTypeName returnType = ParameterizedTypeName.get(rawType,
-                                                                           listElementClassName);
+                                                                     listElementClassName);
         String returnStatement = format("return %s.get%sList()",
-                                              getMessageBuilder(), methodNamePart);
+                                        getMessageBuilder(), methodNamePart);
         MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
@@ -198,25 +198,25 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     private MethodSpec createRawAddObjectMethod() {
         String methodName = ADD_RAW_PREFIX + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         String addValueStatement = getMessageBuilder() + '.'
                 + ADD_PREFIX + methodNamePart + "(convertedValue)";
         String convertStatement = createValidateStatement(CONVERTED_VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(String.class, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addException(ConversionException.class)
-                                            .addStatement(createConvertSingularValue(VALUE),
-                                                          listElementClassName,
-                                                          listElementClassName)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(convertStatement,
-                                                          fieldDescriptor.getName())
-                                            .addStatement(addValueStatement)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(String.class, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addException(ConversionException.class)
+                                      .addStatement(createConvertSingularValue(VALUE),
+                                                    listElementClassName,
+                                                    listElementClassName)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(convertStatement,
+                                                    fieldDescriptor.getName())
+                                      .addStatement(addValueStatement)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
@@ -233,97 +233,97 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
                                                       String realBuilderCallPrefix) {
         String methodName = methodNamePrefix + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         String modificationStatement =
                 format("%s.%s%s(%s, convertedValue)",
                        getMessageBuilder(), realBuilderCallPrefix, methodNamePart, INDEX);
         String convertStatement = createValidateStatement(CONVERTED_VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(TypeName.INT, INDEX)
-                                            .addParameter(String.class, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addException(ConversionException.class)
-                                            .addStatement(createConvertSingularValue(VALUE),
-                                                          listElementClassName,
-                                                          listElementClassName)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(convertStatement,
-                                                          fieldDescriptor.getName())
-                                            .addStatement(modificationStatement)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(TypeName.INT, INDEX)
+                                      .addParameter(String.class, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addException(ConversionException.class)
+                                      .addStatement(createConvertSingularValue(VALUE),
+                                                    listElementClassName,
+                                                    listElementClassName)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(convertStatement,
+                                                    fieldDescriptor.getName())
+                                      .addStatement(modificationStatement)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createRawAddAllMethod() {
         String methodName = fieldType.getSetterPrefix() + rawSuffix() + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         String addAllValues = getMessageBuilder()
                 + format(".addAll%s(%s)", methodNamePart, CONVERTED_VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(String.class, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addException(ConversionException.class)
-                                            .addStatement(createGetConvertedCollectionValue(),
-                                                          List.class,
-                                                          listElementClassName,
-                                                          listElementClassName)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(createValidateStatement(CONVERTED_VALUE),
-                                                          fieldDescriptor.getName())
-                                            .addStatement(addAllValues)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(String.class, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addException(ConversionException.class)
+                                      .addStatement(createGetConvertedCollectionValue(),
+                                                    List.class,
+                                                    listElementClassName,
+                                                    listElementClassName)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(createValidateStatement(CONVERTED_VALUE),
+                                                    fieldDescriptor.getName())
+                                      .addStatement(addAllValues)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createAddAllMethod() {
         String methodName = fieldType.getSetterPrefix() + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         ClassName rawType = ClassName.get(List.class);
         ParameterizedTypeName parameter = ParameterizedTypeName.get(rawType,
-                                                                          listElementClassName);
+                                                                    listElementClassName);
         String fieldName = fieldDescriptor.getName();
         String addAllValues = getMessageBuilder()
                 + format(".addAll%s(%s)", methodNamePart, VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(parameter, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addStatement(descriptorCodeLine,
-                                                          FieldDescriptor.class)
-                                            .addStatement(createValidateStatement(VALUE),
-                                                          fieldName)
-                                            .addStatement(addAllValues)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(parameter, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addStatement(descriptorCodeLine,
+                                                    FieldDescriptor.class)
+                                      .addStatement(createValidateStatement(VALUE),
+                                                    fieldName)
+                                      .addStatement(addAllValues)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createAddObjectMethod() {
         String methodName = ADD_PREFIX + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         String addValue = format("%s.%s%s(%s)",
-                                       getMessageBuilder(), ADD_PREFIX, methodNamePart, VALUE);
+                                 getMessageBuilder(), ADD_PREFIX, methodNamePart, VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(listElementClassName, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(createValidateStatement(VALUE),
-                                                          javaFieldName)
-                                            .addStatement(addValue)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(listElementClassName, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(createValidateStatement(VALUE),
+                                                    javaFieldName)
+                                      .addStatement(addValue)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
@@ -338,46 +338,46 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     private MethodSpec createRemoveObjectByIndexMethod() {
         String methodName = removePrefix() + methodNamePart;
         String addValue = format("%s.%s%s(%s)", getMessageBuilder(),
-                                       removePrefix(), methodNamePart, INDEX);
+                                 removePrefix(), methodNamePart, INDEX);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(TypeName.INT, INDEX)
-                                            .addStatement(addValue)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(TypeName.INT, INDEX)
+                                      .addStatement(addValue)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec modifyCollectionByIndex(String methodPrefix) {
         String methodName = methodPrefix + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         String modificationStatement = format("%s.%s%s(%s, %s)", getMessageBuilder(),
-                                                    methodPrefix, methodNamePart, INDEX, VALUE);
+                                              methodPrefix, methodNamePart, INDEX, VALUE);
         MethodSpec result = MethodSpec.methodBuilder(methodName)
-                                            .returns(builderClassName)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .addParameter(TypeName.INT, INDEX)
-                                            .addParameter(listElementClassName, VALUE)
-                                            .addException(ValidationException.class)
-                                            .addStatement(descriptorCodeLine, FieldDescriptor.class)
-                                            .addStatement(createValidateStatement(VALUE),
-                                                          javaFieldName)
-                                            .addStatement(modificationStatement)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .returns(builderClassName)
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .addParameter(TypeName.INT, INDEX)
+                                      .addParameter(listElementClassName, VALUE)
+                                      .addException(ValidationException.class)
+                                      .addStatement(descriptorCodeLine, FieldDescriptor.class)
+                                      .addStatement(createValidateStatement(VALUE),
+                                                    javaFieldName)
+                                      .addStatement(modificationStatement)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 
     private MethodSpec createClearMethod() {
         String clearField = getMessageBuilder() + clearProperty(methodNamePart);
         MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + methodNamePart)
-                                            .addModifiers(Modifier.PUBLIC)
-                                            .returns(builderClassName)
-                                            .addStatement(clearField)
-                                            .addStatement(returnThis())
-                                            .build();
+                                      .addModifiers(Modifier.PUBLIC)
+                                      .returns(builderClassName)
+                                      .addStatement(clearField)
+                                      .addStatement(returnThis())
+                                      .build();
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethodConstructor.java
@@ -99,13 +99,13 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
         this.fieldIndex = builder.getFieldIndex();
         this.fieldDescriptor = builder.getField();
         this.builderGenericClassName = builder.getGenericClassName();
-        final FieldName fieldName = FieldName.of(fieldDescriptor);
+        FieldName fieldName = FieldName.of(fieldDescriptor);
         this.javaFieldName = fieldName.javaCase();
         this.methodNamePart = fieldName.toCamelCase();
-        final String javaClass = builder.getJavaClass();
-        final String javaPackage = builder.getJavaPackage();
+        String javaClass = builder.getJavaClass();
+        String javaPackage = builder.getJavaPackage();
         this.builderClassName = getClassName(javaPackage, javaClass);
-        final MessageTypeCache messageTypeCache = builder.getTypeCache();
+        MessageTypeCache messageTypeCache = builder.getTypeCache();
         this.listElementClassName = getParameterClassName(fieldDescriptor, messageTypeCache);
         this.isScalarOrEnum = isScalarType(fieldDescriptor) || isEnumType(fieldDescriptor);
     }
@@ -115,7 +115,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
         log().debug("The methods construction for the {} repeated field is started.",
                     javaFieldName);
 
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(createGetter());
         methods.addAll(createRepeatedMethods());
         methods.addAll(createRepeatedRawMethods());
@@ -128,13 +128,13 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     private MethodSpec createGetter() {
         log().debug("The getter construction for the repeated field is started.");
 
-        final String methodName = "get" + methodNamePart;
-        final ClassName rawType = ClassName.get(List.class);
-        final ParameterizedTypeName returnType = ParameterizedTypeName.get(rawType,
+        String methodName = "get" + methodNamePart;
+        ClassName rawType = ClassName.get(List.class);
+        ParameterizedTypeName returnType = ParameterizedTypeName.get(rawType,
                                                                            listElementClassName);
-        final String returnStatement = format("return %s.get%sList()",
+        String returnStatement = format("return %s.get%sList()",
                                               getMessageBuilder(), methodNamePart);
-        final MethodSpec methodSpec =
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(returnType)
@@ -148,7 +148,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     private Collection<MethodSpec> createRepeatedRawMethods() {
         log().debug("The raw methods construction for the repeated field is is started.");
 
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(createRawAddObjectMethod());
         methods.add(createRawSetObjectByIndexMethod());
         methods.add(createRawAddAllMethod());
@@ -163,7 +163,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private Collection<MethodSpec> createRepeatedMethods() {
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
 
         methods.add(createClearMethod());
         methods.add(createAddObjectMethod());
@@ -180,7 +180,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
 
     private static boolean isScalarType(FieldDescriptorProto fieldDescriptor) {
         boolean isScalarType = false;
-        final Type type = fieldDescriptor.getType();
+        Type type = fieldDescriptor.getType();
         for (ScalarType scalarType : ScalarType.values()) {
             if (scalarType.getProtoScalarType() == type) {
                 isScalarType = true;
@@ -190,19 +190,19 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private static boolean isEnumType(FieldDescriptorProto fieldDescriptor) {
-        final Type type = fieldDescriptor.getType();
-        final boolean result = type == TYPE_ENUM;
+        Type type = fieldDescriptor.getType();
+        boolean result = type == TYPE_ENUM;
         return result;
     }
 
     private MethodSpec createRawAddObjectMethod() {
-        final String methodName = ADD_RAW_PREFIX + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = ADD_RAW_PREFIX + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final String addValueStatement = getMessageBuilder() + '.'
+        String addValueStatement = getMessageBuilder() + '.'
                 + ADD_PREFIX + methodNamePart + "(convertedValue)";
-        final String convertStatement = createValidateStatement(CONVERTED_VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        String convertStatement = createValidateStatement(CONVERTED_VALUE);
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(String.class, VALUE)
@@ -221,7 +221,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createRawAddObjectByIndexMethod() {
-        final MethodSpec result = modifyCollectionByIndexWithRaw(ADD_RAW_PREFIX, ADD_PREFIX);
+        MethodSpec result = modifyCollectionByIndexWithRaw(ADD_RAW_PREFIX, ADD_PREFIX);
         return result;
     }
 
@@ -231,14 +231,14 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
 
     private MethodSpec modifyCollectionByIndexWithRaw(String methodNamePrefix,
                                                       String realBuilderCallPrefix) {
-        final String methodName = methodNamePrefix + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = methodNamePrefix + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final String modificationStatement =
+        String modificationStatement =
                 format("%s.%s%s(%s, convertedValue)",
                        getMessageBuilder(), realBuilderCallPrefix, methodNamePart, INDEX);
-        final String convertStatement = createValidateStatement(CONVERTED_VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        String convertStatement = createValidateStatement(CONVERTED_VALUE);
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(TypeName.INT, INDEX)
@@ -258,12 +258,12 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createRawAddAllMethod() {
-        final String methodName = fieldType.getSetterPrefix() + rawSuffix() + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = fieldType.getSetterPrefix() + rawSuffix() + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final String addAllValues = getMessageBuilder()
+        String addAllValues = getMessageBuilder()
                 + format(".addAll%s(%s)", methodNamePart, CONVERTED_VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(String.class, VALUE)
@@ -283,16 +283,16 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createAddAllMethod() {
-        final String methodName = fieldType.getSetterPrefix() + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = fieldType.getSetterPrefix() + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final ClassName rawType = ClassName.get(List.class);
-        final ParameterizedTypeName parameter = ParameterizedTypeName.get(rawType,
+        ClassName rawType = ClassName.get(List.class);
+        ParameterizedTypeName parameter = ParameterizedTypeName.get(rawType,
                                                                           listElementClassName);
-        final String fieldName = fieldDescriptor.getName();
-        final String addAllValues = getMessageBuilder()
+        String fieldName = fieldDescriptor.getName();
+        String addAllValues = getMessageBuilder()
                 + format(".addAll%s(%s)", methodNamePart, VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(parameter, VALUE)
@@ -308,12 +308,12 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createAddObjectMethod() {
-        final String methodName = ADD_PREFIX + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = ADD_PREFIX + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final String addValue = format("%s.%s%s(%s)",
+        String addValue = format("%s.%s%s(%s)",
                                        getMessageBuilder(), ADD_PREFIX, methodNamePart, VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(listElementClassName, VALUE)
@@ -336,10 +336,10 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createRemoveObjectByIndexMethod() {
-        final String methodName = removePrefix() + methodNamePart;
-        final String addValue = format("%s.%s%s(%s)", getMessageBuilder(),
+        String methodName = removePrefix() + methodNamePart;
+        String addValue = format("%s.%s%s(%s)", getMessageBuilder(),
                                        removePrefix(), methodNamePart, INDEX);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(TypeName.INT, INDEX)
@@ -350,12 +350,12 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec modifyCollectionByIndex(String methodPrefix) {
-        final String methodName = methodPrefix + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = methodPrefix + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final String modificationStatement = format("%s.%s%s(%s, %s)", getMessageBuilder(),
+        String modificationStatement = format("%s.%s%s(%s, %s)", getMessageBuilder(),
                                                     methodPrefix, methodNamePart, INDEX, VALUE);
-        final MethodSpec result = MethodSpec.methodBuilder(methodName)
+        MethodSpec result = MethodSpec.methodBuilder(methodName)
                                             .returns(builderClassName)
                                             .addModifiers(Modifier.PUBLIC)
                                             .addParameter(TypeName.INT, INDEX)
@@ -371,8 +371,8 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private MethodSpec createClearMethod() {
-        final String clearField = getMessageBuilder() + clearProperty(methodNamePart);
-        final MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + methodNamePart)
+        String clearField = getMessageBuilder() + clearProperty(methodNamePart);
+        MethodSpec result = MethodSpec.methodBuilder(clearPrefix() + methodNamePart)
                                             .addModifiers(Modifier.PUBLIC)
                                             .returns(builderClassName)
                                             .addStatement(clearField)
@@ -382,7 +382,7 @@ class RepeatedFieldMethodConstructor implements MethodConstructor {
     }
 
     private static String createGetConvertedCollectionValue() {
-        final String result = "final $T<$T> convertedValue = convertToList(value, $T.class)";
+        String result = "final $T<$T> convertedValue = convertToList(value, $T.class)";
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethodConstructor.java
@@ -97,9 +97,9 @@ class SingularFieldMethodConstructor implements MethodConstructor {
         Logger log = log();
         // The variable is used for tracing only.
         String javaFieldName = log.isTraceEnabled()
-                ? FieldName.of(field)
-                           .javaCase()
-                : null;
+                               ? FieldName.of(field)
+                                          .javaCase()
+                               : null;
 
         log.debug("The method construction for the {} singular field is started.", javaFieldName);
         List<MethodSpec> methods = newArrayList();
@@ -119,7 +119,7 @@ class SingularFieldMethodConstructor implements MethodConstructor {
         log().debug("The setters construction for the singular field is started.");
         String methodName = fieldType.getSetterPrefix() + methodNamePart;
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         ParameterSpec parameter = createParameterSpec(field, false);
 
         String setStatement = format("%s.%s(%s)", getMessageBuilder(), methodName, fieldName);
@@ -176,16 +176,16 @@ class SingularFieldMethodConstructor implements MethodConstructor {
         String messageBuilderSetter = fieldType.getSetterPrefix() + methodNamePart;
         String methodName = messageBuilderSetter + rawSuffix();
         String descriptorCodeLine = createDescriptorStatement(fieldIndex,
-                                                                    builderGenericClassName);
+                                                              builderGenericClassName);
         ParameterSpec parameter = createParameterSpec(field, true);
 
         String convertedVariableName = "convertedValue";
         String convertedValue = format("final $T %s = convert(%s, $T.class)",
-                                             convertedVariableName, fieldName);
+                                       convertedVariableName, fieldName);
         String setStatement = format("%s.%s(%s)",
-                                           getMessageBuilder(),
-                                           messageBuilderSetter,
-                                           convertedVariableName);
+                                     getMessageBuilder(),
+                                     messageBuilderSetter,
+                                     convertedVariableName);
         MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
@@ -207,12 +207,12 @@ class SingularFieldMethodConstructor implements MethodConstructor {
 
     private ParameterSpec createParameterSpec(FieldDescriptorProto field, boolean raw) {
         ClassName methodParamClass = raw
-                ? getStringClassName()
-                : fieldClassName;
+                                     ? getStringClassName()
+                                     : fieldClassName;
         String paramName = FieldName.of(field)
-                                          .javaCase();
+                                    .javaCase();
         ParameterSpec result = ParameterSpec.builder(methodParamClass, paramName)
-                                                  .build();
+                                            .build();
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethodConstructor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethodConstructor.java
@@ -84,25 +84,25 @@ class SingularFieldMethodConstructor implements MethodConstructor {
         this.field = builder.getField();
         this.fieldIndex = builder.getFieldIndex();
         this.builderGenericClassName = builder.getGenericClassName();
-        final MessageTypeCache messageTypeCache = builder.getTypeCache();
+        MessageTypeCache messageTypeCache = builder.getTypeCache();
         this.fieldClassName = getParameterClassName(field, messageTypeCache);
         this.builderClassName = getClassName(builder.getJavaPackage(), builder.getJavaClass());
-        final FieldName fieldName = FieldName.of(field);
+        FieldName fieldName = FieldName.of(field);
         this.fieldName = fieldName.javaCase();
         this.methodNamePart = fieldName.toCamelCase();
     }
 
     @Override
     public Collection<MethodSpec> construct() {
-        final Logger log = log();
+        Logger log = log();
         // The variable is used for tracing only.
-        final String javaFieldName = log.isTraceEnabled()
+        String javaFieldName = log.isTraceEnabled()
                 ? FieldName.of(field)
                            .javaCase()
                 : null;
 
         log.debug("The method construction for the {} singular field is started.", javaFieldName);
-        final List<MethodSpec> methods = newArrayList();
+        List<MethodSpec> methods = newArrayList();
         methods.add(constructSetter());
 
         if (!fieldClassName.equals(getStringClassName())) {
@@ -117,13 +117,13 @@ class SingularFieldMethodConstructor implements MethodConstructor {
 
     private MethodSpec constructSetter() {
         log().debug("The setters construction for the singular field is started.");
-        final String methodName = fieldType.getSetterPrefix() + methodNamePart;
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String methodName = fieldType.getSetterPrefix() + methodNamePart;
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final ParameterSpec parameter = createParameterSpec(field, false);
+        ParameterSpec parameter = createParameterSpec(field, false);
 
-        final String setStatement = format("%s.%s(%s)", getMessageBuilder(), methodName, fieldName);
-        final MethodSpec methodSpec =
+        String setStatement = format("%s.%s(%s)", getMessageBuilder(), methodName, fieldName);
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(builderClassName)
@@ -141,9 +141,9 @@ class SingularFieldMethodConstructor implements MethodConstructor {
 
     private MethodSpec constructGetter() {
         log().debug("The getter construction for the singular field is started.");
-        final String methodName = GETTER_PREFIX + methodNamePart;
+        String methodName = GETTER_PREFIX + methodNamePart;
 
-        final MethodSpec methodSpec =
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(fieldClassName)
@@ -155,9 +155,9 @@ class SingularFieldMethodConstructor implements MethodConstructor {
 
     private MethodSpec constructClearMethods() {
         log().debug("The 'clear..()' method construction for the singular field is started.");
-        final String methodBody = getMessageBuilder() + clearProperty(methodNamePart);
+        String methodBody = getMessageBuilder() + clearProperty(methodNamePart);
 
-        final MethodSpec methodSpec =
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(clearPrefix() + methodNamePart)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(builderClassName)
@@ -173,20 +173,20 @@ class SingularFieldMethodConstructor implements MethodConstructor {
     // Although it has the equivalent literal they have the different meaning.
     private MethodSpec constructRawSetter() {
         log().debug("The raw setters construction is started.");
-        final String messageBuilderSetter = fieldType.getSetterPrefix() + methodNamePart;
-        final String methodName = messageBuilderSetter + rawSuffix();
-        final String descriptorCodeLine = createDescriptorStatement(fieldIndex,
+        String messageBuilderSetter = fieldType.getSetterPrefix() + methodNamePart;
+        String methodName = messageBuilderSetter + rawSuffix();
+        String descriptorCodeLine = createDescriptorStatement(fieldIndex,
                                                                     builderGenericClassName);
-        final ParameterSpec parameter = createParameterSpec(field, true);
+        ParameterSpec parameter = createParameterSpec(field, true);
 
-        final String convertedVariableName = "convertedValue";
-        final String convertedValue = format("final $T %s = convert(%s, $T.class)",
+        String convertedVariableName = "convertedValue";
+        String convertedValue = format("final $T %s = convert(%s, $T.class)",
                                              convertedVariableName, fieldName);
-        final String setStatement = format("%s.%s(%s)",
+        String setStatement = format("%s.%s(%s)",
                                            getMessageBuilder(),
                                            messageBuilderSetter,
                                            convertedVariableName);
-        final MethodSpec methodSpec =
+        MethodSpec methodSpec =
                 MethodSpec.methodBuilder(methodName)
                           .addModifiers(Modifier.PUBLIC)
                           .returns(builderClassName)
@@ -206,12 +206,12 @@ class SingularFieldMethodConstructor implements MethodConstructor {
     }
 
     private ParameterSpec createParameterSpec(FieldDescriptorProto field, boolean raw) {
-        final ClassName methodParamClass = raw
+        ClassName methodParamClass = raw
                 ? getStringClassName()
                 : fieldClassName;
-        final String paramName = FieldName.of(field)
+        String paramName = FieldName.of(field)
                                           .javaCase();
-        final ParameterSpec result = ParameterSpec.builder(methodParamClass, paramName)
+        ParameterSpec result = ParameterSpec.builder(methodParamClass, paramName)
                                                   .build();
         return result;
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBTypeLookup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBTypeLookup.java
@@ -58,7 +58,6 @@ class VBTypeLookup {
     /** A map from Protobuf type name to Protobuf FileDescriptorProto. */
     private final Map<DescriptorProto, FileDescriptorProto> descriptorCache = newHashMap();
 
-
     /** Verifies if a message is not one provided by the Protobuf library. */
     private final Predicate<DescriptorProto> isNotStandardType =
             new Predicate<DescriptorProto>() {
@@ -70,7 +69,7 @@ class VBTypeLookup {
                     }
                     String javaPackage = getJavaPackage(message);
                     boolean isGoogleMsg = javaPackage.contains(Message.class.getPackage()
-                                                                                  .getName());
+                                                                            .getName());
                     return !isGoogleMsg;
                 }
             };
@@ -93,7 +92,7 @@ class VBTypeLookup {
         result.addAll(allTypes);
         if (result.size() == 1) {
             VBType found = allTypes.iterator()
-                                         .next();
+                                   .next();
             log.debug("One type found for generating validating builder: {}", found);
         } else {
             log.debug("Types collected, {} validating builders will be generated.", result.size());
@@ -135,8 +134,8 @@ class VBTypeLookup {
 
     private String getJavaPackage(DescriptorProto msgDescriptor) {
         String result = descriptorCache.get(msgDescriptor)
-                                             .getOptions()
-                                             .getJavaPackage();
+                                       .getOptions()
+                                       .getJavaPackage();
         return result;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBTypeLookup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBTypeLookup.java
@@ -68,8 +68,8 @@ class VBTypeLookup {
                     if (message == null) {
                         return false;
                     }
-                    final String javaPackage = getJavaPackage(message);
-                    final boolean isGoogleMsg = javaPackage.contains(Message.class.getPackage()
+                    String javaPackage = getJavaPackage(message);
+                    boolean isGoogleMsg = javaPackage.contains(Message.class.getPackage()
                                                                                   .getName());
                     return !isGoogleMsg;
                 }
@@ -85,14 +85,14 @@ class VBTypeLookup {
      * @return the {@code Set} of the assembled metadata for the validating builders.
      */
     Set<VBType> collect() {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Collecting types for all validating builders.");
-        final Set<FileDescriptorProto> fileDescriptors = parseAndCollectTypes(descriptorSetFile);
-        final Set<VBType> result = newHashSet();
-        final Set<VBType> allTypes = fromAllFiles(fileDescriptors);
+        Set<FileDescriptorProto> fileDescriptors = parseAndCollectTypes(descriptorSetFile);
+        Set<VBType> result = newHashSet();
+        Set<VBType> allTypes = fromAllFiles(fileDescriptors);
         result.addAll(allTypes);
         if (result.size() == 1) {
-            final VBType found = allTypes.iterator()
+            VBType found = allTypes.iterator()
                                          .next();
             log.debug("One type found for generating validating builder: {}", found);
         } else {
@@ -103,10 +103,10 @@ class VBTypeLookup {
 
     private Set<VBType> fromAllFiles(Iterable<FileDescriptorProto> files) {
         log().debug("Obtaining the file-level metadata for the validating builders.");
-        final Set<VBType> result = newHashSet();
+        Set<VBType> result = newHashSet();
         for (FileDescriptorProto file : files) {
-            final List<DescriptorProto> messageDescriptors = file.getMessageTypeList();
-            final Set<VBType> metadataSet = createMetadata(messageDescriptors, file);
+            List<DescriptorProto> messageDescriptors = file.getMessageTypeList();
+            Set<VBType> metadataSet = createMetadata(messageDescriptors, file);
             result.addAll(metadataSet);
 
         }
@@ -116,10 +116,10 @@ class VBTypeLookup {
 
     private Set<VBType> createMetadata(Iterable<DescriptorProto> descriptors,
                                        FileDescriptorProto file) {
-        final Set<VBType> result = newHashSet();
+        Set<VBType> result = newHashSet();
         for (DescriptorProto message : descriptors) {
             if (isNotStandardType.apply(message)) {
-                final VBType type = newType(message, file);
+                VBType type = newType(message, file);
                 result.add(type);
             }
         }
@@ -127,24 +127,24 @@ class VBTypeLookup {
     }
 
     private VBType newType(DescriptorProto message, FileDescriptorProto file) {
-        final String className = message.getName() + JAVA_CLASS_NAME_SUFFIX;
-        final String javaPackage = getJavaPackage(message);
-        final VBType result = new VBType(javaPackage, className, message, file.getName());
+        String className = message.getName() + JAVA_CLASS_NAME_SUFFIX;
+        String javaPackage = getJavaPackage(message);
+        VBType result = new VBType(javaPackage, className, message, file.getName());
         return result;
     }
 
     private String getJavaPackage(DescriptorProto msgDescriptor) {
-        final String result = descriptorCache.get(msgDescriptor)
+        String result = descriptorCache.get(msgDescriptor)
                                              .getOptions()
                                              .getJavaPackage();
         return result;
     }
 
     private Set<FileDescriptorProto> parseAndCollectTypes(String descFilePath) {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Obtaining the file descriptors by {} path.", descFilePath);
-        final ImmutableSet.Builder<FileDescriptorProto> result = ImmutableSet.builder();
-        final Collection<FileDescriptorProto> allDescriptors = parse(descFilePath);
+        ImmutableSet.Builder<FileDescriptorProto> result = ImmutableSet.builder();
+        Collection<FileDescriptorProto> allDescriptors = parse(descFilePath);
 
         for (FileDescriptorProto file : allDescriptors) {
             cacheTypesFromFile(file);

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderGenerator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderGenerator.java
@@ -83,14 +83,14 @@ public class VBuilderGenerator {
     }
 
     public void processDescriptorSetFile(File setFile) {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Generating the validating builders from {}.", setFile);
 
-        final VBTypeLookup lookup = new VBTypeLookup(setFile.getPath());
-        final Set<VBType> allFound = lookup.collect();
-        final MessageTypeCache typeCache = lookup.getTypeCache();
+        VBTypeLookup lookup = new VBTypeLookup(setFile.getPath());
+        Set<VBType> allFound = lookup.collect();
+        MessageTypeCache typeCache = lookup.getTypeCache();
 
-        final Set<VBType> filtered = filter(classpathGenEnabled, allFound);
+        Set<VBType> filtered = filter(classpathGenEnabled, allFound);
         if (filtered.isEmpty()) {
             log.warn("No validating builders will be generated.");
         } else {
@@ -99,15 +99,15 @@ public class VBuilderGenerator {
     }
 
     private void writeVBuilders(Set<VBType> builders, MessageTypeCache cache) {
-        final Logger log = log();
-        final ValidatingBuilderWriter writer =
+        Logger log = log();
+        ValidatingBuilderWriter writer =
                 new ValidatingBuilderWriter(targetDirPath, indent, cache);
 
         for (VBType vb : builders) {
             try {
                 writer.write(vb);
             } catch (RuntimeException e) {
-                final String message =
+                String message =
                         format("Cannot generate the validating builder for %s. %n" +
                                "Error: %s", vb, e.toString());
                 // If debug level is enabled give it under this lever, otherwise WARN.
@@ -122,18 +122,18 @@ public class VBuilderGenerator {
     }
 
     private Set<VBType> filter(boolean classpathGenEnabled, Set<VBType> types) {
-        final Predicate<VBType> shouldWrite = getPredicate(classpathGenEnabled);
-        final Iterable<VBType> filtered = Iterables.filter(types, shouldWrite);
-        final Set<VBType> result = ImmutableSet.copyOf(filtered);
+        Predicate<VBType> shouldWrite = getPredicate(classpathGenEnabled);
+        Iterable<VBType> filtered = Iterables.filter(types, shouldWrite);
+        Set<VBType> result = ImmutableSet.copyOf(filtered);
         return result;
     }
 
     private Predicate<VBType> getPredicate(boolean classpathGenEnabled) {
-        final Predicate<VBType> result;
+        Predicate<VBType> result;
         if (classpathGenEnabled) {
             result = Predicates.alwaysTrue();
         } else {
-            final String rootPath = protoSrcDirPath.endsWith(File.separator)
+            String rootPath = protoSrcDirPath.endsWith(File.separator)
                                     ? protoSrcDirPath
                                     : protoSrcDirPath + File.separator;
             result = new SourceProtoBelongsToModule(rootPath);
@@ -163,9 +163,9 @@ public class VBuilderGenerator {
         public boolean apply(@Nullable VBType input) {
             checkNotNull(input);
 
-            final String path = input.getSourceProtoFile();
-            final File protoFile = new File(rootPath + path);
-            final boolean belongsToModule = protoFile.exists();
+            String path = input.getSourceProtoFile();
+            File protoFile = new File(rootPath + path);
+            boolean belongsToModule = protoFile.exists();
             return belongsToModule;
         }
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderGenerator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderGenerator.java
@@ -134,8 +134,8 @@ public class VBuilderGenerator {
             result = Predicates.alwaysTrue();
         } else {
             String rootPath = protoSrcDirPath.endsWith(File.separator)
-                                    ? protoSrcDirPath
-                                    : protoSrcDirPath + File.separator;
+                              ? protoSrcDirPath
+                              : protoSrcDirPath + File.separator;
             result = new SourceProtoBelongsToModule(rootPath);
         }
         return result;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidatingBuilderWriter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidatingBuilderWriter.java
@@ -107,8 +107,8 @@ class ValidatingBuilderWriter {
                                           messageClassParam,
                                           messageBuilderParam);
         typeBuilder.addModifiers(Modifier.PUBLIC, Modifier.FINAL)
-               .superclass(superClass)
-               .addMethods(methodSpecs);
+                   .superclass(superClass)
+                   .addMethods(methodSpecs);
         return typeBuilder;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidatingBuilderWriter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidatingBuilderWriter.java
@@ -66,22 +66,22 @@ class ValidatingBuilderWriter {
         log().debug("Preparing to writing the {} class under the {} package",
                     type.getJavaClass(), type.getJavaPackage());
 
-        final MethodGenerator methodsAssembler =
+        MethodGenerator methodsAssembler =
                 new MethodGenerator(type, messageTypeCache);
-        final String javaClass = type.getJavaClass();
-        final String javaPackage = type.getJavaPackage();
-        final DescriptorProto descriptor = type.getDescriptor();
-        final ClassName messageClassName =
+        String javaClass = type.getJavaClass();
+        String javaPackage = type.getJavaPackage();
+        DescriptorProto descriptor = type.getDescriptor();
+        ClassName messageClassName =
                 getValidatorMessageClassName(javaPackage,
                                              messageTypeCache,
                                              descriptor.getName());
-        final ClassName messageBuilderClassName =
+        ClassName messageBuilderClassName =
                 messageClassName.nestedClass(SimpleClassName.ofBuilder()
                                                             .value());
 
-        final File rootDirectory = new File(targetDir);
-        final TypeSpec.Builder classBuilder = TypeSpec.classBuilder(javaClass);
-        final TypeSpec javaClassToWrite =
+        File rootDirectory = new File(targetDir);
+        TypeSpec.Builder classBuilder = TypeSpec.classBuilder(javaClass);
+        TypeSpec javaClassToWrite =
                 setupClassContract(classBuilder,
                                    messageClassName,
                                    messageBuilderClassName,
@@ -100,9 +100,9 @@ class ValidatingBuilderWriter {
                                                        ClassName messageClassParam,
                                                        ClassName messageBuilderParam,
                                                        Iterable<MethodSpec> methodSpecs) {
-        final ClassName abstractBuilderTypeName = ClassName.get(AbstractValidatingBuilder.class);
+        ClassName abstractBuilderTypeName = ClassName.get(AbstractValidatingBuilder.class);
 
-        final ParameterizedTypeName superClass =
+        ParameterizedTypeName superClass =
                 ParameterizedTypeName.get(abstractBuilderTypeName,
                                           messageClassParam,
                                           messageBuilderParam);
@@ -122,7 +122,7 @@ class ValidatingBuilderWriter {
                     .build()
                     .writeTo(rootFolder);
         } catch (IOException e) {
-            final String exMessage = String.format("%s was not written.", rootFolder);
+            String exMessage = String.format("%s was not written.", rootFolder);
             log().warn(exMessage, e);
             throw newIllegalArgumentException(exMessage, e);
         }

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/CleaningPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/CleaningPlugin.java
@@ -41,9 +41,9 @@ import static io.spine.tools.gradle.TaskName.PRE_CLEAN;
 public class CleaningPlugin extends SpinePlugin {
 
     @Override
-    public void apply(final Project project) {
-        final Logger log = log();
-        final Action<Task> preCleanAction = new Action<Task>() {
+    public void apply(Project project) {
+        Logger log = log();
+        Action<Task> preCleanAction = new Action<Task>() {
             @Override
             public void execute(Task task) {
                 log.debug("Pre-clean: deleting the directories");
@@ -51,7 +51,7 @@ public class CleaningPlugin extends SpinePlugin {
             }
         };
         logDependingTask(PRE_CLEAN, CLEAN);
-        final GradleTask preCleanTask =
+        GradleTask preCleanTask =
                 newTask(PRE_CLEAN, preCleanAction)
                         .insertBeforeTask(CLEAN)
                         .applyNowTo(project);

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/DescriptorSetMergerPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/DescriptorSetMergerPlugin.java
@@ -91,7 +91,8 @@ public class DescriptorSetMergerPlugin extends SpinePlugin {
                     configuration.getFiles()
                                  .stream()
                                  .map(task.getProject()::zipTree)
-                                 .flatMap(fileTree -> fileTree.getFiles().stream())
+                                 .flatMap(fileTree -> fileTree.getFiles()
+                                                              .stream())
                                  .filter(file -> KNOWN_TYPES.equals(file.getName()))
                                  .peek(file -> log().debug("Merging descriptors from {}", file))
                                  .collect(toList());

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/EnrichmentLookupPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/EnrichmentLookupPlugin.java
@@ -55,40 +55,40 @@ import static io.spine.tools.gradle.compiler.Extension.getTestTargetGenResources
 public class EnrichmentLookupPlugin extends SpinePlugin {
 
     @Override
-    public void apply(final Project project) {
-        final Action<Task> mainScopeAction = mainScopeActionFor(project);
+    public void apply(Project project) {
+        Action<Task> mainScopeAction = mainScopeActionFor(project);
         logDependingTask(FIND_ENRICHMENTS, PROCESS_RESOURCES, COMPILE_JAVA);
-        final GradleTask findEnrichments =
+        GradleTask findEnrichments =
                 newTask(FIND_ENRICHMENTS,
                         mainScopeAction).insertAfterTask(COMPILE_JAVA)
                                         .insertBeforeTask(PROCESS_RESOURCES)
                                         .applyNowTo(project);
-        final Action<Task> testScopeAction = testScopeActionFor(project);
+        Action<Task> testScopeAction = testScopeActionFor(project);
         logDependingTask(FIND_TEST_ENRICHMENTS, PROCESS_TEST_RESOURCES, COMPILE_TEST_JAVA);
-        final GradleTask findTestEnrichments =
+        GradleTask findTestEnrichments =
                 newTask(FIND_TEST_ENRICHMENTS,
                         testScopeAction).insertAfterTask(COMPILE_TEST_JAVA)
                                         .insertBeforeTask(PROCESS_TEST_RESOURCES)
                                         .applyNowTo(project);
 
-        final String msg = "Enrichment lookup phase initialized with tasks: {}, {}";
+        String msg = "Enrichment lookup phase initialized with tasks: {}, {}";
         log().debug(msg, findEnrichments, findTestEnrichments);
     }
 
-    private Action<Task> testScopeActionFor(final Project project) {
+    private Action<Task> testScopeActionFor(Project project) {
         log().debug("Initializing the enrichment lookup for the \"test\" source code");
         return task -> findEnrichmentsAndWriteProps(getTestDescriptorSetPath(project),
                                                     getTestTargetGenResourcesDir(project));
     }
 
-    private Action<Task> mainScopeActionFor(final Project project) {
+    private Action<Task> mainScopeActionFor(Project project) {
         log().debug("Initializing the enrichment lookup for the \"main\" source code");
         return task -> findEnrichmentsAndWriteProps(getMainDescriptorSetPath(project),
                                                     getMainTargetGenResourcesDir(project));
     }
 
     private void findEnrichmentsAndWriteProps(String descriptorSetFile, String targetDir) {
-        final File file = new File(descriptorSetFile);
+        File file = new File(descriptorSetFile);
 
         if (!file.exists()) {
             logMissingDescriptorSetFile(file);

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
@@ -242,8 +242,8 @@ public class Extension {
 
     private static String pathOrDefault(String path, Object defaultValue) {
         return isNullOrEmpty(path)
-                ? defaultValue.toString()
-                : path;
+               ? defaultValue.toString()
+               : path;
     }
 
     public static boolean isGenerateValidatingBuilders(Project project) {
@@ -298,7 +298,7 @@ public class Extension {
             dirsToClean.add(singleDir);
         } else {
             String defaultValue = def(project).generated()
-                                                    .toString();
+                                              .toString();
             log().debug("Default directory to clean: {}", defaultValue);
             dirsToClean.add(defaultValue);
         }
@@ -329,7 +329,7 @@ public class Extension {
             );
         }
         File spinePath = DefaultProject.at(projectDir)
-                                             .tempArtifacts();
+                                       .tempArtifacts();
         if (spinePath.exists()) {
             return Optional.of(spinePath.toString());
         } else {

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
@@ -247,19 +247,19 @@ public class Extension {
     }
 
     public static boolean isGenerateValidatingBuilders(Project project) {
-        final boolean result = spineProtobuf(project).generateValidatingBuilders;
+        boolean result = spineProtobuf(project).generateValidatingBuilders;
         log().debug("The current validating builder generation setting is {}", result);
         return result;
     }
 
     public static Indent getIndent(Project project) {
-        final Indent result = spineProtobuf(project).indent;
+        Indent result = spineProtobuf(project).indent;
         log().debug("The current indent is {}", result.getSize());
         return result;
     }
 
     public static boolean isGenerateValidatingBuildersFromClasspath(Project project) {
-        final boolean result = spineProtobuf(project).generateBuildersFromClasspath;
+        boolean result = spineProtobuf(project).generateBuildersFromClasspath;
         log().debug("Validating builder are generated from  {}",
                     (result ? "the classpath" : "this module only"));
         return result;
@@ -286,10 +286,10 @@ public class Extension {
     }
 
     public static List<String> getDirsToClean(Project project) {
-        final List<String> dirsToClean = newLinkedList(spineDirs(project));
+        List<String> dirsToClean = newLinkedList(spineDirs(project));
         log().debug("Finding the directories to clean");
-        final List<String> dirs = spineProtobuf(project).dirsToClean;
-        final String singleDir = spineProtobuf(project).dirToClean;
+        List<String> dirs = spineProtobuf(project).dirsToClean;
+        String singleDir = spineProtobuf(project).dirToClean;
         if (dirs.size() > 0) {
             log().error("Found {} directories to clean: {}", dirs.size(), dirs);
             dirsToClean.addAll(dirs);
@@ -297,7 +297,7 @@ public class Extension {
             log().debug("Found directory to clean: {}", singleDir);
             dirsToClean.add(singleDir);
         } else {
-            final String defaultValue = def(project).generated()
+            String defaultValue = def(project).generated()
                                                     .toString();
             log().debug("Default directory to clean: {}", defaultValue);
             dirsToClean.add(defaultValue);
@@ -306,9 +306,9 @@ public class Extension {
     }
 
     private static Iterable<String> spineDirs(Project project) {
-        final List<String> spineDirs = newLinkedList();
-        final Optional<String> spineDir = spineDir(project);
-        final Optional<String> rootSpineDir = spineDir(project.getRootProject());
+        List<String> spineDirs = newLinkedList();
+        Optional<String> spineDir = spineDir(project);
+        Optional<String> rootSpineDir = spineDir(project.getRootProject());
         if (spineDir.isPresent()) {
             spineDirs.add(spineDir.get());
             if (rootSpineDir.isPresent() && !spineDir.equals(rootSpineDir)) {
@@ -319,7 +319,7 @@ public class Extension {
     }
 
     private static Optional<String> spineDir(Project project) {
-        final File projectDir;
+        File projectDir;
         try {
             projectDir = project.getProjectDir()
                                 .getCanonicalFile();
@@ -328,7 +328,7 @@ public class Extension {
                     e, "Project directory %s is invalid!", project.getProjectDir()
             );
         }
-        final File spinePath = DefaultProject.at(projectDir)
+        File spinePath = DefaultProject.at(projectDir)
                                              .tempArtifacts();
         if (spinePath.exists()) {
             return Optional.of(spinePath.toString());

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtoAnnotatorPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtoAnnotatorPlugin.java
@@ -192,12 +192,12 @@ public class ProtoAnnotatorPlugin extends SpinePlugin {
     private Action<Task> newAction(String descriptorSetPath, Project project, boolean isTestTask) {
 
         String generatedProtoDir = isTestTask
-                ? getTestGenProtoDir(project)
-                : getMainGenProtoDir(project);
+                                   ? getTestGenProtoDir(project)
+                                   : getMainGenProtoDir(project);
 
         String generatedGrpcDir = isTestTask
-                ? getTestGenGrpcDir(project)
-                : getMainGenGrpcDir(project);
+                                  ? getTestGenGrpcDir(project)
+                                  : getMainGenGrpcDir(project);
 
         return task -> {
             File setFile = new File(descriptorSetPath);

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocPluginImporter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocPluginImporter.java
@@ -49,12 +49,12 @@ public class ProtocPluginImporter extends SpinePlugin {
     private static final String PROTOBUF_PLUGIN_ID = "com.google.protobuf";
 
     @Override
-    public void apply(final Project project) {
-        final File configFile = generateSpineProtoc();
+    public void apply(Project project) {
+        File configFile = generateSpineProtoc();
         project.getPluginManager().withPlugin(PROTOBUF_PLUGIN_ID, new Action<AppliedPlugin>() {
             @Override
             public void execute(AppliedPlugin appliedPlugin) {
-                final Logger log = log();
+                Logger log = log();
                 log.debug("Applying {} ({})",
                           PROTOC_CONFIG_FILE_NAME,
                           configFile.getAbsolutePath());
@@ -74,8 +74,8 @@ public class ProtocPluginImporter extends SpinePlugin {
      * @throws IllegalStateException upon an {@link IOException}
      */
     private static File generateSpineProtoc() throws IllegalStateException {
-        final File tempFolder = Files.createTempDir();
-        final File configFile = new File(tempFolder, PROTOC_CONFIG_FILE_NAME);
+        File tempFolder = Files.createTempDir();
+        File configFile = new File(tempFolder, PROTOC_CONFIG_FILE_NAME);
         try (InputStream in = ProtocPluginImporter.class
                 .getClassLoader()
                 .getResourceAsStream(PROTOC_CONFIG_FILE_NAME);

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/RejectionGenPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/RejectionGenPlugin.java
@@ -76,32 +76,32 @@ public class RejectionGenPlugin extends SpinePlugin {
      * before corresponding {@code :compileJava} tasks.
      */
     @Override
-    public void apply(final Project project) {
-        final Logger log = log();
+    public void apply(Project project) {
+        Logger log = log();
 
-        final Action<Task> mainScopeAction = new Action<Task>() {
+        Action<Task> mainScopeAction = new Action<Task>() {
             @Override
             public void execute(Task task) {
-                final String mainFile = getMainDescriptorSetPath(project);
-                final String targetFolder = getTargetGenRejectionsRootDir(project);
+                String mainFile = getMainDescriptorSetPath(project);
+                String targetFolder = getTargetGenRejectionsRootDir(project);
 
                 generateRejections(mainFile, targetFolder);
             }
         };
 
         logDependingTask(GENERATE_REJECTIONS, COMPILE_JAVA, GENERATE_PROTO);
-        final GradleTask mainTask =
+        GradleTask mainTask =
                 newTask(GENERATE_REJECTIONS, mainScopeAction)
                         .insertAfterTask(GENERATE_PROTO)
                         .insertBeforeTask(COMPILE_JAVA)
                         .applyNowTo(project);
 
-        final Action<Task> testScopeAction = new Action<Task>() {
+        Action<Task> testScopeAction = new Action<Task>() {
             @Override
             public void execute(Task task) {
-                final String mainFile = getMainDescriptorSetPath(project);
-                final String testFile = getTestDescriptorSetPath(project);
-                final String targetFolder = getTargetTestGenRejectionsRootDir(project);
+                String mainFile = getMainDescriptorSetPath(project);
+                String testFile = getTestDescriptorSetPath(project);
+                String targetFolder = getTargetTestGenRejectionsRootDir(project);
 
                 generateTestRejections(mainFile, testFile, targetFolder);
             }
@@ -109,7 +109,7 @@ public class RejectionGenPlugin extends SpinePlugin {
 
         logDependingTask(GENERATE_TEST_REJECTIONS, COMPILE_TEST_JAVA, GENERATE_TEST_PROTO);
 
-        final GradleTask testTask =
+        GradleTask testTask =
                 newTask(GENERATE_TEST_REJECTIONS, testScopeAction)
                         .insertAfterTask(GENERATE_TEST_PROTO)
                         .insertBeforeTask(COMPILE_TEST_JAVA)
@@ -119,29 +119,29 @@ public class RejectionGenPlugin extends SpinePlugin {
     }
 
     private void generateRejections(String mainFile, String targetFolder) {
-        final Logger log = log();
-        final File setFile = new File(mainFile);
+        Logger log = log();
+        File setFile = new File(mainFile);
         if (!setFile.exists()) {
             logMissingDescriptorSetFile(setFile);
             return;
         }
 
         log.debug("Generating rejections from {}", mainFile);
-        final List<FileDescriptorProto> mainFiles = parse(mainFile);
+        List<FileDescriptorProto> mainFiles = parse(mainFile);
         collectAllMessageTypes(mainFiles);
-        final List<RejectionsFile> rejectionFiles = collect(mainFiles);
+        List<RejectionsFile> rejectionFiles = collect(mainFiles);
         doGenerate(rejectionFiles, targetFolder);
     }
 
     private void generateTestRejections(String mainFile, String testFile, String targetFolder) {
-        final Logger log = log();
-        final File setFile = new File(mainFile);
+        Logger log = log();
+        File setFile = new File(mainFile);
         if (!setFile.exists()) {
             logMissingDescriptorSetFile(setFile);
             return;
         }
 
-        final File testSetFile = new File(testFile);
+        File testSetFile = new File(testFile);
         if (!testSetFile.exists()) {
             logMissingDescriptorSetFile(testSetFile);
             return;
@@ -149,12 +149,12 @@ public class RejectionGenPlugin extends SpinePlugin {
 
         log.debug("Generating test rejections from {}", testFile);
 
-        final List<FileDescriptorProto> mainFiles = parse(mainFile);
+        List<FileDescriptorProto> mainFiles = parse(mainFile);
         collectAllMessageTypes(mainFiles);
 
-        final List<FileDescriptorProto> testFiles = parse(testFile);
+        List<FileDescriptorProto> testFiles = parse(testFile);
         collectAllMessageTypes(testFiles);
-        final List<RejectionsFile> rejectionFiles = collect(testFiles);
+        List<RejectionsFile> rejectionFiles = collect(testFiles);
         doGenerate(rejectionFiles, targetFolder);
     }
 
@@ -165,7 +165,7 @@ public class RejectionGenPlugin extends SpinePlugin {
     }
 
     private void doGenerate(Iterable<RejectionsFile> files, String outDir) {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Processing the file descriptors for the rejections {}", files);
         for (RejectionsFile file : files) {
             // We are sure that this is a rejections file because we got them filtered.
@@ -176,7 +176,7 @@ public class RejectionGenPlugin extends SpinePlugin {
     private void generateRejections(RejectionsFile file,
                                            Map<String, String> messageTypeMap,
                                            String rejectionsRootDir) {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Generating rejections from file {}", file.getPath());
 
         if (log.isTraceEnabled()) {
@@ -185,13 +185,13 @@ public class RejectionGenPlugin extends SpinePlugin {
                       SimpleClassName.outerOf(file.getDescriptor()));
         }
 
-        final List<RejectionDeclaration> rejections = file.getRejectionDeclarations();
-        final File outDir = new File(rejectionsRootDir);
+        List<RejectionDeclaration> rejections = file.getRejectionDeclarations();
+        File outDir = new File(rejectionsRootDir);
         for (RejectionDeclaration rejection : rejections) {
             // The name of the generated `ThrowableMessage` will be the same
             // as for the Protobuf message.
             log.debug("Processing rejection '{}'", rejection.getSimpleTypeName());
-            final RejectionWriter writer = new RejectionWriter(rejection, outDir, messageTypeMap);
+            RejectionWriter writer = new RejectionWriter(rejection, outDir, messageTypeMap);
             writer.write();
         }
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/RejectionGenPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/RejectionGenPlugin.java
@@ -174,8 +174,8 @@ public class RejectionGenPlugin extends SpinePlugin {
     }
 
     private void generateRejections(RejectionsFile file,
-                                           Map<String, String> messageTypeMap,
-                                           String rejectionsRootDir) {
+                                    Map<String, String> messageTypeMap,
+                                    String rejectionsRootDir) {
         Logger log = log();
         log.debug("Generating rejections from file {}", file.getPath());
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPlugin.java
@@ -88,9 +88,9 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
 
     @Override
     public void apply(Project project) {
-        final Logger log = log();
+        Logger log = log();
         log.debug("Preparing to generate validating builders.");
-        final Action<Task> mainScopeAction =
+        Action<Task> mainScopeAction =
                 createAction(project,
                              getMainDescriptorSetPath(project),
                              getTargetGenValidatorsRootDir(project),
@@ -101,13 +101,13 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
                          COMPILE_JAVA,
                          GENERATE_PROTO);
 
-        final GradleTask generateValidator =
+        GradleTask generateValidator =
                 newTask(GENERATE_VALIDATING_BUILDERS, mainScopeAction)
                         .insertAfterTask(GENERATE_PROTO)
                         .insertBeforeTask(COMPILE_JAVA)
                         .applyNowTo(project);
         log.debug("Preparing to generate test validating builders.");
-        final Action<Task> testScopeAction =
+        Action<Task> testScopeAction =
                 createAction(project,
                              getTestDescriptorSetPath(project),
                              getTargetTestGenValidatorsRootDir(project),
@@ -117,7 +117,7 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
                          COMPILE_TEST_JAVA,
                          GENERATE_TEST_PROTO);
 
-        final GradleTask generateTestValidator =
+        GradleTask generateTestValidator =
                 newTask(GENERATE_TEST_VALIDATING_BUILDERS, testScopeAction)
                         .insertAfterTask(GENERATE_TEST_PROTO)
                         .insertBeforeTask(COMPILE_TEST_JAVA)
@@ -175,13 +175,13 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
             if (!isGenerateValidatingBuilders(project)) {
                 return;
             }
-            final File setFile = new File(descriptorPath);
+            File setFile = new File(descriptorPath);
             if (!setFile.exists()) {
                 plugin.logMissingDescriptorSetFile(setFile);
             } else {
-                final Indent indent = getIndent(project);
-                final boolean genFromClasspath = isGenerateValidatingBuildersFromClasspath(project);
-                final VBuilderGenerator generator =
+                Indent indent = getIndent(project);
+                boolean genFromClasspath = isGenerateValidatingBuildersFromClasspath(project);
+                VBuilderGenerator generator =
                         new VBuilderGenerator(targetDirPath, protoSrcDirPath, genFromClasspath,
                                               indent);
                 generator.processDescriptorSetFile(setFile);

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPlugin.java
@@ -54,8 +54,8 @@ public class ValidationRulesLookupPlugin extends SpinePlugin {
     public void apply(Project project) {
         logDependingTask(FIND_VALIDATION_RULES, PROCESS_RESOURCES, GENERATE_PROTO);
 
-        final Action<Task> mainScopeAction = mainScopeActionFor(project);
-        final GradleTask findRules =
+        Action<Task> mainScopeAction = mainScopeActionFor(project);
+        GradleTask findRules =
                 newTask(FIND_VALIDATION_RULES, mainScopeAction)
                         .insertAfterTask(GENERATE_PROTO)
                         .insertBeforeTask(PROCESS_RESOURCES)
@@ -63,8 +63,8 @@ public class ValidationRulesLookupPlugin extends SpinePlugin {
 
         logDependingTask(FIND_TEST_VALIDATION_RULES, PROCESS_TEST_RESOURCES, GENERATE_TEST_PROTO);
 
-        final Action<Task> testScopeAction = testScopeActionFor(project);
-        final GradleTask findTestRules =
+        Action<Task> testScopeAction = testScopeActionFor(project);
+        GradleTask findTestRules =
                 newTask(FIND_TEST_VALIDATION_RULES, testScopeAction)
                         .insertAfterTask(GENERATE_TEST_PROTO)
                         .insertBeforeTask(PROCESS_TEST_RESOURCES)
@@ -74,36 +74,36 @@ public class ValidationRulesLookupPlugin extends SpinePlugin {
                     findRules, findTestRules);
     }
 
-    private Action<Task> mainScopeActionFor(final Project project) {
+    private Action<Task> mainScopeActionFor(Project project) {
         log().debug("Initializing the validation lookup for the `main` source code.");
         return new Action<Task>() {
             @Override
             public void execute(Task task) {
-                final String descriptorSetFile = getMainDescriptorSetPath(project);
-                final String targetResourcesDir = getMainTargetGenResourcesDir(project);
+                String descriptorSetFile = getMainDescriptorSetPath(project);
+                String targetResourcesDir = getMainTargetGenResourcesDir(project);
                 processDescriptorSet(descriptorSetFile, targetResourcesDir);
             }
         };
     }
 
-    private Action<Task> testScopeActionFor(final Project project) {
+    private Action<Task> testScopeActionFor(Project project) {
         log().debug("Initializing the validation lookup for the `test` source code.");
         return new Action<Task>() {
             @Override
             public void execute(Task task) {
-                final String descriptorSetPath = getTestDescriptorSetPath(project);
-                final String targetGenResourcesDir = getTestTargetGenResourcesDir(project);
+                String descriptorSetPath = getTestDescriptorSetPath(project);
+                String targetGenResourcesDir = getTestTargetGenResourcesDir(project);
                 processDescriptorSet(descriptorSetPath, targetGenResourcesDir);
             }
         };
     }
 
     private void processDescriptorSet(String descriptorSetFile, String targetDirectory) {
-        final File setFile = new File(descriptorSetFile);
+        File setFile = new File(descriptorSetFile);
         if (!setFile.exists()) {
             logMissingDescriptorSetFile(setFile);
         } else {
-            final File targetDir = new File(targetDirectory);
+            File targetDir = new File(targetDirectory);
             ValidationRulesLookup.processDescriptorSetFile(setFile, targetDir);
         }
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/EnumAnnotatorShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/EnumAnnotatorShould.java
@@ -50,9 +50,9 @@ public class EnumAnnotatorShould {
 
     @Test
     public void not_annotate_enum_without_option() {
-        final EnumDescriptorProto descriptorWithoutOption = Language.getDescriptor()
+        EnumDescriptorProto descriptorWithoutOption = Language.getDescriptor()
                                                                     .toProto();
-        final boolean shouldAnnotate = annotator.shouldAnnotate(descriptorWithoutOption);
+        boolean shouldAnnotate = annotator.shouldAnnotate(descriptorWithoutOption);
         assertFalse(shouldAnnotate);
     }
 }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/EnumAnnotatorShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/EnumAnnotatorShould.java
@@ -51,7 +51,7 @@ public class EnumAnnotatorShould {
     @Test
     public void not_annotate_enum_without_option() {
         EnumDescriptorProto descriptorWithoutOption = Language.getDescriptor()
-                                                                    .toProto();
+                                                              .toProto();
         boolean shouldAnnotate = annotator.shouldAnnotate(descriptorWithoutOption);
         assertFalse(shouldAnnotate);
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/FieldAnnotatorShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/FieldAnnotatorShould.java
@@ -36,25 +36,25 @@ public class FieldAnnotatorShould {
 
     @Test
     public void annotate_accessor_for_field() {
-        final String fieldName = "FieldName";
-        final String methodName = getAccessorName(fieldName);
+        String fieldName = "FieldName";
+        String methodName = getAccessorName(fieldName);
         assertTrue(shouldAnnotateMethod(methodName, fieldName, Collections.<String>emptyList()));
     }
 
     @Test
     public void not_annotate_accessor_for_field_that_does_not_require_it() {
-        final String requiresAnnotation = "GoodBoy";
-        final String notRequiresAnnotation = requiresAnnotation + "AdditionalPart";
-        final String methodName = getAccessorName(notRequiresAnnotation);
+        String requiresAnnotation = "GoodBoy";
+        String notRequiresAnnotation = requiresAnnotation + "AdditionalPart";
+        String methodName = getAccessorName(notRequiresAnnotation);
         assertFalse(shouldAnnotateMethod(methodName, requiresAnnotation,
                                          singleton(notRequiresAnnotation)));
     }
 
     @Test
     public void filter_fields_that_does_not_require_annotation_by_name_length() {
-        final String requiresAnnotation = "FriendList";
-        final String notRequiresAnnotation = requiresAnnotation.substring(0, 4);
-        final String methodName = getAccessorName(requiresAnnotation);
+        String requiresAnnotation = "FriendList";
+        String notRequiresAnnotation = requiresAnnotation.substring(0, 4);
+        String methodName = getAccessorName(requiresAnnotation);
         assertTrue(shouldAnnotateMethod(methodName, requiresAnnotation,
                                         singleton(notRequiresAnnotation)));
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/FieldAnnotationCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/FieldAnnotationCheck.java
@@ -64,9 +64,10 @@ public class FieldAnnotationCheck implements SourceCheck {
 
     private void checkAccessorsAnnotation(JavaClassSource message) {
         String fieldName = FieldName.of(fieldDescriptor)
-                                          .toCamelCase();
+                                    .toCamelCase();
         for (MethodSource method : message.getMethods()) {
-            if (method.isPublic() && method.getName().contains(fieldName)) {
+            if (method.isPublic() && method.getName()
+                                           .contains(fieldName)) {
                 AnnotationSource annotation = findSpiAnnotation(method);
                 if (shouldBeAnnotated) {
                     assertNotNull(annotation);

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/FieldAnnotationCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/FieldAnnotationCheck.java
@@ -55,19 +55,19 @@ public class FieldAnnotationCheck implements SourceCheck {
     @Override
     public Void apply(@Nullable AbstractJavaSource<JavaClassSource> input) {
         checkNotNull(input);
-        final JavaClassSource message = (JavaClassSource) input;
-        final JavaClassSource messageBuilder = getBuilder(message);
+        JavaClassSource message = (JavaClassSource) input;
+        JavaClassSource messageBuilder = getBuilder(message);
         checkAccessorsAnnotation(message);
         checkAccessorsAnnotation(messageBuilder);
         return null;
     }
 
     private void checkAccessorsAnnotation(JavaClassSource message) {
-        final String fieldName = FieldName.of(fieldDescriptor)
+        String fieldName = FieldName.of(fieldDescriptor)
                                           .toCamelCase();
         for (MethodSource method : message.getMethods()) {
             if (method.isPublic() && method.getName().contains(fieldName)) {
-                final AnnotationSource annotation = findSpiAnnotation(method);
+                AnnotationSource annotation = findSpiAnnotation(method);
                 if (shouldBeAnnotated) {
                     assertNotNull(annotation);
                 } else {
@@ -78,8 +78,8 @@ public class FieldAnnotationCheck implements SourceCheck {
     }
 
     private static JavaClassSource getBuilder(JavaSource messageSource) {
-        final TypeHolder messageType = (TypeHolder) messageSource;
-        final JavaType builderType = messageType.getNestedType(ofBuilder().value());
+        TypeHolder messageType = (TypeHolder) messageSource;
+        JavaType builderType = messageType.getNestedType(ofBuilder().value());
         return (JavaClassSource) builderType;
     }
 }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/MainDefinitionAnnotationCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/MainDefinitionAnnotationCheck.java
@@ -45,7 +45,7 @@ public class MainDefinitionAnnotationCheck implements SourceCheck {
     @Override
     public Void apply(@Nullable AbstractJavaSource<JavaClassSource> input) {
         checkNotNull(input);
-        final AnnotationSource annotationSource = findSpiAnnotation(input);
+        AnnotationSource annotationSource = findSpiAnnotation(input);
         if (shouldBeAnnotated) {
             assertNotNull(annotationSource);
         } else {

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/NestedTypeFieldsAnnotationCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/NestedTypeFieldsAnnotationCheck.java
@@ -50,7 +50,7 @@ public class NestedTypeFieldsAnnotationCheck implements SourceCheck {
     public Void apply(@Nullable AbstractJavaSource<JavaClassSource> outerClass) {
         checkNotNull(outerClass);
         for (DescriptorProtos.FieldDescriptorProto fieldDescriptor : messageDescriptor.getFieldList()) {
-            final AbstractJavaSource nestedType =
+            AbstractJavaSource nestedType =
                     (AbstractJavaSource) outerClass.getNestedType(messageDescriptor.getName());
             new FieldAnnotationCheck(fieldDescriptor, shouldBeAnnotated).apply(nestedType);
         }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/NestedTypesAnnotationCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/NestedTypesAnnotationCheck.java
@@ -47,7 +47,7 @@ public class NestedTypesAnnotationCheck implements SourceCheck {
     public Void apply(@Nullable AbstractJavaSource<JavaClassSource> outerClass) {
         checkNotNull(outerClass);
         for (JavaSource<?> nestedType : outerClass.getNestedTypes()) {
-            final AnnotationSource annotation = findSpiAnnotation(nestedType);
+            AnnotationSource annotation = findSpiAnnotation(nestedType);
             if (shouldBeAnnotated) {
                 assertNotNull(annotation);
             } else {

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/enrichment/TypeNameParserShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/enrichment/TypeNameParserShould.java
@@ -43,22 +43,22 @@ public class TypeNameParserShould {
 
     @Test
     public void add_package_prefix_to_unqualified_type() {
-        final TypeName parsedTypes = parser.parseTypeName(MESSAGE_NAME);
+        TypeName parsedTypes = parser.parseTypeName(MESSAGE_NAME);
         assertEquals(PACKAGE_PREFIX + MESSAGE_NAME, parsedTypes.value());
     }
 
     @Test
     public void not_add_package_prefix_to_fully_qualified_type() {
-        final String fqn = PACKAGE_PREFIX + MESSAGE_NAME;
-        final TypeName parsedType = parser.parseTypeName(fqn);
+        String fqn = PACKAGE_PREFIX + MESSAGE_NAME;
+        TypeName parsedType = parser.parseTypeName(fqn);
         assertEquals(fqn, parsedType.value());
     }
 
     @Test
     public void return_empty_collection_if_option_is_not_present() {
-        final DescriptorProto definitionWithoutOption = StringValue.getDescriptor()
+        DescriptorProto definitionWithoutOption = StringValue.getDescriptor()
                                                                    .toProto();
-        final Collection<TypeName> result = parser.parse(definitionWithoutOption);
+        Collection<TypeName> result = parser.parse(definitionWithoutOption);
         assertTrue(result.isEmpty());
     }
 }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/enrichment/TypeNameParserShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/enrichment/TypeNameParserShould.java
@@ -57,7 +57,7 @@ public class TypeNameParserShould {
     @Test
     public void return_empty_collection_if_option_is_not_present() {
         DescriptorProto definitionWithoutOption = StringValue.getDescriptor()
-                                                                   .toProto();
+                                                             .toProto();
         Collection<TypeName> result = parser.parse(definitionWithoutOption);
         assertTrue(result.isEmpty());
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/rejection/RootDocReceiver.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/rejection/RootDocReceiver.java
@@ -65,7 +65,7 @@ public class RootDocReceiver extends Standard {
     }
 
     public static void main(String[] args) {
-        final String name = RootDocReceiver.class.getName();
+        String name = RootDocReceiver.class.getName();
         Main.execute(name, name, args);
     }
 

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/MethodConstructorsShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/MethodConstructorsShould.java
@@ -39,25 +39,25 @@ public class MethodConstructorsShould {
 
     @Test
     public void return_constructed_descriptor_statement() {
-        final String result = createDescriptorStatement(0, ClassName.get(getClass()));
+        String result = createDescriptorStatement(0, ClassName.get(getClass()));
         assertNotNull(result);
     }
 
     @Test
     public void return_constructed_validate_statement(){
-        final String result = createValidateStatement(TEST_VALUE);
+        String result = createValidateStatement(TEST_VALUE);
         assertNotNull(result);
     }
 
     @Test
     public void return_constructed_converted_value_statement() {
-        final String result = createConvertSingularValue(TEST_VALUE);
+        String result = createConvertSingularValue(TEST_VALUE);
         assertNotNull(result);
     }
 
     @Test
     public void return_validate_statement() {
-        final String result = createConvertSingularValue(TEST_VALUE);
+        String result = createConvertSingularValue(TEST_VALUE);
         assertNotNull(result);
     }
 

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/MethodConstructorsShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/MethodConstructorsShould.java
@@ -44,7 +44,7 @@ public class MethodConstructorsShould {
     }
 
     @Test
-    public void return_constructed_validate_statement(){
+    public void return_constructed_validate_statement() {
         String result = createValidateStatement(TEST_VALUE);
         assertNotNull(result);
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ExtensionShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ExtensionShould.java
@@ -139,7 +139,7 @@ public class ExtensionShould {
     }
 
     @Test
-    public void return_targetGenValidatorsRootDir_if_not_set(){
+    public void return_targetGenValidatorsRootDir_if_not_set() {
         String dir = Extension.getTargetGenValidatorsRootDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
@@ -155,7 +155,7 @@ public class ExtensionShould {
     }
 
     @Test
-    public void return_targetTestGenValidatorsRootDir_if_not_set(){
+    public void return_targetTestGenValidatorsRootDir_if_not_set() {
         String dir = Extension.getTargetTestGenValidatorsRootDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
@@ -213,9 +213,9 @@ public class ExtensionShould {
         File spineDir = defaultProject.tempArtifacts();
         assertTrue(spineDir.mkdir());
         String generatedDir = defaultProject.generated()
-                                                  .getPath()
-                                                  .toFile()
-                                                  .getCanonicalPath();
+                                            .getPath()
+                                            .toFile()
+                                            .getCanonicalPath();
 
         List<String> dirsToClean = Extension.getDirsToClean(project);
 

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ExtensionShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ExtensionShould.java
@@ -59,7 +59,7 @@ public class ExtensionShould {
 
     @Test
     public void return_default_mainTargetGenResourcesDir_if_not_set() {
-        final String dir = Extension.getMainTargetGenResourcesDir(project);
+        String dir = Extension.getMainTargetGenResourcesDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -69,14 +69,14 @@ public class ExtensionShould {
 
         spineProtobuf().mainTargetGenResourcesDir = newUuid();
 
-        final String dir = Extension.getMainTargetGenResourcesDir(project);
+        String dir = Extension.getMainTargetGenResourcesDir(project);
 
         assertEquals(spineProtobuf().mainTargetGenResourcesDir, dir);
     }
 
     @Test
     public void return_default_testTargetGenResourcesDir_if_not_set() {
-        final String dir = Extension.getTestTargetGenResourcesDir(project);
+        String dir = Extension.getTestTargetGenResourcesDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -85,14 +85,14 @@ public class ExtensionShould {
     public void return_testTargetGenResourcesDir_if_set() {
         spineProtobuf().testTargetGenResourcesDir = newUuid();
 
-        final String dir = Extension.getTestTargetGenResourcesDir(project);
+        String dir = Extension.getTestTargetGenResourcesDir(project);
 
         assertEquals(spineProtobuf().testTargetGenResourcesDir, dir);
     }
 
     @Test
     public void return_default_mainDescriptorSetPath_if_not_set() {
-        final String dir = Extension.getMainDescriptorSetPath(project);
+        String dir = Extension.getMainDescriptorSetPath(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -101,14 +101,14 @@ public class ExtensionShould {
     public void return_mainDescriptorSetPath_if_set() {
         spineProtobuf().mainDescriptorSetPath = newUuid();
 
-        final String dir = Extension.getMainDescriptorSetPath(project);
+        String dir = Extension.getMainDescriptorSetPath(project);
 
         assertEquals(spineProtobuf().mainDescriptorSetPath, dir);
     }
 
     @Test
     public void return_default_testDescriptorSetPath_if_not_set() {
-        final String dir = Extension.getTestDescriptorSetPath(project);
+        String dir = Extension.getTestDescriptorSetPath(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -117,14 +117,14 @@ public class ExtensionShould {
     public void return_testDescriptorSetPath_if_set() {
         spineProtobuf().testDescriptorSetPath = newUuid();
 
-        final String dir = Extension.getTestDescriptorSetPath(project);
+        String dir = Extension.getTestDescriptorSetPath(project);
 
         assertEquals(spineProtobuf().testDescriptorSetPath, dir);
     }
 
     @Test
     public void return_default_targetGenRejectionsRootDir_if_not_set() {
-        final String dir = Extension.getTargetGenRejectionsRootDir(project);
+        String dir = Extension.getTargetGenRejectionsRootDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -133,14 +133,14 @@ public class ExtensionShould {
     public void return_targetGenRejectionsRootDir_if_set() {
         spineProtobuf().targetGenRejectionsRootDir = newUuid();
 
-        final String dir = Extension.getTargetGenRejectionsRootDir(project);
+        String dir = Extension.getTargetGenRejectionsRootDir(project);
 
         assertEquals(spineProtobuf().targetGenRejectionsRootDir, dir);
     }
 
     @Test
     public void return_targetGenValidatorsRootDir_if_not_set(){
-        final String dir = Extension.getTargetGenValidatorsRootDir(project);
+        String dir = Extension.getTargetGenValidatorsRootDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -149,14 +149,14 @@ public class ExtensionShould {
     public void return_targetTestGenValidatorsRootDir_if_set() {
         spineProtobuf().targetTestGenVBuildersRootDir = newUuid();
 
-        final String dir = Extension.getTargetTestGenValidatorsRootDir(project);
+        String dir = Extension.getTargetTestGenValidatorsRootDir(project);
 
         assertEquals(spineProtobuf().targetTestGenVBuildersRootDir, dir);
     }
 
     @Test
     public void return_targetTestGenValidatorsRootDir_if_not_set(){
-        final String dir = Extension.getTargetTestGenValidatorsRootDir(project);
+        String dir = Extension.getTargetTestGenValidatorsRootDir(project);
 
         assertNotEmptyAndIsInProjectDir(dir);
     }
@@ -165,14 +165,14 @@ public class ExtensionShould {
     public void return_targetGenValidatorsRootDir_if_set() {
         spineProtobuf().targetGenVBuildersRootDir = newUuid();
 
-        final String dir = Extension.getTargetGenValidatorsRootDir(project);
+        String dir = Extension.getTargetGenValidatorsRootDir(project);
 
         assertEquals(spineProtobuf().targetGenVBuildersRootDir, dir);
     }
 
     @Test
     public void return_default_dirsToClean_if_not_set() {
-        final List<String> actualDirs = Extension.getDirsToClean(project);
+        List<String> actualDirs = Extension.getDirsToClean(project);
 
         assertEquals(1, actualDirs.size());
         assertNotEmptyAndIsInProjectDir(actualDirs.get(0));
@@ -182,7 +182,7 @@ public class ExtensionShould {
     public void return_single_dirToClean_if_set() {
         spineProtobuf().dirToClean = newUuid();
 
-        final List<String> actualDirs = Extension.getDirsToClean(project);
+        List<String> actualDirs = Extension.getDirsToClean(project);
 
         assertEquals(1, actualDirs.size());
         assertEquals(spineProtobuf().dirToClean, actualDirs.get(0));
@@ -192,7 +192,7 @@ public class ExtensionShould {
     public void return_dirsToClean_list_if_array_is_set() {
         spineProtobuf().dirsToClean = newArrayList(newUuid(), newUuid());
 
-        final List<String> actualDirs = Extension.getDirsToClean(project);
+        List<String> actualDirs = Extension.getDirsToClean(project);
 
         assertEquals(spineProtobuf().dirsToClean, actualDirs);
     }
@@ -202,22 +202,22 @@ public class ExtensionShould {
         spineProtobuf().dirsToClean = newArrayList(newUuid(), newUuid());
         spineProtobuf().dirToClean = newUuid();
 
-        final List<String> actualDirs = Extension.getDirsToClean(project);
+        List<String> actualDirs = Extension.getDirsToClean(project);
 
         assertEquals(spineProtobuf().dirsToClean, actualDirs);
     }
 
     @Test
     public void include_spine_dir_in_dirsToClean_if_exists() throws IOException {
-        final DefaultProject defaultProject = DefaultProject.at(projectDir.getRoot());
-        final File spineDir = defaultProject.tempArtifacts();
+        DefaultProject defaultProject = DefaultProject.at(projectDir.getRoot());
+        File spineDir = defaultProject.tempArtifacts();
         assertTrue(spineDir.mkdir());
-        final String generatedDir = defaultProject.generated()
+        String generatedDir = defaultProject.generated()
                                                   .getPath()
                                                   .toFile()
                                                   .getCanonicalPath();
 
-        final List<String> dirsToClean = Extension.getDirsToClean(project);
+        List<String> dirsToClean = Extension.getDirsToClean(project);
 
         assertThat(dirsToClean,
                    containsInAnyOrder(spineDir.getCanonicalPath(), generatedDir)

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ModelCompilerPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ModelCompilerPluginShould.java
@@ -59,7 +59,7 @@ public class ModelCompilerPluginShould {
 
     @Before
     public void setUp() {
-        final Project project = newProject();
+        Project project = newProject();
         project.getPluginManager()
                .apply(SPINE_PROTOBUF_PLUGIN_ID);
         tasks = project.getTasks();
@@ -67,7 +67,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void apply_to_project() {
-        final Project project = newProject();
+        Project project = newProject();
         project.getPluginManager()
                .apply(SPINE_PROTOBUF_PLUGIN_ID);
     }
@@ -80,7 +80,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_generateRejections() {
-        final Task genRejections = task(GENERATE_REJECTIONS);
+        Task genRejections = task(GENERATE_REJECTIONS);
         assertNotNull(genRejections);
         assertTrue(dependsOn(genRejections, GENERATE_PROTO));
         assertTrue(dependsOn(task(COMPILE_JAVA), genRejections));
@@ -88,7 +88,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_generateTestRejections() {
-        final Task genTestRejections = task(GENERATE_TEST_REJECTIONS);
+        Task genTestRejections = task(GENERATE_TEST_REJECTIONS);
         assertNotNull(genTestRejections);
         assertTrue(dependsOn(genTestRejections, GENERATE_TEST_PROTO));
         assertTrue(dependsOn(task(COMPILE_TEST_JAVA), genTestRejections));
@@ -96,7 +96,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_findEnrichments() {
-        final Task find = task(FIND_ENRICHMENTS);
+        Task find = task(FIND_ENRICHMENTS);
         assertNotNull(find);
         assertTrue(dependsOn(find, COMPILE_JAVA));
         assertTrue(dependsOn(task(PROCESS_RESOURCES), find));
@@ -104,7 +104,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_findTestEnrichments() {
-        final Task find = task(FIND_TEST_ENRICHMENTS);
+        Task find = task(FIND_TEST_ENRICHMENTS);
         assertNotNull(find);
         assertTrue(dependsOn(find, COMPILE_TEST_JAVA));
         assertTrue(dependsOn(task(PROCESS_TEST_RESOURCES), find));
@@ -112,7 +112,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_findValidationRules() {
-        final Task find = task(FIND_VALIDATION_RULES);
+        Task find = task(FIND_VALIDATION_RULES);
         assertNotNull(find);
         assertTrue(dependsOn(find, GENERATE_PROTO));
         assertTrue(dependsOn(task(PROCESS_RESOURCES), find));
@@ -120,7 +120,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_findTestValidationRules() {
-        final Task find = task(FIND_TEST_VALIDATION_RULES);
+        Task find = task(FIND_TEST_VALIDATION_RULES);
         assertNotNull(find);
         assertTrue(dependsOn(find, GENERATE_TEST_PROTO));
         assertTrue(dependsOn(task(PROCESS_TEST_RESOURCES), find));
@@ -128,7 +128,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_generation_validating_builders() {
-        final Task genValidatingBuilders = task(GENERATE_VALIDATING_BUILDERS);
+        Task genValidatingBuilders = task(GENERATE_VALIDATING_BUILDERS);
         assertNotNull(genValidatingBuilders);
         assertTrue(dependsOn(genValidatingBuilders, GENERATE_PROTO));
         assertTrue(dependsOn(task(COMPILE_JAVA), genValidatingBuilders));
@@ -136,7 +136,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_generation_test_validating_builders() {
-        final Task genTestValidatingBuidlers = task(GENERATE_TEST_VALIDATING_BUILDERS);
+        Task genTestValidatingBuidlers = task(GENERATE_TEST_VALIDATING_BUILDERS);
         assertNotNull(genTestValidatingBuidlers);
         assertTrue(dependsOn(genTestValidatingBuidlers, GENERATE_TEST_PROTO));
         assertTrue(dependsOn(task(COMPILE_TEST_JAVA), genTestValidatingBuidlers));
@@ -144,7 +144,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_annotateProto() {
-        final Task annotateProto = task(ANNOTATE_PROTO);
+        Task annotateProto = task(ANNOTATE_PROTO);
         assertNotNull(annotateProto);
         assertTrue(dependsOn(annotateProto, GENERATE_PROTO));
         assertTrue(dependsOn(task(COMPILE_JAVA), annotateProto));
@@ -152,7 +152,7 @@ public class ModelCompilerPluginShould {
 
     @Test
     public void add_task_annotateTestProto() {
-        final Task annotateTestProto = task(ANNOTATE_TEST_PROTO);
+        Task annotateTestProto = task(ANNOTATE_TEST_PROTO);
         assertNotNull(annotateTestProto);
         assertTrue(dependsOn(annotateTestProto, GENERATE_TEST_PROTO));
         assertTrue(dependsOn(task(COMPILE_TEST_JAVA), annotateTestProto));

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
@@ -50,14 +50,14 @@ public class RejectionGenPluginShould {
     @Test
     public void compile_generated_rejections() {
         Collection<String> files = Arrays.asList("test_rejections.proto",
-                                                       "outer_class_by_file_name_rejections.proto",
-                                                       "outer_class_set_rejections.proto",
-                                                       "deps/deps.proto");
+                                                 "outer_class_by_file_name_rejections.proto",
+                                                 "outer_class_set_rejections.proto",
+                                                 "deps/deps.proto");
         GradleProject project = GradleProject.newBuilder()
-                                                   .setProjectName("rejections-gen-plugin-test")
-                                                   .setProjectFolder(testProjectDir.getRoot())
-                                                   .addProtoFiles(files)
-                                                   .build();
+                                             .setProjectName("rejections-gen-plugin-test")
+                                             .setProjectFolder(testProjectDir.getRoot())
+                                             .addProtoFiles(files)
+                                             .build();
         project.executeTask(COMPILE_JAVA);
     }
 
@@ -68,7 +68,7 @@ public class RejectionGenPluginShould {
         project.executeTask(COMPILE_JAVA);
 
         RootDoc root = RootDocReceiver.getRootDoc(testProjectDir,
-                                                        rejectionsJavadocSourceName());
+                                                  rejectionsJavadocSourceName());
         ClassDoc rejectionDoc = root.classes()[0];
         ConstructorDoc rejectionCtorDoc = rejectionDoc.constructors()[0];
 

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/RejectionGenPluginShould.java
@@ -49,11 +49,11 @@ public class RejectionGenPluginShould {
 
     @Test
     public void compile_generated_rejections() {
-        final Collection<String> files = Arrays.asList("test_rejections.proto",
+        Collection<String> files = Arrays.asList("test_rejections.proto",
                                                        "outer_class_by_file_name_rejections.proto",
                                                        "outer_class_set_rejections.proto",
                                                        "deps/deps.proto");
-        final GradleProject project = GradleProject.newBuilder()
+        GradleProject project = GradleProject.newBuilder()
                                                    .setProjectName("rejections-gen-plugin-test")
                                                    .setProjectFolder(testProjectDir.getRoot())
                                                    .addProtoFiles(files)
@@ -64,13 +64,13 @@ public class RejectionGenPluginShould {
     @Test
     public void generate_rejection_javadoc() {
 
-        final GradleProject project = newProjectWithRejectionsJavadoc(testProjectDir);
+        GradleProject project = newProjectWithRejectionsJavadoc(testProjectDir);
         project.executeTask(COMPILE_JAVA);
 
-        final RootDoc root = RootDocReceiver.getRootDoc(testProjectDir,
+        RootDoc root = RootDocReceiver.getRootDoc(testProjectDir,
                                                         rejectionsJavadocSourceName());
-        final ClassDoc rejectionDoc = root.classes()[0];
-        final ConstructorDoc rejectionCtorDoc = rejectionDoc.constructors()[0];
+        ClassDoc rejectionDoc = root.classes()[0];
+        ConstructorDoc rejectionCtorDoc = rejectionDoc.constructors()[0];
 
         assertEquals(getExpectedClassComment(), rejectionDoc.getRawCommentText());
         assertEquals(getExpectedCtorComment(), rejectionCtorDoc.getRawCommentText());

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
@@ -63,7 +63,7 @@ public class SpineProtocShould {
     public void create_spine_directory() {
         project.executeTask(BUILD);
         File spineDirPath = DefaultProject.at(projectDir.getRoot())
-                                                .tempArtifacts();
+                                          .tempArtifacts();
         assertTrue(spineDirPath.exists());
     }
 }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/SpineProtocShould.java
@@ -62,7 +62,7 @@ public class SpineProtocShould {
     @Test
     public void create_spine_directory() {
         project.executeTask(BUILD);
-        final File spineDirPath = DefaultProject.at(projectDir.getRoot())
+        File spineDirPath = DefaultProject.at(projectDir.getRoot())
                                                 .tempArtifacts();
         assertTrue(spineDirPath.exists());
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
@@ -79,9 +79,9 @@ public class ValidationRulesLookupPluginShould {
 
     private Map<String, String> loadProperties() {
         PropertyFile propFile = PropertyFile.of(ValidationRules.fileName())
-                                                  .at(DefaultProject.at(testProjectDir.getRoot())
-                                                                    .generated()
-                                                                    .mainResources());
+                                            .at(DefaultProject.at(testProjectDir.getRoot())
+                                                              .generated()
+                                                              .mainResources());
         Map<String, String> result = propFile.load();
         return result;
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
@@ -66,23 +66,23 @@ public class ValidationRulesLookupPluginShould {
 
     @Test
     public void findNestedValidationRules() {
-        final String file = "nested_validation_rule.proto";
-        final GradleProject project = newProjectWithFile(file, NESTED_VALIDATION_RULE_PROTO);
+        String file = "nested_validation_rule.proto";
+        GradleProject project = newProjectWithFile(file, NESTED_VALIDATION_RULE_PROTO);
         project.executeTask(FIND_VALIDATION_RULES);
 
-        final String expectedKey = PROTO_FILE_PACKAGE + DOT +
+        String expectedKey = PROTO_FILE_PACKAGE + DOT +
                                    OUTER_MESSAGE_TYPE + DOT +
                                    VALIDATION_RULE_TYPE;
-        final String value = loadProperties().get(expectedKey);
+        String value = loadProperties().get(expectedKey);
         assertEquals(VALIDATION_TARGET, value);
     }
 
     private Map<String, String> loadProperties() {
-        final PropertyFile propFile = PropertyFile.of(ValidationRules.fileName())
+        PropertyFile propFile = PropertyFile.of(ValidationRules.fileName())
                                                   .at(DefaultProject.at(testProjectDir.getRoot())
                                                                     .generated()
                                                                     .mainResources());
-        final Map<String, String> result = propFile.load();
+        Map<String, String> result = propFile.load();
         return result;
     }
 

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/ModelCompilerTestEnv.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/ModelCompilerTestEnv.java
@@ -57,7 +57,7 @@ public class ModelCompilerTestEnv {
      * @param projectDir {@link Project#getProjectDir() Project.getProjectDir()} of the project
      */
     public static Project newProject(File projectDir) {
-        final Project project = ProjectBuilder.builder()
+        Project project = ProjectBuilder.builder()
                                               .withProjectDir(projectDir)
                                               .build();
         project.getPluginManager()
@@ -68,7 +68,7 @@ public class ModelCompilerTestEnv {
     }
 
     public static String newUuid() {
-        final String result = UUID.randomUUID()
+        String result = UUID.randomUUID()
                                   .toString();
         return result;
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/ModelCompilerTestEnv.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/ModelCompilerTestEnv.java
@@ -58,8 +58,8 @@ public class ModelCompilerTestEnv {
      */
     public static Project newProject(File projectDir) {
         Project project = ProjectBuilder.builder()
-                                              .withProjectDir(projectDir)
-                                              .build();
+                                        .withProjectDir(projectDir)
+                                        .build();
         project.getPluginManager()
                .apply("java");
         project.task(GENERATE_PROTO.getValue());
@@ -69,7 +69,7 @@ public class ModelCompilerTestEnv {
 
     public static String newUuid() {
         String result = UUID.randomUUID()
-                                  .toString();
+                            .toString();
         return result;
     }
 }

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
@@ -64,7 +64,7 @@ public class RejectionTestEnv {
     }
 
     public static String rejectionsJavadocSourceName() {
-        final Path fileName = DefaultProject.at(Paths.get("/"))
+        Path fileName = DefaultProject.at(Paths.get("/"))
                                             .generated()
                                             .mainSpine()
                                             .resolve(JAVA_PACKAGE.toDirectory())
@@ -102,10 +102,10 @@ public class RejectionTestEnv {
     }
 
     public static String getExpectedCtorComment() {
-        final String param = " @param ";
-        final String firstFieldJavaName = FieldName.of(FIRST_FIELD_NAME)
+        String param = " @param ";
+        String firstFieldJavaName = FieldName.of(FIRST_FIELD_NAME)
                                                    .javaCase();
-        final String secondFieldJavaName = FieldName.of(SECOND_FIELD_NAME)
+        String secondFieldJavaName = FieldName.of(SECOND_FIELD_NAME)
                                                     .javaCase();
         return " Creates a new instance." + JAVADOC_LINE_SEPARATOR + JAVADOC_LINE_SEPARATOR
                 + param + firstFieldJavaName + "                " + FIRST_FIELD_COMMENT

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/given/RejectionTestEnv.java
@@ -65,10 +65,10 @@ public class RejectionTestEnv {
 
     public static String rejectionsJavadocSourceName() {
         Path fileName = DefaultProject.at(Paths.get("/"))
-                                            .generated()
-                                            .mainSpine()
-                                            .resolve(JAVA_PACKAGE.toDirectory())
-                                            .resolve(REJECTION_FILE_NAME.value());
+                                      .generated()
+                                      .mainSpine()
+                                      .resolve(JAVA_PACKAGE.toDirectory())
+                                      .resolve(REJECTION_FILE_NAME.value());
         return fileName.toString();
     }
 
@@ -104,9 +104,9 @@ public class RejectionTestEnv {
     public static String getExpectedCtorComment() {
         String param = " @param ";
         String firstFieldJavaName = FieldName.of(FIRST_FIELD_NAME)
-                                                   .javaCase();
+                                             .javaCase();
         String secondFieldJavaName = FieldName.of(SECOND_FIELD_NAME)
-                                                    .javaCase();
+                                              .javaCase();
         return " Creates a new instance." + JAVADOC_LINE_SEPARATOR + JAVADOC_LINE_SEPARATOR
                 + param + firstFieldJavaName + "                " + FIRST_FIELD_COMMENT
                 + JAVADOC_LINE_SEPARATOR


### PR DESCRIPTION
This PR provides the following changes for the `model-compiler` module:

1. The `final` keyword on local variables was removed;
2. Guava's `Optional` was replaced with JDK 8 `Optional`.