### PR TITLE
Supplier adapters

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -144,7 +144,6 @@
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComparisonToNaN" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionalExpressionWithIdenticalBranches" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
@@ -767,7 +766,16 @@
     </inspection_tool>
     <inspection_tool class="UnsecureRandomNumberGeneration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="UnstableApiUsage" enabled="true" level="WARNING" enabled_by_default="true">
-      <scope name="Tests" level="WEAK WARNING" enabled="true" />
+      <option name="unstableApiAnnotations">
+        <set>
+          <option value="io.reactivex.annotations.Beta" />
+          <option value="io.reactivex.annotations.Experimental" />
+          <option value="org.apache.http.annotation.Beta" />
+          <option value="org.jetbrains.annotations.ApiStatus.Experimental" />
+          <option value="rx.annotations.Beta" />
+          <option value="rx.annotations.Experimental" />
+        </set>
+      </option>
     </inspection_tool>
     <inspection_tool class="UnusedCatchParameter" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreCatchBlocksWithComments" value="true" />

--- a/base/src/main/java/io/spine/util/Preconditions2.java
+++ b/base/src/main/java/io/spine/util/Preconditions2.java
@@ -59,7 +59,8 @@ public class Preconditions2 {
      */
     @CanIgnoreReturnValue
     public static String checkNotEmptyOrBlank(String stringToCheck, String message) {
-        checkNotNull(stringToCheck, message);
+        checkNotNull(stringToCheck);
+        checkNotNull(message);
         checkArgument(!stringToCheck.isEmpty(), message);
         String trimmed = stringToCheck.trim();
         checkArgument(trimmed.length() > 0, message);

--- a/base/src/main/java/io/spine/util/Suppliers2.java
+++ b/base/src/main/java/io/spine/util/Suppliers2.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.base.Suppliers;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Utilities for working with {@link java.util.function.Supplier Supplier}s.
+ *
+ * <p>These utilities aim to adapt those {@linkplain com.google.common.base.Suppliers provided by
+ * Guava}.
+ *
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings("Guava") /* Adapt Guava Suppliers is one of the purposes of the class. */
+public class Suppliers2 {
+
+    /** Prevents instantiation of this utility class. */
+    private Suppliers2() {
+    }
+
+    /**
+     * Creates a supplier which caches the value obtained from the passed one.
+     *
+     * <p>This creates an adapter for a {@linkplain
+     * Suppliers#memoize(com.google.common.base.Supplier) memoizing supplier} provided by Guava.
+     */
+    public static <T> Supplier<T> memoize(Supplier<T> supplier) {
+        checkNotNull(supplier);
+        return adapt(Suppliers.memoize(reverse(supplier)));
+    }
+
+    /**
+     * Creates a standard {@code Supplier} which adapts Guava's.
+     */
+    public static <T> Supplier<T> adapt(com.google.common.base.Supplier<T> supplier) {
+        checkNotNull(supplier);
+        return new Adapter<>(supplier);
+    }
+
+    /**
+     * Creates a Guava's {@code Supplier} which adapts a standard one.
+     */
+    public static <T> com.google.common.base.Supplier<T> reverse(Supplier<T> supplier) {
+        checkNotNull(supplier);
+        return new ReverseAdapter<>(supplier);
+    }
+
+    /**
+     * Adapts the Guava supplier to math the {@linkplain java.util.function.Supplier standard
+     * Java API}.
+     *
+     * @param <T> the type of the object to supply
+     */
+    private static final class Adapter<T> implements Supplier<T>, Serializable {
+
+        private static final long serialVersionUID = 0L;
+
+        /**
+         * Guava's Supplier being adapted.
+         *
+         * <p>This field is serializable since Guava's Suppliers are
+         * {@linkplain com.google.common.base.Suppliers serializable} if their
+         * parameters are serializable.
+         */
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final com.google.common.base.Supplier<T> adaptee;
+
+        private Adapter(com.google.common.base.Supplier<T> adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @Override
+        public T get() {
+            return adaptee.get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Adapter)) {
+                return false;
+            }
+            Adapter<?> adapter = (Adapter<?>) o;
+            return Objects.equals(adaptee, adapter.adaptee);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(adaptee);
+        }
+    }
+
+    /**
+     * Adapts  {@linkplain java.util.function.Supplier standard Supplier} to Guava's.
+     *
+     * <p>This class is {@code Serializable} if the adaptee is {@code Serializable}.
+     *
+     * @param <T> the type of the object to supply
+     */
+    private static final class ReverseAdapter<T>
+            implements com.google.common.base.Supplier<T>, Serializable {
+
+        private static final long serialVersionUID = 0L;
+        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        private final Supplier<T> adaptee;
+
+        private ReverseAdapter(Supplier<T> adaptee) {
+            this.adaptee = adaptee;
+        }
+
+        @CanIgnoreReturnValue
+        @Override
+        public T get() {
+            return adaptee.get();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof ReverseAdapter)) {
+                return false;
+            }
+            ReverseAdapter<?> adapter = (ReverseAdapter<?>) o;
+            return Objects.equals(adaptee, adapter.adaptee);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(adaptee);
+        }
+    }
+}

