### PR TITLE
Remove the unnecessary `final` keyword on local variables for the `javadoc-filter` module

### DIFF
--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/AnnotationAnalyst.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/AnnotationAnalyst.java
@@ -55,6 +55,8 @@ public class AnnotationAnalyst<C extends Class<? extends Annotation>> {
     }
 
     private boolean isQualifiedAnnotation(AnnotationDesc annotation) {
-        return annotation.annotationType().qualifiedTypeName().equals(annotationClass.getName());
+        return annotation.annotationType()
+                         .qualifiedTypeName()
+                         .equals(annotationClass.getName());
     }
 }

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalDoclet.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalDoclet.java
@@ -112,7 +112,9 @@ public class ExcludeInternalDoclet extends Standard {
             return null;
         }
 
-        if (returnValue.getClass().getName().startsWith("com.sun.")) {
+        if (returnValue.getClass()
+                       .getName()
+                       .startsWith("com.sun.")) {
             Class cls = returnValue.getClass();
             return Proxy.newProxyInstance(cls.getClassLoader(),
                                           cls.getInterfaces(),

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalDoclet.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalDoclet.java
@@ -80,7 +80,7 @@ public class ExcludeInternalDoclet extends Standard {
      * @param args the command-line parameters
      */
     public static void main(String[] args) {
-        final String name = ExcludeInternalDoclet.class.getName();
+        String name = ExcludeInternalDoclet.class.getName();
         Main.execute(name, name, args);
     }
 
@@ -93,8 +93,8 @@ public class ExcludeInternalDoclet extends Standard {
      */
     @SuppressWarnings("unused") // called by com.sun.tools.javadoc.Main
     public static boolean start(RootDoc root) {
-        final ExcludePrinciple excludePrinciple = new ExcludeInternalPrinciple(root);
-        final ExcludeInternalDoclet doclet = new ExcludeInternalDoclet(excludePrinciple);
+        ExcludePrinciple excludePrinciple = new ExcludeInternalPrinciple(root);
+        ExcludeInternalDoclet doclet = new ExcludeInternalDoclet(excludePrinciple);
         return Standard.start((RootDoc) doclet.process(root, RootDoc.class));
     }
 
@@ -113,14 +113,14 @@ public class ExcludeInternalDoclet extends Standard {
         }
 
         if (returnValue.getClass().getName().startsWith("com.sun.")) {
-            final Class cls = returnValue.getClass();
+            Class cls = returnValue.getClass();
             return Proxy.newProxyInstance(cls.getClassLoader(),
                                           cls.getInterfaces(),
                                           new ExcludeHandler(returnValue));
         } else if (returnValue instanceof Object[] && returnValueType.getComponentType() != null) {
-            final Class componentType = returnValueType.getComponentType();
-            final Object[] array = (Object[]) returnValue;
-            final List<Object> list = new ArrayList<>();
+            Class componentType = returnValueType.getComponentType();
+            Object[] array = (Object[]) returnValue;
+            List<Object> list = new ArrayList<>();
             for (Object entry : array) {
                 if (!(entry instanceof ProgramElementDoc && excludePrinciple.shouldExclude(
                         (ProgramElementDoc) entry))) {

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
@@ -55,7 +55,7 @@ class ExcludeInternalPrinciple implements ExcludePrinciple {
     }
 
     private boolean inExclusions(ProgramElementDoc doc) {
-        final String docPackageName = doc.containingPackage().name();
+        String docPackageName = doc.containingPackage().name();
 
         for (PackageDoc exclusion : exclusions) {
             if (docPackageName.startsWith(exclusion.name())) {
@@ -67,7 +67,7 @@ class ExcludeInternalPrinciple implements ExcludePrinciple {
     }
 
     private Collection<PackageDoc> getExclusions(RootDoc root) {
-        final PackageCollector packageCollector = new PackageCollector(internalAnalyst);
+        PackageCollector packageCollector = new PackageCollector(internalAnalyst);
         return packageCollector.collect(root);
     }
 }

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
@@ -55,7 +55,8 @@ class ExcludeInternalPrinciple implements ExcludePrinciple {
     }
 
     private boolean inExclusions(ProgramElementDoc doc) {
-        String docPackageName = doc.containingPackage().name();
+        String docPackageName = doc.containingPackage()
+                                   .name();
 
         for (PackageDoc exclusion : exclusions) {
             if (docPackageName.startsWith(exclusion.name())) {

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/PackageCollector.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/PackageCollector.java
@@ -124,7 +124,8 @@ class PackageCollector {
 
         @Override
         public int compare(PackageDoc o1, PackageDoc o2) {
-            return o1.name().compareTo(o2.name());
+            return o1.name()
+                     .compareTo(o2.name());
         }
     }
 }

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/PackageCollector.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/PackageCollector.java
@@ -50,7 +50,7 @@ class PackageCollector {
      * @return collected {@linkplain PackageDoc}s
      */
     Collection<PackageDoc> collect(RootDoc root) {
-        final Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
+        Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
 
         packages.addAll(collect(root.specifiedPackages()));
         packages.addAll(collect(root.specifiedClasses()));
@@ -59,8 +59,8 @@ class PackageCollector {
     }
 
     private Collection<PackageDoc> collect(ClassDoc[] forClasses) {
-        final Collection<PackageDoc> allPackages = getPackages(forClasses);
-        final Collection<PackageDoc> basePackages = getPackages(forClasses);
+        Collection<PackageDoc> allPackages = getPackages(forClasses);
+        Collection<PackageDoc> basePackages = getPackages(forClasses);
 
         for (ClassDoc classDoc : forClasses) {
             if (isSubpackage(classDoc.containingPackage(), basePackages)) {
@@ -72,8 +72,8 @@ class PackageCollector {
     }
 
     private Collection<PackageDoc> collect(PackageDoc[] forPackages) {
-        final Collection<PackageDoc> allPackages = getBasePackages(forPackages);
-        final Collection<PackageDoc> basePackages = getBasePackages(forPackages);
+        Collection<PackageDoc> allPackages = getBasePackages(forPackages);
+        Collection<PackageDoc> basePackages = getBasePackages(forPackages);
 
         for (PackageDoc packageDoc : forPackages) {
             if (isSubpackage(packageDoc, basePackages)) {
@@ -85,7 +85,7 @@ class PackageCollector {
     }
 
     private Collection<PackageDoc> getBasePackages(PackageDoc[] forPackages) {
-        final Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
+        Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
 
         for (PackageDoc packageDoc : forPackages) {
             if (analyst.isAnnotationPresent(packageDoc.annotations())) {
@@ -97,7 +97,7 @@ class PackageCollector {
     }
 
     private Collection<PackageDoc> getPackages(ClassDoc[] forClasses) {
-        final Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
+        Collection<PackageDoc> packages = new TreeSet<>(new PackageDocComparator());
 
         for (ClassDoc classDoc : forClasses) {
             if (analyst.isAnnotationPresent(classDoc.containingPackage().annotations())) {

--- a/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/ExcludeInternalDocletShould.java
+++ b/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/ExcludeInternalDocletShould.java
@@ -57,7 +57,7 @@ public class ExcludeInternalDocletShould {
 
     @Test
     public void run_standard_doclet() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(NOT_INTERNAL_CLASS_FILENAME)
                 .build();
 
@@ -68,132 +68,132 @@ public class ExcludeInternalDocletShould {
 
     @Test
     public void exclude_internal_annotated_annotations() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("InternalAnnotatedAnnotation.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(0, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void exclude_internal_ctors() {
-        final String[] args = new JavadocArgsBuilder().addSource("InternalCtorClass.java")
+        String[] args = new JavadocArgsBuilder().addSource("InternalCtorClass.java")
                                                       .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
-        final ClassDoc classDoc = rootDoc.specifiedClasses()[0];
+        ClassDoc classDoc = rootDoc.specifiedClasses()[0];
         assertEquals(0, classDoc.constructors().length);
     }
 
     @Test
     public void exclude_internal_fields() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("InternalFieldClass.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
-        final ClassDoc classDoc = rootDoc.specifiedClasses()[0];
+        ClassDoc classDoc = rootDoc.specifiedClasses()[0];
         assertEquals(0, classDoc.fields().length);
     }
 
     @Test
     public void exclude_internal_methods() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(INTERNAL_METHOD_CLASS_FILENAME)
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
-        final ClassDoc classDoc = rootDoc.specifiedClasses()[0];
+        ClassDoc classDoc = rootDoc.specifiedClasses()[0];
         assertEquals(0, classDoc.methods().length);
     }
 
     @Test
     public void exclude_internal_package_content() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("/internal/InternalPackageClass.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(0, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void exclude_only_from_internal_subpackages() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("/internal/subinternal/SubInternalPackageClass.java")
                 .addSource(NOT_INTERNAL_CLASS_FILENAME)
                 .addPackage(INTERNAL_PACKAGE)
                 .addPackage(TEST_SOURCES_PACKAGE + ".notinternal")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(1, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void exclude_internal_classes() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(INTERNAL_CLASS_FILENAME)
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(0, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void exclude_internal_interfaces() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("InternalAnnotatedInterface.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(0, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void exclude_internal_enums() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("InternalEnum.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(0, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void not_exclude_elements_annotated_with_Internal_located_in_another_package() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource("GrpcInternalAnnotatedClass.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         assertEquals(1, rootDoc.specifiedClasses().length);
     }
 
     @Test
     public void correctly_work_when_compareTo_called() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(INTERNAL_CLASS_FILENAME)
                 .addSource(DERIVED_FROM_INTERNAL_CLASS_FILENAME)
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         // invoke compareTo to be sure, that proxy unwrapping
         // doest not expose object passed to compareTo method
-        final ClassDoc classDoc = rootDoc.specifiedClasses()[0];
-        final ClassDoc anotherClassDoc = classDoc.superclass();
+        ClassDoc classDoc = rootDoc.specifiedClasses()[0];
+        ClassDoc anotherClassDoc = classDoc.superclass();
         classDoc.compareTo(anotherClassDoc);
 
         assertEquals(1, rootDoc.specifiedClasses().length);
@@ -201,19 +201,19 @@ public class ExcludeInternalDocletShould {
 
     @Test
     public void correctly_work_when_overrides_called() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(INTERNAL_METHOD_CLASS_FILENAME)
                 .addSource("OverridesInternalMethod.java")
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         // invoke overrides to be sure, that proxy unwrapping
         // doest not expose overridden method
-        final ClassDoc overridesInternalMethod =
+        ClassDoc overridesInternalMethod =
                 rootDoc.classNamed(TEST_SOURCES_PACKAGE + ".OverridesInternalMethod");
-        final MethodDoc methodDoc = overridesInternalMethod.methods()[0];
-        final MethodDoc overriddenMethod = methodDoc.overriddenMethod();
+        MethodDoc methodDoc = overridesInternalMethod.methods()[0];
+        MethodDoc overriddenMethod = methodDoc.overriddenMethod();
         methodDoc.overrides(overriddenMethod);
 
         assertEquals(0, rootDoc.classNamed(TEST_SOURCES_PACKAGE + ".InternalMethodClass")
@@ -222,17 +222,17 @@ public class ExcludeInternalDocletShould {
 
     @Test
     public void correctly_work_when_subclassOf_invoked() {
-        final String[] args = new JavadocArgsBuilder()
+        String[] args = new JavadocArgsBuilder()
                 .addSource(INTERNAL_CLASS_FILENAME)
                 .addSource(DERIVED_FROM_INTERNAL_CLASS_FILENAME)
                 .build();
 
-        final RootDoc rootDoc = rootDocFor(args);
+        RootDoc rootDoc = rootDocFor(args);
 
         // invoke subclassOf to be sure, that proxy unwrapping
         // doest not expose parent internal class
-        final ClassDoc classDoc = rootDoc.specifiedClasses()[0];
-        final ClassDoc superclass = classDoc.superclass();
+        ClassDoc classDoc = rootDoc.specifiedClasses()[0];
+        ClassDoc superclass = classDoc.superclass();
         classDoc.subclassOf(superclass);
 
         assertEquals(1, rootDoc.specifiedClasses().length);
@@ -244,7 +244,7 @@ public class ExcludeInternalDocletShould {
     })
     @Test
     public void not_throw_NPE_processing_null_values() {
-        final ExcludeInternalDoclet doclet = new NullProcessingTestDoclet();
+        ExcludeInternalDoclet doclet = new NullProcessingTestDoclet();
 
         try {
             doclet.process(Tests.nullRef(), void.class);

--- a/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/ExcludeInternalDocletShould.java
+++ b/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/ExcludeInternalDocletShould.java
@@ -80,7 +80,7 @@ public class ExcludeInternalDocletShould {
     @Test
     public void exclude_internal_ctors() {
         String[] args = new JavadocArgsBuilder().addSource("InternalCtorClass.java")
-                                                      .build();
+                                                .build();
 
         RootDoc rootDoc = rootDocFor(args);
 

--- a/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/JavadocArgsBuilder.java
+++ b/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/JavadocArgsBuilder.java
@@ -46,7 +46,7 @@ class JavadocArgsBuilder {
     }
 
     String[] build() {
-        final List<String> allArguments = new ArrayList<>();
+        List<String> allArguments = new ArrayList<>();
 
         addDestination(allArguments);
         addSourcePath(allArguments);

--- a/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/RootDocProxyReceiver.java
+++ b/tools/javadoc-filter/src/test/java/io/spine/tools/javadoc/RootDocProxyReceiver.java
@@ -35,14 +35,14 @@ public class RootDocProxyReceiver extends ExcludeInternalDoclet {
     }
 
     public static void main(String[] args) {
-        final String name = RootDocProxyReceiver.class.getName();
+        String name = RootDocProxyReceiver.class.getName();
         Main.execute(name, name, args);
     }
 
     @SuppressWarnings("unused") // called by com.sun.tools.javadoc.Main
     public static boolean start(RootDoc root) {
-        final ExcludePrinciple excludePrinciple = new ExcludeInternalPrinciple(root);
-        final ExcludeInternalDoclet doclet = new ExcludeInternalDoclet(excludePrinciple);
+        ExcludePrinciple excludePrinciple = new ExcludeInternalPrinciple(root);
+        ExcludeInternalDoclet doclet = new ExcludeInternalDoclet(excludePrinciple);
 
         // We can obtain RootDoc only here
         rootDocProxy = (RootDoc) doclet.process(root, root.getClass());


### PR DESCRIPTION
This PR provides the following changes for the `javadoc-filter` module:

- The `final` keyword on local variables was removed.