### PR TITLE
Replacement of Guava's `Predicate` and `Function` with JDK8 classes

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.50-SNAPSHOT'
+final def SPINE_VERSION = '0.10.51-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/SourceVisitor.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/SourceVisitor.java
@@ -20,9 +20,10 @@
 
 package io.spine.tools.compiler.annotation;
 
-import com.google.common.base.Function;
 import org.jboss.forge.roaster.model.impl.AbstractJavaSource;
 import org.jboss.forge.roaster.model.source.JavaSource;
+
+import java.util.function.Function;
 
 /**
  * A {@link AbstractJavaSource} visitor.

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidationRulesLookup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidationRulesLookup.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.compiler.validation;
 
-import com.google.common.base.Predicate;
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import io.spine.code.properties.PropertiesWriter;
@@ -34,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMap;
@@ -96,7 +96,7 @@ public final class ValidationRulesLookup {
     private static class IsValidationRule implements Predicate<DescriptorProto> {
 
         @Override
-        public boolean apply(@Nullable DescriptorProto input) {
+        public boolean test(@Nullable DescriptorProto input) {
             checkNotNull(input);
             return Options.option(input, validationOf)
                           .isPresent();

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/SourceCheck.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/annotation/check/SourceCheck.java
@@ -20,9 +20,10 @@
 
 package io.spine.tools.compiler.annotation.check;
 
-import com.google.common.base.Function;
 import org.jboss.forge.roaster.model.impl.AbstractJavaSource;
 import org.jboss.forge.roaster.model.source.JavaClassSource;
+
+import java.util.function.Function;
 
 /**
  * Interface for validation of a {@link JavaClassSource}.


### PR DESCRIPTION
This PR provides the following changes for the `model-compiler` module:

- Guava's `Predicate` was replaced with JDK8 `Predicate`;
- Guava's `Function` was replaced with JDK8 `Function`;
- The version was updated to `0.10.51-SNAPSHOT`.