### PR TITLE
Remove the unnecessary `final` keyword on local variables for the `reflections-plugin` module

### DIFF
--- a/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/Extension.java
+++ b/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/Extension.java
@@ -42,7 +42,7 @@ public class Extension {
     public String targetDir;
 
     static String getTargetDir(Project project) {
-        final String path = reflectionsPlugin(project).targetDir;
+        String path = reflectionsPlugin(project).targetDir;
         if (path == null || path.isEmpty()) {
             return project.getProjectDir() + separator +
                     Joiner.on(separator)

--- a/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
+++ b/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
@@ -66,19 +66,19 @@ public class ReflectionsPlugin extends SpinePlugin {
      * <p>The plugin runs after `:classes` task and before `:processResources`.
      */
     @Override
-    public void apply(final Project project) {
-        final Logger log = log();
+    public void apply(Project project) {
+        Logger log = log();
         log.debug("Applying the Reflections plugin");
         project.getExtensions()
                .create(REFLECTIONS_PLUGIN_EXTENSION, Extension.class);
 
-        final Action<Task> scanClassPathAction = new Action<Task>() {
+        Action<Task> scanClassPathAction = new Action<Task>() {
             @Override
             public void execute(Task task) {
                 scanClassPath(project);
             }
         };
-        final GradleTask task =
+        GradleTask task =
                 newTask(SCAN_CLASS_PATH, scanClassPathAction).insertAfterTask(CLASSES)
                                                              .insertBeforeTask(BUILD)
                                                              .applyNowTo(project);
@@ -89,31 +89,30 @@ public class ReflectionsPlugin extends SpinePlugin {
     private void scanClassPath(Project project) {
         log().debug("Scanning the classpath");
 
-        final String outputDirPath = project.getProjectDir() + "/build";
-        final File outputDir = new File(outputDirPath);
+        String outputDirPath = project.getProjectDir() + "/build";
+        File outputDir = new File(outputDirPath);
         ensureFolderCreated(outputDir);
 
-        final String targetDirPath = Extension.getTargetDir(project);
-        final File reflectionsOutputDir = new File(targetDirPath);
+        String targetDirPath = Extension.getTargetDir(project);
+        File reflectionsOutputDir = new File(targetDirPath);
         ensureFolderCreated(reflectionsOutputDir);
 
-        final ConfigurationBuilder config = new ConfigurationBuilder();
+        ConfigurationBuilder config = new ConfigurationBuilder();
         config.setUrls(toUrls(outputDir));
         config.setScanners(new SubTypesScanner(), new TypeAnnotationsScanner());
 
-        final Serializer serializerInstance = new XmlSerializer();
+        Serializer serializerInstance = new XmlSerializer();
         config.setSerializer(serializerInstance);
 
-        final Reflections reflections = new Reflections(config);
-        final String reflectionsOutputFilePath =
+        Reflections reflections = new Reflections(config);
+        String reflectionsOutputFilePath =
                 targetDirPath + separatorChar + project.getName() + "-reflections.xml";
         reflections.save(reflectionsOutputFilePath);
     }
 
     private static Set<URL> toUrls(File outputDir) {
         // because they are file URIs, they will not cause any network-related issues.
-        @SuppressWarnings("CollectionContainsUrl")
-        final Set<URL> urls = new HashSet<>();
+        @SuppressWarnings("CollectionContainsUrl") Set<URL> urls = new HashSet<>();
         try {
             urls.add(outputDir.toURI()
                               .toURL());

--- a/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/ExtensionShould.java
+++ b/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/ExtensionShould.java
@@ -43,7 +43,7 @@ public class ExtensionShould {
 
     @Test
     public void return_default_targetDir_if_not_set() {
-        final String dir = Extension.getTargetDir(project);
+        String dir = Extension.getTargetDir(project);
 
         assertFalse(dir.trim()
                        .isEmpty());
@@ -53,10 +53,10 @@ public class ExtensionShould {
 
     @Test
     public void return_targetDir_if_set() {
-        final Extension extension = Extension.reflectionsPlugin(project);
+        Extension extension = Extension.reflectionsPlugin(project);
         extension.targetDir = "some target dir value";
 
-        final String dir = Extension.getTargetDir(project);
+        String dir = Extension.getTargetDir(project);
 
         assertEquals(extension.targetDir, dir);
     }

--- a/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/Given.java
+++ b/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/Given.java
@@ -38,7 +38,7 @@ class Given {
     /** Creates a project with all required tasks. */
     public static Project newProject() {
         Project project = ProjectBuilder.builder()
-                                              .build();
+                                        .build();
         project.task(CLASSES.getValue());
         project.task(BUILD.getValue());
         return project;

--- a/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/Given.java
+++ b/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/Given.java
@@ -37,7 +37,7 @@ class Given {
 
     /** Creates a project with all required tasks. */
     public static Project newProject() {
-        final Project project = ProjectBuilder.builder()
+        Project project = ProjectBuilder.builder()
                                               .build();
         project.task(CLASSES.getValue());
         project.task(BUILD.getValue());

--- a/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/ReflectionsPluginShould.java
+++ b/tools/reflections-plugin/src/test/java/io/spine/tools/reflections/ReflectionsPluginShould.java
@@ -40,20 +40,20 @@ public class ReflectionsPluginShould {
 
     @Test
     public void apply_to_project() {
-        final Project project = newProject();
+        Project project = newProject();
         project.getPluginManager()
                .apply(REFLECTIONS_PLUGIN_ID);
     }
 
     @Test
     public void add_task_scanClassPath() {
-        final Project project = newProject();
+        Project project = newProject();
         project.getPluginManager()
                .apply(REFLECTIONS_PLUGIN_ID);
 
-        final TaskContainer tasks = project.getTasks();
-        final Task scanClassPathTask = tasks.getByName(SCAN_CLASS_PATH.getValue());
-        final Task buildTask = tasks.getByName(BUILD.getValue());
+        TaskContainer tasks = project.getTasks();
+        Task scanClassPathTask = tasks.getByName(SCAN_CLASS_PATH.getValue());
+        Task buildTask = tasks.getByName(BUILD.getValue());
 
         assertNotNull(scanClassPathTask);
         assertTrue(dependsOn(scanClassPathTask, CLASSES));


### PR DESCRIPTION
This PR provides the following changes for the `reflections-plugin` module:

- The `final` keyword on local variables was removed.