### PR TITLE
Replacement of optional for the `javadoc-prettifier` module

### DIFF
--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/BacktickFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/BacktickFormatting.java
@@ -55,14 +55,14 @@ class BacktickFormatting extends LineFormatting {
     @Override
     String formatLine(String line) {
         // Double the line size to avoid possible memory reallocation.
-        final StringBuffer buffer = new StringBuffer(line.length() * 2);
+        StringBuffer buffer = new StringBuffer(line.length() * 2);
 
-        final Matcher matcher = PATTERN_TEXT_IN_BACKTICKS.matcher(line);
+        Matcher matcher = PATTERN_TEXT_IN_BACKTICKS.matcher(line);
         while (matcher.find()) {
-            final String partToFormat = matcher.group();
-            final String partWithoutBackticks = PATTERN_BACKTICK.matcher(partToFormat)
+            String partToFormat = matcher.group();
+            String partWithoutBackticks = PATTERN_BACKTICK.matcher(partToFormat)
                                                                 .replaceAll("");
-            final String replacement = wrapWithCodeTag(partWithoutBackticks);
+            String replacement = wrapWithCodeTag(partWithoutBackticks);
             matcher.appendReplacement(buffer, quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/BacktickFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/BacktickFormatting.java
@@ -61,7 +61,7 @@ class BacktickFormatting extends LineFormatting {
         while (matcher.find()) {
             String partToFormat = matcher.group();
             String partWithoutBackticks = PATTERN_BACKTICK.matcher(partToFormat)
-                                                                .replaceAll("");
+                                                          .replaceAll("");
             String replacement = wrapWithCodeTag(partWithoutBackticks);
             matcher.appendReplacement(buffer, quoteReplacement(replacement));
         }

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/Extension.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/Extension.java
@@ -59,7 +59,7 @@ public class Extension {
      * @return the absolute path to the main directory
      */
     static String getAbsoluteMainGenProtoDir(Project project) {
-        final String mainGenProtoDir = getExtension(project).mainGenProtoDir;
+        String mainGenProtoDir = getExtension(project).mainGenProtoDir;
         checkExtensionField(mainGenProtoDir, "mainGenProtoDir");
         return rootPath(project) + File.separator + mainGenProtoDir;
     }
@@ -71,7 +71,7 @@ public class Extension {
      * @return the absolute path to the test directory
      */
     static String getAbsoluteTestGenProtoDir(Project project) {
-        final String testGenProtoDir = getExtension(project).testGenProtoDir;
+        String testGenProtoDir = getExtension(project).testGenProtoDir;
         checkExtensionField(testGenProtoDir, "testGenProtoDir");
         return rootPath(project) + File.separator + testGenProtoDir;
     }
@@ -88,7 +88,7 @@ public class Extension {
 
     private static void checkExtensionField(@Nullable String value, String name) {
         if (value == null) {
-            final String errMSg = format("%s.%s was not set.", PROTO_JAVADOC_EXTENSION_NAME, name);
+            String errMSg = format("%s.%s was not set.", PROTO_JAVADOC_EXTENSION_NAME, name);
             throw new IllegalStateException(errMSg);
         }
     }

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/JavadocFormatter.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/JavadocFormatter.java
@@ -20,14 +20,13 @@
 
 package io.spine.tools.protodoc;
 
-import com.google.common.base.Optional;
-
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static java.lang.System.lineSeparator;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -103,13 +102,13 @@ class JavadocFormatter {
      *
      * @param reader the reader for the file
      * @return the {@code Optional} of the next part
-     *         or {@code Optional.absent()} if if the end of the stream has been reached
+     *         or {@code Optional.empty()} if if the end of the stream has been reached
      * @throws IOException if an I/O error occurred during reading
      */
     private Optional<String> getNextPart(BufferedReader reader) throws IOException {
         String firstLine = reader.readLine();
         if (firstLine == null) {
-            return Optional.absent();
+            return Optional.empty();
         }
 
         if (!isJavadocBeginning(firstLine)) {

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/JavadocFormatter.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/JavadocFormatter.java
@@ -78,8 +78,8 @@ class JavadocFormatter {
             return;
         }
 
-        final Path folder = path.getParent();
-        final Path tempPath = folder.resolve(TEMP_FILE_NAME);
+        Path folder = path.getParent();
+        Path tempPath = folder.resolve(TEMP_FILE_NAME);
 
         try (BufferedReader reader = newBufferedReader(path, UTF_8);
              BufferedWriter writer = newBufferedWriter(tempPath, UTF_8)) {
@@ -107,7 +107,7 @@ class JavadocFormatter {
      * @throws IOException if an I/O error occurred during reading
      */
     private Optional<String> getNextPart(BufferedReader reader) throws IOException {
-        final String firstLine = reader.readLine();
+        String firstLine = reader.readLine();
         if (firstLine == null) {
             return Optional.absent();
         }
@@ -116,14 +116,14 @@ class JavadocFormatter {
             return Optional.of(firstLine);
         }
 
-        final String javadoc = getJavadoc(firstLine, reader);
-        final String formattedJavadoc = formatText(javadoc);
+        String javadoc = getJavadoc(firstLine, reader);
+        String formattedJavadoc = formatText(javadoc);
         return Optional.of(formattedJavadoc);
     }
 
     private static String getJavadoc(String firstLine,
                                      BufferedReader reader) throws IOException {
-        final StringBuilder javadoc = new StringBuilder();
+        StringBuilder javadoc = new StringBuilder();
 
         String currentLine = firstLine;
         while (!containsJavadocEnding(currentLine)) {

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/LineFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/LineFormatting.java
@@ -45,11 +45,11 @@ abstract class LineFormatting implements FormattingAction {
      */
     @Override
     public String execute(String text) {
-        final List<String> textAsLines = Splitter.on(lineSeparator())
+        List<String> textAsLines = Splitter.on(lineSeparator())
                                                  .splitToList(text);
-        final List<String> formattedLines = newLinkedList();
+        List<String> formattedLines = newLinkedList();
         for (String line : textAsLines) {
-            final String formattedLine = formatLine(line);
+            String formattedLine = formatLine(line);
             formattedLines.add(formattedLine);
         }
         return Joiner.on(lineSeparator())

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/LineFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/LineFormatting.java
@@ -46,7 +46,7 @@ abstract class LineFormatting implements FormattingAction {
     @Override
     public String execute(String text) {
         List<String> textAsLines = Splitter.on(lineSeparator())
-                                                 .splitToList(text);
+                                           .splitToList(text);
         List<String> formattedLines = newLinkedList();
         for (String line : textAsLines) {
             String formattedLine = formatLine(line);

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/PreTagFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/PreTagFormatting.java
@@ -53,15 +53,15 @@ class PreTagFormatting implements FormattingAction {
             return javadoc;
         }
 
-        final Matcher matcher = PATTERN_OPENING_PRE.matcher(javadoc);
-        final String withoutOpeningPre = matcher.replaceFirst("");
+        Matcher matcher = PATTERN_OPENING_PRE.matcher(javadoc);
+        String withoutOpeningPre = matcher.replaceFirst("");
         return removeLastClosingPre(withoutOpeningPre);
     }
 
     private static String removeLastClosingPre(String text) {
-        final int tagIndex = text.lastIndexOf(CLOSING_PRE);
-        final String beforeTag = text.substring(0, tagIndex);
-        final String afterTag = text.substring(tagIndex + CLOSING_PRE.length());
+        int tagIndex = text.lastIndexOf(CLOSING_PRE);
+        String beforeTag = text.substring(0, tagIndex);
+        String afterTag = text.substring(tagIndex + CLOSING_PRE.length());
         return beforeTag + afterTag;
     }
 

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/PreTagFormatting.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/PreTagFormatting.java
@@ -75,6 +75,7 @@ class PreTagFormatting implements FormattingAction {
      * @return {@code true} if the Javadoc contains opening and closing {@code pre} tag
      */
     private static boolean shouldFormat(String javadoc) {
-        return NOT_FORMATTED_DOC_PATTERN.matcher(javadoc).matches();
+        return NOT_FORMATTED_DOC_PATTERN.matcher(javadoc)
+                                        .matches();
     }
 }

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/ProtoJavadocPlugin.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/ProtoJavadocPlugin.java
@@ -68,19 +68,19 @@ public class ProtoJavadocPlugin extends SpinePlugin {
     static final String PROTO_JAVADOC_EXTENSION_NAME = "protoJavadoc";
 
     @Override
-    public void apply(final Project project) {
+    public void apply(Project project) {
         log().debug("Adding the ProtoJavadocPlugin extension to the project.");
         project.getExtensions()
                .create(PROTO_JAVADOC_EXTENSION_NAME, Extension.class);
 
-        final Action<Task> mainAction = createAction(project, TaskType.MAIN);
+        Action<Task> mainAction = createAction(project, TaskType.MAIN);
         newTask(FORMAT_PROTO_DOC, mainAction)
                 .insertBeforeTask(COMPILE_JAVA)
                 .insertAfterTask(GENERATE_PROTO)
                 .applyNowTo(project);
         logDependingTask(FORMAT_PROTO_DOC, COMPILE_JAVA, GENERATE_PROTO);
 
-        final Action<Task> testAction = createAction(project, TaskType.TEST);
+        Action<Task> testAction = createAction(project, TaskType.TEST);
         newTask(FORMAT_TEST_PROTO_DOC, testAction)
                 .insertBeforeTask(COMPILE_TEST_JAVA)
                 .insertAfterTask(GENERATE_TEST_PROTO)
@@ -88,25 +88,25 @@ public class ProtoJavadocPlugin extends SpinePlugin {
         logDependingTask(FORMAT_TEST_PROTO_DOC, COMPILE_TEST_JAVA, GENERATE_TEST_PROTO);
     }
 
-    private Action<Task> createAction(final Project project, final TaskType taskType) {
+    private Action<Task> createAction(Project project, TaskType taskType) {
         return task -> formatJavadocs(project, taskType);
     }
 
     private void formatJavadocs(Project project, TaskType taskType) {
-        final String genProtoDir = taskType.getGenProtoDir(project);
-        final File file = new File(genProtoDir);
+        String genProtoDir = taskType.getGenProtoDir(project);
+        File file = new File(genProtoDir);
         if (!file.exists()) {
             log().warn("Cannot perform formatting. Directory `{}` does not exist.", file);
             return;
         }
 
-        final JavadocFormatter formatter = new JavadocFormatter(asList(new BacktickFormatting(),
+        JavadocFormatter formatter = new JavadocFormatter(asList(new BacktickFormatting(),
                                                                        new PreTagFormatting()));
         try {
             log().debug("Starting Javadocs formatting in `{}`.", genProtoDir);
             Files.walkFileTree(file.toPath(), new FormattingFileVisitor(formatter));
         } catch (IOException e) {
-            final String errMsg = format("Failed to format the sources in `%s`.", genProtoDir);
+            String errMsg = format("Failed to format the sources in `%s`.", genProtoDir);
             throw new IllegalStateException(errMsg, e);
         }
     }

--- a/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/ProtoJavadocPlugin.java
+++ b/tools/javadoc-prettifier/src/main/java/io/spine/tools/protodoc/ProtoJavadocPlugin.java
@@ -101,7 +101,7 @@ public class ProtoJavadocPlugin extends SpinePlugin {
         }
 
         JavadocFormatter formatter = new JavadocFormatter(asList(new BacktickFormatting(),
-                                                                       new PreTagFormatting()));
+                                                                 new PreTagFormatting()));
         try {
             log().debug("Starting Javadocs formatting in `{}`.", genProtoDir);
             Files.walkFileTree(file.toPath(), new FormattingFileVisitor(formatter));

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/BacktickFormattingShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/BacktickFormattingShould.java
@@ -40,23 +40,23 @@ public class BacktickFormattingShould {
 
     @Test
     public void surround_text_in_backticks_with_code_tag() {
-        final String result = formatting.execute(TEXT_IN_BACKTICKS);
+        String result = formatting.execute(TEXT_IN_BACKTICKS);
         assertEquals(TEXT_IN_CODE_TAG, result);
     }
 
     @Test
     public void handle_multiple_entries_surrounded_with_backticks() {
-        final String separatingPart = " some other text ";
-        final String source = TEXT_IN_BACKTICKS + separatingPart + TEXT_IN_BACKTICKS;
-        final String expected = TEXT_IN_CODE_TAG + separatingPart + TEXT_IN_CODE_TAG;
+        String separatingPart = " some other text ";
+        String source = TEXT_IN_BACKTICKS + separatingPart + TEXT_IN_BACKTICKS;
+        String expected = TEXT_IN_CODE_TAG + separatingPart + TEXT_IN_CODE_TAG;
         assertEquals(expected, formatting.execute(source));
     }
 
     @Test
     public void not_handle_multi_lined_text_surrounded_with_backticks() {
-        final String lineWithOpeningBacktick = BACKTICK + TEXT;
-        final String lineWithClosingBacktick = TEXT + BACKTICK;
-        final String multiLinedText = lineWithOpeningBacktick + lineSeparator()
+        String lineWithOpeningBacktick = BACKTICK + TEXT;
+        String lineWithClosingBacktick = TEXT + BACKTICK;
+        String multiLinedText = lineWithOpeningBacktick + lineSeparator()
                 + lineWithClosingBacktick;
         assertEquals(multiLinedText, formatting.execute(multiLinedText));
     }
@@ -66,8 +66,8 @@ public class BacktickFormattingShould {
      */
     @Test
     public void escape_replacement_for_matcher() {
-        final String dollarInBackticks = BACKTICK + "$" + BACKTICK;
-        final String result = formatting.execute(dollarInBackticks);
+        String dollarInBackticks = BACKTICK + "$" + BACKTICK;
+        String result = formatting.execute(dollarInBackticks);
         assertEquals("{@code $}", result);
     }
 }

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/JavadocFormatterShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/JavadocFormatterShould.java
@@ -56,14 +56,14 @@ public class JavadocFormatterShould {
 
     @Test
     public void ignore_files_except_java() throws IOException {
-        final Path path = Paths.get("Non_existing_file.txt");
+        Path path = Paths.get("Non_existing_file.txt");
         backtickFormatter.format(path);
     }
 
     @Test
     public void format_Javadocs() throws Exception {
-        final String javadoc = getJavadoc(TEXT_IN_BACKTICKS);
-        final String expected = getJavadoc(TEXT_IN_CODE_TAG);
+        String javadoc = getJavadoc(TEXT_IN_BACKTICKS);
+        String expected = getJavadoc(TEXT_IN_CODE_TAG);
         assertEquals(expected, getFormattingResult(javadoc));
     }
 
@@ -77,19 +77,19 @@ public class JavadocFormatterShould {
     }
 
     private String getFormattingResult(String content) throws IOException {
-        final Path path = createJavaFile();
+        Path path = createJavaFile();
         Files.write(path, content.getBytes());
 
         backtickFormatter.format(path);
 
-        final List<String> lines = Files.readAllLines(path, UTF_8);
+        List<String> lines = Files.readAllLines(path, UTF_8);
         return Joiner.on(lineSeparator())
                      .join(lines);
     }
 
     private Path createJavaFile() throws IOException {
-        final String fileName = "JavadocFormatter_test_file.java";
-        final File file = folder.newFile(fileName);
+        String fileName = "JavadocFormatter_test_file.java";
+        File file = folder.newFile(fileName);
         return file.toPath();
     }
 }

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/LineFormattingShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/LineFormattingShould.java
@@ -37,10 +37,10 @@ public class LineFormattingShould {
 
     @Test
     public void merge_lines_correctly() {
-        final String lineText = "a text in a single line";
-        final int lineCount = 5;
-        final Iterable<String> lines = Collections.nCopies(lineCount, lineText);
-        final String linesAsString = Joiner.on(lineSeparator())
+        String lineText = "a text in a single line";
+        int lineCount = 5;
+        Iterable<String> lines = Collections.nCopies(lineCount, lineText);
+        String linesAsString = Joiner.on(lineSeparator())
                                            .join(lines);
         assertEquals(linesAsString, formatting.execute(linesAsString));
     }

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/LineFormattingShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/LineFormattingShould.java
@@ -41,7 +41,7 @@ public class LineFormattingShould {
         int lineCount = 5;
         Iterable<String> lines = Collections.nCopies(lineCount, lineText);
         String linesAsString = Joiner.on(lineSeparator())
-                                           .join(lines);
+                                     .join(lines);
         assertEquals(linesAsString, formatting.execute(linesAsString));
     }
 

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/PreTagFormattingShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/PreTagFormattingShould.java
@@ -37,7 +37,6 @@ public class PreTagFormattingShould {
     private static final String RAW_PROTO_DOC_WITH_PRE_TAG =
             "/** Doc header <pre> Preformated doc </pre> <code>string field = 1;</code> */";
 
-
     private final FormattingAction formatting = new PreTagFormatting();
 
     @Test

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/PreTagFormattingShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/PreTagFormattingShould.java
@@ -42,7 +42,7 @@ public class PreTagFormattingShould {
 
     @Test
     public void remove_tags_generated_by_proto_compiler() {
-        final String result = formatting.execute(RAW_PROTO_DOC);
+        String result = formatting.execute(RAW_PROTO_DOC);
         assertEquals(PROCESSED_PROTO_DOC, result);
     }
 
@@ -53,7 +53,7 @@ public class PreTagFormattingShould {
 
     @Test
     public void not_format_javadoc_without_pre_tags() {
-        final String javadoc = "/** smth */";
+        String javadoc = "/** smth */";
         assertEquals(javadoc, formatting.execute(javadoc));
     }
 }

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/ProtoJavadocPluginShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/ProtoJavadocPluginShould.java
@@ -73,7 +73,7 @@ public class ProtoJavadocPluginShould {
     @Test
     public void have_extension() {
         Extension extension = project.getExtensions()
-                                           .getByType(Extension.class);
+                                     .getByType(Extension.class);
         assertNotNull(extension);
     }
 
@@ -98,10 +98,10 @@ public class ProtoJavadocPluginShould {
         String text = "javadoc text";
         String generatedFieldDescription = " <code>field description</code>";
         String textInPreTags = new StringBuilder().append(OPENING_PRE)
-                                                        .append(text)
-                                                        .append(CLOSING_PRE)
-                                                        .append(generatedFieldDescription)
-                                                        .toString();
+                                                  .append(text)
+                                                  .append(CLOSING_PRE)
+                                                  .append(generatedFieldDescription)
+                                                  .toString();
         String expected = getJavadoc(text + generatedFieldDescription);
         String javadocToFormat = getJavadoc(textInPreTags);
         formatAndAssert(expected, javadocToFormat, testProjectDir);
@@ -117,18 +117,18 @@ public class ProtoJavadocPluginShould {
 
     private static String multilineJavadoc(String codeOpening, String codeClosing) {
         String text = new StringBuilder().append("/**")
-                                               .append(System.lineSeparator())
-                                               .append("Javadoc header")
-                                               .append(System.lineSeparator())
-                                               .append(OPENING_PRE)
-                                               .append(codeOpening)
-                                               .append("java snippet")
-                                               .append(codeClosing)
-                                               .append(CLOSING_PRE)
-                                               .append(System.lineSeparator())
-                                               .append("Javadoc footer")
-                                               .append("*/")
-                                               .toString();
+                                         .append(System.lineSeparator())
+                                         .append("Javadoc header")
+                                         .append(System.lineSeparator())
+                                         .append(OPENING_PRE)
+                                         .append(codeOpening)
+                                         .append("java snippet")
+                                         .append(codeClosing)
+                                         .append(CLOSING_PRE)
+                                         .append(System.lineSeparator())
+                                         .append("Javadoc footer")
+                                         .append("*/")
+                                         .toString();
         return text;
     }
 
@@ -143,7 +143,7 @@ public class ProtoJavadocPluginShould {
 
     private static Project newProject() {
         Project project = ProjectBuilder.builder()
-                                              .build();
+                                        .build();
         project.task(COMPILE_JAVA.getValue());
         project.task(COMPILE_TEST_JAVA.getValue());
         project.task(GENERATE_PROTO.getValue());

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/ProtoJavadocPluginShould.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/ProtoJavadocPluginShould.java
@@ -66,20 +66,20 @@ public class ProtoJavadocPluginShould {
 
     @Test
     public void apply_to_project() {
-        final PluginContainer plugins = project.getPlugins();
+        PluginContainer plugins = project.getPlugins();
         assertTrue(plugins.hasPlugin(PLUGIN_ID));
     }
 
     @Test
     public void have_extension() {
-        final Extension extension = project.getExtensions()
+        Extension extension = project.getExtensions()
                                            .getByType(Extension.class);
         assertNotNull(extension);
     }
 
     @Test
     public void add_task_formatProtoDoc() {
-        final Task formatProtoDoc = task(FORMAT_PROTO_DOC);
+        Task formatProtoDoc = task(FORMAT_PROTO_DOC);
         assertNotNull(formatProtoDoc);
         assertTrue(dependsOn(formatProtoDoc, GENERATE_PROTO));
         assertTrue(dependsOn(task(COMPILE_JAVA), formatProtoDoc));
@@ -87,7 +87,7 @@ public class ProtoJavadocPluginShould {
 
     @Test
     public void add_task_formatTestProtoDoc() {
-        final Task formatTestProtoDoc = task(FORMAT_TEST_PROTO_DOC);
+        Task formatTestProtoDoc = task(FORMAT_TEST_PROTO_DOC);
         assertNotNull(formatTestProtoDoc);
         assertTrue(dependsOn(formatTestProtoDoc, GENERATE_TEST_PROTO));
         assertTrue(dependsOn(task(COMPILE_TEST_JAVA), formatTestProtoDoc));
@@ -95,28 +95,28 @@ public class ProtoJavadocPluginShould {
 
     @Test
     public void format_generated_java_sources() throws IOException {
-        final String text = "javadoc text";
-        final String generatedFieldDescription = " <code>field description</code>";
-        final String textInPreTags = new StringBuilder().append(OPENING_PRE)
+        String text = "javadoc text";
+        String generatedFieldDescription = " <code>field description</code>";
+        String textInPreTags = new StringBuilder().append(OPENING_PRE)
                                                         .append(text)
                                                         .append(CLOSING_PRE)
                                                         .append(generatedFieldDescription)
                                                         .toString();
-        final String expected = getJavadoc(text + generatedFieldDescription);
-        final String javadocToFormat = getJavadoc(textInPreTags);
+        String expected = getJavadoc(text + generatedFieldDescription);
+        String javadocToFormat = getJavadoc(textInPreTags);
         formatAndAssert(expected, javadocToFormat, testProjectDir);
     }
 
     @Test
     public void handle_multiline_code_snippets_properly() throws IOException {
-        final String protoDoc = multilineJavadoc(BACKTICK, BACKTICK);
-        final String javadoc = multilineJavadoc("{@code ", "}");
+        String protoDoc = multilineJavadoc(BACKTICK, BACKTICK);
+        String javadoc = multilineJavadoc("{@code ", "}");
 
         formatAndAssert(javadoc, protoDoc, testProjectDir);
     }
 
     private static String multilineJavadoc(String codeOpening, String codeClosing) {
-        final String text = new StringBuilder().append("/**")
+        String text = new StringBuilder().append("/**")
                                                .append(System.lineSeparator())
                                                .append("Javadoc header")
                                                .append(System.lineSeparator())
@@ -142,7 +142,7 @@ public class ProtoJavadocPluginShould {
     }
 
     private static Project newProject() {
-        final Project project = ProjectBuilder.builder()
+        Project project = ProjectBuilder.builder()
                                               .build();
         project.task(COMPILE_JAVA.getValue());
         project.task(COMPILE_TEST_JAVA.getValue());

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
@@ -57,11 +57,11 @@ public final class ProtoJavadocPluginTestEnv {
     }
 
     public static void formatAndAssert(String expectedContent, String contentToFormat,
-                                TemporaryFolder folder) throws IOException {
+                                       TemporaryFolder folder) throws IOException {
         Path formattedFilePath = format(contentToFormat, folder);
         List<String> formattedLines = Files.readAllLines(formattedFilePath, UTF_8);
         String mergedLines = Joiner.on(lineSeparator())
-                                         .join(formattedLines);
+                                   .join(formattedLines);
         assertEquals(expectedContent, mergedLines);
     }
 

--- a/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
+++ b/tools/javadoc-prettifier/src/test/java/io/spine/tools/protodoc/given/ProtoJavadocPluginTestEnv.java
@@ -58,9 +58,9 @@ public final class ProtoJavadocPluginTestEnv {
 
     public static void formatAndAssert(String expectedContent, String contentToFormat,
                                 TemporaryFolder folder) throws IOException {
-        final Path formattedFilePath = format(contentToFormat, folder);
-        final List<String> formattedLines = Files.readAllLines(formattedFilePath, UTF_8);
-        final String mergedLines = Joiner.on(lineSeparator())
+        Path formattedFilePath = format(contentToFormat, folder);
+        List<String> formattedLines = Files.readAllLines(formattedFilePath, UTF_8);
+        String mergedLines = Joiner.on(lineSeparator())
                                          .join(formattedLines);
         assertEquals(expectedContent, mergedLines);
     }


### PR DESCRIPTION
This PR provides the following changes for the `javadoc-prettifier` module:

1. The `final` keyword on local var iables was removed;
2. Guava's `Optional` was replaced with JDK 8 `Optional`.