### PR TITLE
Fix `MessageClass` Interface

### DIFF
--- a/base/src/main/java/io/spine/type/MessageClass.java
+++ b/base/src/main/java/io/spine/type/MessageClass.java
@@ -35,7 +35,7 @@ public abstract class MessageClass<M extends Message> extends ClassTypeValue<M> 
     /** The name of the type of proto messages represented by this class. */
     private final TypeName typeName;
 
-    protected MessageClass(Class<M> value) {
+    protected MessageClass(Class<? extends M> value) {
         super(value);
         this.typeName = TypeName.of(value);
     }

--- a/base/src/main/java/io/spine/validate/ConstraintViolations.java
+++ b/base/src/main/java/io/spine/validate/ConstraintViolations.java
@@ -150,7 +150,7 @@ public class ConstraintViolations {
     @Internal
     public abstract static class ExceptionFactory<E extends Exception,
                                                   M extends Message,
-                                                  C extends MessageClass<M>,
+                                                  C extends MessageClass<?>,
                                                   R extends ProtocolMessageEnum> {
 
         private final Iterable<ConstraintViolation> constraintViolations;

--- a/base/src/test/java/io/spine/type/MessageClassTest.java
+++ b/base/src/test/java/io/spine/type/MessageClassTest.java
@@ -58,7 +58,7 @@ class MessageClassTest {
 
         @SuppressWarnings("unchecked") // OK for tests.
         private TestMessageClass(Class<? extends Message> value) {
-            super((Class<Message>) value);
+            super(value);
         }
     }
 }


### PR DESCRIPTION
Since recently, `MessageClass` is parametrized with a type of the stored message type.

In this PR we change the signature of the constructor from `MessageClass(Class<M> value)` to `MessageClass(Class<? extends M> value)`, so that the extended classes have some wiggle room.

Also, the signature of `ExceptionFactory` was changed to allow any kinds of `MessageClass`-es, regardless of the wrapper type.