--- a/base/src/main/java/io/spine/util/Suppliers2.java
+++ b/base/src/main/java/io/spine/util/Suppliers2.java
@@ -119,7 +119,7 @@ public class Suppliers2 {
     }
 
     /**
-     * Adapts  {@linkplain java.util.function.Supplier standard Supplier} to Guava's.
+     * Adapts {@linkplain java.util.function.Supplier standard Supplier} to Guava's.
      *
      * <p>This class is {@code Serializable} if the adaptee is {@code Serializable}.
      *

--- a/base/src/test/java/io/spine/base/EnvironmentShould.java
+++ b/base/src/test/java/io/spine/base/EnvironmentShould.java
@@ -69,7 +69,7 @@ public class EnvironmentShould {
     }
 
     @After
-    public void cleanUp() throws NoSuchFieldException, IllegalAccessException {
+    public void cleanUp() {
         Environment.getInstance()
                    .reset();
     }
@@ -80,7 +80,7 @@ public class EnvironmentShould {
     }
 
     @Test
-    public void tell_that_we_are_under_tests_if_env_var_set_to_true() throws Exception {
+    public void tell_that_we_are_under_tests_if_env_var_set_to_true() {
         Environment.getInstance()
                    .setToTests();
 
@@ -89,7 +89,7 @@ public class EnvironmentShould {
     }
 
     @Test
-    public void tell_that_we_are_under_tests_if_env_var_set_to_1() throws Exception {
+    public void tell_that_we_are_under_tests_if_env_var_set_to_1() {
         System.setProperty(Environment.ENV_KEY_TESTS, "1");
 
         assertTrue(environment.isTests());

--- a/base/src/test/java/io/spine/util/Preconditions2Test.java
+++ b/base/src/test/java/io/spine/util/Preconditions2Test.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import io.spine.testing.UtilityClassTest;
+import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings("InnerClassMayBeStatic")
+@DisplayName("Preconditions2 utility class should")
+class Preconditions2Test extends UtilityClassTest<Preconditions2> {
+
+    Preconditions2Test() {
+        super(Preconditions2.class);
+    }
+
+    @Nested
+    @DisplayName("Check that a String is")
+    class StringArg {
+
+        private void assertThrowsOn(String arg) {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> checkNotEmptyOrBlank(arg)
+            );
+        }
+
+        @Test
+        @DisplayName("empty")
+        void emptyString() {
+            assertThrowsOn("");
+        }
+
+        @Test
+        @DisplayName("blank")
+        void blankString() {
+            assertThrowsOn(" ");
+            assertThrowsOn("  ");
+            assertThrowsOn("   ");
+        }
+    }
+}

--- a/base/src/test/java/io/spine/util/Suppliers2Test.java
+++ b/base/src/test/java/io/spine/util/Suppliers2Test.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.base.Suppliers;
+import io.spine.testing.TestValues;
+import io.spine.testing.UtilityClassTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Supplier;
+
+import static com.google.common.testing.SerializableTester.reserializeAndAssert;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SuppressWarnings({"InnerClassMayBeStatic", "Guava"}) // we test adaptation API.
+@DisplayName("Suppliers2 utility class should")
+class Suppliers2Test extends UtilityClassTest<Suppliers2> {
+
+    Suppliers2Test() {
+        super(Suppliers2.class);
+    }
+
+    @Nested
+    @DisplayName("Adapt Guava Supplier")
+    class Adapter {
+
+        private com.google.common.base.Supplier<Long> adaptee;
+        private Supplier<Long> adapter;
+
+        @BeforeEach
+        void setUp() {
+            adaptee = Suppliers.ofInstance((long) TestValues.random(10_000));
+            adapter = Suppliers2.adapt(adaptee);
+        }
+
+        @Test
+        @DisplayName("returning its values")
+        void gettingValues() {
+            assertEquals(adaptee.get(), adapter.get());
+        }
+
+        @Test
+        @DisplayName("being Serializable")
+        void serialize() {
+            reserializeAndAssert(adapter);
+        }
+    }
+
+    @Nested
+    @DisplayName("Provide reverse adapter for Guava Supplier")
+    class ReverseAdapter {
+
+        private com.google.common.base.Supplier<String> adapter;
+        private Supplier<String> adaptee;
+
+        @BeforeEach
+        void setUp() {
+            String value = TestValues.randomString();
+            adaptee = Suppliers2.adapt(Suppliers.ofInstance(value));
+            adapter = Suppliers2.reverse(adaptee);
+        }
+
+        @Test
+        @DisplayName("which returns adaptee values")
+        void gettingValues() {
+            assertEquals(adaptee.get(), adapter.get());
+        }
+
+        @Test
+        @DisplayName("which is Serializable")
+        void serialize() {
+            reserializeAndAssert(adapter);
+        }
+    }
+
+    @Nested
+    @DisplayName("Provide memoizing Supplier")
+    class Memoizing {
+
+        @Test
+        @DisplayName("which remembers values")
+        void remember() {
+            Supplier<Integer> supplier = new CountingSupplier();
+            assertOutput(0, supplier);
+            // We incremented the counter here.
+
+            Supplier<Integer> memoizing = Suppliers2.memoize(supplier);
+            // See that we get a new value from the adaptee.
+            assertOutput(1, memoizing);
+            // Should be the same as we memoize.
+            assertOutput(1, memoizing);
+            // Still the same.
+            assertOutput(1, memoizing);
+        }
+
+        void assertOutput(int expected, Supplier<Integer> supplier) {
+            assertEquals(expected, supplier.get()
+                                        .intValue());
+        }
+
+        /** The counter incrementing after each {@link #get()}. */
+        private class CountingSupplier implements Supplier<Integer> {
+
+            private int count = 0;
+
+            @Override
+            public Integer get() {
+                Integer result = count;
+                ++count;
+                return result;
+            }
+        }
+    }
+}

