### PR TITLE
Remove redundant logging

### DIFF
--- a/base/src/main/java/io/spine/code/proto/FileDescriptors.java
+++ b/base/src/main/java/io/spine/code/proto/FileDescriptors.java
@@ -130,7 +130,7 @@ public final class FileDescriptors {
                     e, "Cannot get proto file descriptors. Path: %s", descriptorSetFile
             );
         }
-        log.debug("Found {} files: {}", files.size(), files);
+        log.debug("Found {} files.", files.size());
         return files;
     }
 

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.68-SNAPSHOT'
+final def SPINE_VERSION = '0.10.69-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
In this PR we remove overly large and redundant logging of `.desc` files lookup.

This problem is a blocker since Travis cannot build `core-java` with `--debug` option in Gradle—the log size is over 4 MB.