### PR TITLE
Adopt Google Truth

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -279,7 +279,9 @@
     </inspection_tool>
     <inspection_tool class="InconsistentLanguageLevel" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="IncrementDecrementUsedAsExpression" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="InnerClassMayBeStatic" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Tests" level="WARNING" enabled="false" />
+    </inspection_tool>
     <inspection_tool class="InstanceMethodNamingConvention" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Tests" level="INFO" enabled="false">
         <option name="m_regex" value="[a-z][A-Za-z\d]*" />

--- a/base/src/test/java/io/spine/base/TimeTest.java
+++ b/base/src/test/java/io/spine/base/TimeTest.java
@@ -36,6 +36,8 @@ import static io.spine.base.Time.resetProvider;
 import static io.spine.base.Time.setProvider;
 
 import io.spine.base.given.ConstantTimeProvider;
+
+import static io.spine.base.Time.systemTime;
 import static io.spine.base.given.GivenDurations.DURATION_1_MINUTE;
 import static io.spine.base.given.GivenDurations.DURATION_5_MINUTES;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
@@ -70,7 +72,7 @@ class TimeTest {
     @Test
     @DisplayName("resent TimeProvider to default value")
     void reset() {
-        Timestamp aMinuteAgo = subtract(Time.systemTime(), DURATION_1_MINUTE);
+        Timestamp aMinuteAgo = subtract(systemTime(), DURATION_1_MINUTE);
 
         setProvider(new ConstantTimeProvider(aMinuteAgo));
         resetProvider();
@@ -92,9 +94,9 @@ class TimeTest {
 
     @Test
     @DisplayName("obtain system time event if TimeProvider is set")
-    void systemTime() {
+    void gettingSystemTime() {
         setProvider(new ConstantTimeProvider(Timestamp.getDefaultInstance()));
 
-        assertNotEquals(0, Time.systemTime());
+        assertNotEquals(0, systemTime());
     }
 }

--- a/base/src/test/java/io/spine/base/given/ConstantTimeProvider.java
+++ b/base/src/test/java/io/spine/base/given/ConstantTimeProvider.java
@@ -20,44 +20,24 @@
 
 package io.spine.base.given;
 
-import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 
 /**
+ * The provider of the current time with value that does not change.
+ *
  * @author Mykhailo Drachuk
  */
-public class TimeTestEnv {
+public class ConstantTimeProvider implements Time.Provider {
 
-    private static final int SECONDS_IN_1_MINUTE = 60;
-    private static final int SECONDS_IN_5_MINUTES = 5 * SECONDS_IN_1_MINUTE;
+    private final Timestamp timestamp;
 
-    public static final Duration DURATION_1_MINUTE = newDuration(SECONDS_IN_1_MINUTE);
-    public static final Duration DURATION_5_MINUTES = newDuration(SECONDS_IN_5_MINUTES);
-
-    private static Duration newDuration(int seconds) {
-        return Duration.newBuilder()
-                       .setSeconds(seconds)
-                       .build();
+    public ConstantTimeProvider(Timestamp timestamp) {
+        this.timestamp = timestamp;
     }
 
-    /** Prevent instantiation of this test environment. */
-    private TimeTestEnv() {
-    }
-
-    /**
-     * The provider of the current time with value that does not change.
-     */
-    public static class ConstantTimeProvider implements Time.Provider {
-        private final Timestamp timestamp;
-
-        public ConstantTimeProvider(Timestamp timestamp) {
-            this.timestamp = timestamp;
-        }
-
-        @Override
-        public Timestamp getCurrentTime() {
-            return timestamp;
-        }
+    @Override
+    public Timestamp getCurrentTime() {
+        return timestamp;
     }
 }

--- a/base/src/test/java/io/spine/base/given/GivenDurations.java
+++ b/base/src/test/java/io/spine/base/given/GivenDurations.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base.given;
+
+import com.google.protobuf.Duration;
+
+/**
+ * @author Mykhailo Drachuk
+ */
+public class GivenDurations {
+
+    private static final int SECONDS_IN_1_MINUTE = 60;
+    private static final int SECONDS_IN_5_MINUTES = 5 * SECONDS_IN_1_MINUTE;
+
+    public static final Duration DURATION_1_MINUTE = newDuration(SECONDS_IN_1_MINUTE);
+    public static final Duration DURATION_5_MINUTES = newDuration(SECONDS_IN_5_MINUTES);
+
+    private static Duration newDuration(int seconds) {
+        return Duration.newBuilder()
+                       .setSeconds(seconds)
+                       .build();
+    }
+
+    /** Prevent instantiation of this test environment. */
+    private GivenDurations() {
+    }
+}

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.63-SNAPSHOT'
+final def SPINE_VERSION = '0.10.64-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -27,7 +27,8 @@ dependencies {
     api deps.build.protobuf
     api deps.test.junit4
     api deps.test.junit5Api
+    api deps.test.truth
+    api deps.test.guavaTestlib
     api deps.test.mockito
     api deps.test.hamcrest
-    api deps.test.guavaTestlib
 }


### PR DESCRIPTION
This PR adds Google Truth into dependencies, and migrates `TimeTest` to using this assertion framework.