--- a/base/src/test/java/io/spine/util/Suppliers2Test.java
+++ b/base/src/test/java/io/spine/util/Suppliers2Test.java
@@ -114,9 +114,9 @@ class Suppliers2Test extends UtilityClassTest<Suppliers2> {
             assertOutput(1, memoizing);
         }
 
-        void assertOutput(int expected, Supplier<Integer> supplier) {
+        private void assertOutput(int expected, Supplier<Integer> supplier) {
             assertEquals(expected, supplier.get()
-                                        .intValue());
+                                           .intValue());
         }
 
         /** The counter incrementing after each {@link #get()}. */

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.51-SNAPSHOT'
+final def SPINE_VERSION = '0.10.53-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
+++ b/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing;
+
+import com.google.common.testing.NullPointerTester;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
+
+/**
+ * Abstract base for utility classes tests.
+ *
+ * @param <T> the type of the utility class under the test
+ * @author Alexander Yevsyukov
+ */
+@SuppressWarnings("UnstableApiUsage")
+public abstract class UtilityClassTest<T> {
+
+    private final Class<T> utilityClass;
+
+    protected UtilityClassTest(Class<T> aClass) {
+        utilityClass = aClass;
+    }
+
+    protected Class<T> getUtilityClass() {
+        return utilityClass;
+    }
+
+    @Test
+    @DisplayName("have utility constructor")
+    void hasUtilityConstructor() {
+        assertHasPrivateParameterlessCtor(getUtilityClass());
+    }
+
+    @Test
+    @DisplayName("not accept nulls in public static methods if the arg is non-Nullable")
+    void nullCheckPublicStaticMethods() {
+        NullPointerTester tester = new NullPointerTester();
+        setDefaults(tester);
+        tester.testAllPublicStaticMethods(getUtilityClass());
+    }
+
+    /**
+     * A callback to set default values for a passed {@linkplain NullPointerTester}.
+     *
+     * <p>Does nothing. Override to specify default values in a derived test.
+     */
+    @SuppressWarnings("NoopMethodInAbstractClass") // We do not force overriding without a need.
+    protected void setDefaults(@SuppressWarnings("unused") NullPointerTester tester) {
+        // Do nothing.
+    }
+}


### PR DESCRIPTION
This PR:
   * Introduces `Suppliers2` utility which adapts Guava `Supplier`s to those from Java 8.
   * Adds `UtilityClassTest` test class base.

Spine version advances to `0.10.53-SNAPSHOT`.