### PR TITLE
Remove Redundant Code Generation

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -32,6 +32,7 @@ apply plugin: 'com.google.protobuf'
 apply from: deps.scripts.testArtifacts
 
 dependencies {
+    // Re-generate standard Proto types, so they are included in `known_types.desc`.
     protobuf deps.build.protobuf
 
     testImplementation project(path: ":testlib")

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -32,6 +32,8 @@ apply plugin: 'com.google.protobuf'
 apply from: deps.scripts.testArtifacts
 
 dependencies {
+    protobuf deps.build.protobuf
+
     testImplementation project(path: ":testlib")
 }
 

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -62,9 +62,11 @@ sourceSets {
     }
 }
 
-clean {
-    delete "$projectDir/generated"
+task cleanGenerated(type: Delete) {
+    delete = "$projectDir/generated"
 }
+
+clean.dependsOn cleanGenerated
 
 jar {
     // See `base-validating-builders/README.md`.

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -32,8 +32,6 @@ apply plugin: 'com.google.protobuf'
 apply from: deps.scripts.testArtifacts
 
 dependencies {
-    protobuf deps.build.protobuf
-
     testImplementation project(path: ":testlib")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -253,6 +253,10 @@ subprojects {
             }
         }
     }
+
+    clean {
+        delete = "$projectDir/generated"
+    }
 }
 
 // IDEA project configuration.

--- a/tools/model-compiler/build.gradle
+++ b/tools/model-compiler/build.gradle
@@ -53,7 +53,6 @@ dependencies {
         exclude group: 'com.google.guava'
     }
 
-    testProtobuf project(':base')
     testImplementation project(':testlib')
     testImplementation deps.test.hamcrest
     testImplementation gradleTestKit()

--- a/tools/model-compiler/build.gradle
+++ b/tools/model-compiler/build.gradle
@@ -39,7 +39,6 @@ dependencies {
         exclude group: 'com.google.guava'
     }
 
-    implementation deps.build.protobuf
     implementation deps.gen.javaPoet
 
     // A library for parsing Java sources.

--- a/tools/protoc-plugin/build.gradle
+++ b/tools/protoc-plugin/build.gradle
@@ -24,9 +24,9 @@ group 'io.spine.tools'
 
 dependencies {
     implementation project(':base')
-
     implementation deps.gen.javaPoet
-    testProtobuf project(':base')
+
+    testCompile project(':base')
 }
 
 protobuf {


### PR DESCRIPTION
In this PR we remove the redundant generated classes. 

Before, all the `google.protobuf` and `spine.base` definitions were converted into Java in some modules tests. This might be leftovers from some kind of a debug process. Now, this code generation is not done anymore.

Also, since now all the `generated` directories are deleted on `:clean`.