### PR TITLE
Mute Tests

### DIFF
--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.91-SNAPSHOT'
+final def SPINE_VERSION = '0.10.92-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * An {@link java.io.OutputStream} which stores its input.
+ *
+ * <p>The stream stores all the given bytes in a {@link java.nio.ByteBuffer}. The size of the buffer is
+ * exactly 1 MiB. If the steam is not {@linkplain #clear() cleared} before the buffer fills up,
+ * an {@link java.nio.BufferOverflowException} occurs.
+ *
+ * @author Dmytro Dashenkov
+ */
+final class MemoizingStream extends OutputStream {
+
+    private static final int ONE_MEBI_BYTE = 1024 * 1024;
+
+    private final ByteBuffer memory = ByteBuffer.allocate(ONE_MEBI_BYTE);
+
+    @Override
+    public void write(int b) {
+        if (b >= 0) {
+            @SuppressWarnings("NumericCastThatLosesPrecision")
+                // Adheres to the OutputStream contract.
+            byte byteValue = (byte) b;
+            memory.put(byteValue);
+        }
+    }
+
+    /**
+     * Clears the memoized input.
+     */
+    void clear() {
+        memory.clear();
+    }
+
+    /**
+     * Copies the memoized input into the given stream and {@linkplain #clear() clears} memory.
+     *
+     * @param stream the target stream
+     * @throws java.io.IOException if the target stream throws an {@link java.io.IOException} on a write operation
+     */
+    void flushTo(OutputStream stream) throws IOException {
+        int entryCount = memory.position();
+        for (int i = 0; i < entryCount; i++) {
+            byte byteValue = memory.get(i);
+            stream.write(byteValue);
+        }
+    }
+}

--- a/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
@@ -41,6 +41,10 @@ final class MemoizingStream extends OutputStream {
 
     @Override
     public void write(int b) {
+        /*
+           According to the `OutputStream` contract, a negative value may represent the end of
+           the stream. The actual data is the lowest 8 bits of the int.
+         */
         if (b >= 0) {
             @SuppressWarnings("NumericCastThatLosesPrecision")
                 // Adheres to the OutputStream contract.

--- a/testlib/src/main/java/io/spine/testing/logging/MuteLogging.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MuteLogging.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Mutes all the logging for a certain test case or test suite.
+ *
+ * <p>Any kind of output into the standard output streams is blocked by this annotation.
+ *
+ * <p>If the test fails, the output is printed into the standard error stream.
+ *
+ * <p>After the test completes, the standard output capabilities are restored.
+ *
+ * @author Dmytro Dashenkov
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(MuteLoggingExtension.class)
+public @interface MuteLogging {
+}

--- a/testlib/src/main/java/io/spine/testing/logging/MuteLoggingExtension.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MuteLoggingExtension.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Optional;
+
+/**
+ * A JUnit {@link org.junit.jupiter.api.extension.Extension Extension} which mutes all the logs
+ * for a test case.
+ *
+ * <p>Do not use this extension directly. Mark the target test method or class with
+ * the {@link MuteLogging} annotation.
+ *
+ * @see MuteLogging
+ * @author Dmytro Dashenkov
+ */
+public final class MuteLoggingExtension implements BeforeEachCallback, AfterEachCallback {
+
+    private final MemoizingStream memoizingStream = new MemoizingStream();
+    private final PrintStream temporaryOutputStream = new PrintStream(memoizingStream);
+    private final ProgramOutput temporaryOutput = ProgramOutput.into(temporaryOutputStream);
+
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        if (isAnnotated(context)) {
+            mute();
+        }
+    }
+
+    @Override
+    public void afterEach(ExtensionContext context) throws IOException {
+        if (isAnnotated(context)) {
+            unMute(context);
+        }
+    }
+
+    private void mute() {
+        temporaryOutput.install();
+    }
+
+    private void unMute(ExtensionContext context) throws IOException {
+        ProgramOutput standardOutput = ProgramOutput.fromSystem();
+        standardOutput.install();
+        Optional<Throwable> exception = context.getExecutionException();
+        if (exception.isPresent()) {
+            memoizingStream.flushTo(standardOutput.err);
+        } else {
+            memoizingStream.clear();
+        }
+    }
+
+    private static boolean isAnnotated(ExtensionContext context) {
+        boolean result = context.getElement()
+                                .map(element -> element.isAnnotationPresent(MuteLogging.class))
+                                .orElse(false);
+        return result;
+    }
+
+    /**
+     * The output of a software component.
+     */
+    private static final class ProgramOutput {
+
+        @SuppressWarnings("UseOfSystemOutOrSystemErr")
+        private static final ProgramOutput SYSTEM = new ProgramOutput(System.out, System.err);
+
+        private final PrintStream out;
+        private final PrintStream err;
+
+        private ProgramOutput(PrintStream out, PrintStream err) {
+            this.out = out;
+            this.err = err;
+        }
+
+        /**
+         * Creates an {@code ProgramOutput} into the given stream.
+         *
+         * <p>Both the output and error streams are represented with the given target stream.
+         *
+         * @param stream the target stream
+         * @return new instance of {@code ProgramOutput}
+         */
+        private static ProgramOutput into(PrintStream stream) {
+            return new ProgramOutput(stream, stream);
+        }
+
+        /**
+         * Obtains an instance of {@code ProgramOutput} from the standard I/O of this process.
+         *
+         * @return the standard I/O output
+         */
+        private static ProgramOutput fromSystem() {
+            return SYSTEM;
+        }
+
+        /**
+         * Installs this output for the current process.
+         */
+        private void install() {
+            System.setOut(out);
+            System.setErr(err);
+        }
+    }
+}

--- a/testlib/src/main/java/io/spine/testing/logging/MuteLoggingExtension.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MuteLoggingExtension.java
@@ -46,16 +46,12 @@ public final class MuteLoggingExtension implements BeforeEachCallback, AfterEach
 
     @Override
     public void beforeEach(ExtensionContext context) {
-        if (isAnnotated(context)) {
-            mute();
-        }
+        mute();
     }
 
     @Override
     public void afterEach(ExtensionContext context) throws IOException {
-        if (isAnnotated(context)) {
-            unMute(context);
-        }
+        unMute(context);
     }
 
     private void mute() {
@@ -71,13 +67,6 @@ public final class MuteLoggingExtension implements BeforeEachCallback, AfterEach
         } else {
             memoizingStream.clear();
         }
-    }
-
-    private static boolean isAnnotated(ExtensionContext context) {
-        boolean result = context.getElement()
-                                .map(element -> element.isAnnotationPresent(MuteLogging.class))
-                                .orElse(false);
-        return result;
     }
 
     /**

--- a/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
@@ -31,6 +31,7 @@ import static com.google.common.primitives.Bytes.asList;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.TestValues.random;
 import static java.lang.Byte.MAX_VALUE;
+import static java.lang.Byte.MIN_VALUE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("MemoizingStream should")
@@ -101,6 +102,20 @@ class MemoizingStreamTest {
 
         assertThrows(BufferOverflowException.class, () -> stream.write(42));
         checkMemoized(stream, input);
+    }
+
+    @Test
+    @DisplayName("ignore negative values")
+    void negatives() throws IOException {
+        MemoizingStream stream = new MemoizingStream();
+
+        stream.write(-1);
+        stream.write(-42);
+        stream.write(10);
+        stream.write(0);
+        stream.write(MIN_VALUE);
+
+        checkMemoized(stream, new byte[]{(byte) 10, (byte) 0});
     }
 
     private static void checkMemoized(MemoizingStream stream, byte[] expected)

--- a/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.BufferOverflowException;
+
+import static com.google.common.primitives.Bytes.asList;
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.testing.TestValues.random;
+import static java.lang.Byte.MAX_VALUE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@DisplayName("MemoizingStream should")
+class MemoizingStreamTest {
+
+    private static final byte[] EMPTY_BYTES = {};
+
+    @Test
+    @DisplayName("flush all the input")
+    void flushEverything() throws IOException {
+        MemoizingStream stream = new MemoizingStream();
+        byte[] input = randomBytes(42);
+
+        stream.write(input);
+
+        checkMemoized(stream, input);
+    }
+
+    @Test
+    @DisplayName("not store flushed bytes")
+    void clearAfterFlush() throws IOException {
+        MemoizingStream stream = new MemoizingStream();
+        byte[] input = randomBytes(12);
+
+        stream.write(input);
+
+        checkMemoized(stream, input);
+        checkMemoized(stream, EMPTY_BYTES);
+    }
+
+    @Test
+    @DisplayName("clear memoized bytes on demand")
+    void clearOnDemand() throws IOException {
+        MemoizingStream stream = new MemoizingStream();
+        byte[] input = randomBytes(4);
+
+        stream.write(input);
+        stream.clear();
+
+        checkMemoized(stream, EMPTY_BYTES);
+    }
+
+    @Test
+    @DisplayName("clear memoized bytes idempotently")
+    void clearIdempotently() throws IOException {
+        MemoizingStream stream = new MemoizingStream();
+        byte[] input = randomBytes(4);
+
+        stream.write(input);
+
+        checkMemoized(stream, input);
+        checkMemoized(stream, EMPTY_BYTES);
+
+        stream.clear();
+        stream.clear();
+
+        checkMemoized(stream, EMPTY_BYTES);
+    }
+
+    @Test
+    @DisplayName("store 1 MiB of data")
+    void capacity() throws IOException {
+        int mebiByte = 1024 * 1024;
+        byte[] input = randomBytes(mebiByte);
+
+        MemoizingStream stream = new MemoizingStream();
+        stream.write(input);
+
+        assertThrows(BufferOverflowException.class, () -> stream.write(42));
+        checkMemoized(stream, input);
+    }
+
+    private static void checkMemoized(MemoizingStream stream, byte[] expected)
+            throws IOException {
+        ByteArrayOutputStream outputCollector = new ByteArrayOutputStream();
+        stream.flushTo(outputCollector);
+        byte[] actualBytes = outputCollector.toByteArray();
+
+        assertThat(actualBytes).asList().containsAllIn(asList(expected));
+    }
+
+    private static byte[] randomBytes(int count) {
+        byte[] result = new byte[count];
+        for (int i = 0; i < count; i++) {
+            @SuppressWarnings("NumericCastThatLosesPrecision") // OK because of the bounds.
+            byte randomByte = (byte) random(0, MAX_VALUE);
+            result[i] = randomByte;
+        }
+        return result;
+    }
+}

--- a/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
@@ -75,8 +75,8 @@ class MemoizingStreamTest {
     }
 
     @Test
-    @DisplayName("clear memoized bytes idempotently")
-    void clearIdempotently() throws IOException {
+    @DisplayName("allow to clear memoized bytes any number of times")
+    void clearAnyNumberOfTimes() throws IOException {
         MemoizingStream stream = new MemoizingStream();
         byte[] input = randomBytes(4);
 

--- a/testlib/src/test/java/io/spine/testing/logging/MuteLoggingExtensionTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MuteLoggingExtensionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.lang.reflect.Modifier.isPublic;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("UseOfSystemOutOrSystemErr") // Test std I/O overloading.
+@DisplayName("MuteLogging JUnit Extension should")
+class MuteLoggingExtensionTest {
+
+    @Test
+    @DisplayName("have public parameter-less constructor")
+    void ctor() throws NoSuchMethodException {
+        Constructor<MuteLoggingExtension> constructor = MuteLoggingExtension.class.getConstructor();
+        int modifiers = constructor.getModifiers();
+        assertTrue(isPublic(modifiers));
+    }
+
+    @Test
+    @DisplayName("hide the program output")
+    void hideOutput() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(err));
+
+        MuteLoggingExtension extension = new MuteLoggingExtension();
+        extension.beforeEach(successfulContext());
+        System.out.println("Output Message");
+        System.out.println("Error Message");
+        extension.afterEach(successfulContext());
+
+        assertEquals(0, out.size());
+        assertEquals(0, err.size());
+    }
+
+    @Test
+    @DisplayName("print the program output into std err stream if the test fails")
+    void printOutputOnException() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        System.setOut(new PrintStream(out));
+        System.setErr(new PrintStream(err));
+
+        MuteLoggingExtension extension = new MuteLoggingExtension();
+        extension.beforeEach(successfulContext());
+        String outputMessage = "out";
+        String errorMessage = "err";
+        System.out.println(outputMessage);
+        System.out.println(errorMessage);
+        extension.afterEach(failedContext());
+
+        assertEquals(0, out.size());
+        String actualErrorOutput = new String(err.toByteArray());
+        assertThat(actualErrorOutput).contains(
+                outputMessage
+              + System.lineSeparator()
+              + errorMessage
+        );
+    }
+
+    private static ExtensionContext successfulContext() {
+        ExtensionContext context = mock(ExtensionContext.class);
+        when(context.getExecutionException()).thenReturn(Optional.empty());
+        return context;
+    }
+
+    private static ExtensionContext failedContext() {
+        ExtensionContext context = mock(ExtensionContext.class);
+        when(context.getExecutionException()).thenReturn(Optional.of(new TestThrowable()));
+        return context;
+    }
+
+    private static class TestThrowable extends Throwable {
+        private static final long serialVersionUID = 0L;
+    }
+}

--- a/testlib/src/test/java/io/spine/testing/logging/MuteLoggingTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MuteLoggingTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import com.google.common.truth.ObjectArraySubject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extension;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("@MuteLogging should")
+class MuteLoggingTest {
+
+    @Test
+    @DisplayName("be marked as an extension")
+    void annotated() {
+        Class<MuteLogging> annotation = MuteLogging.class;
+        ExtendWith extendsWith = annotation.getAnnotation(ExtendWith.class);
+        Class<? extends Extension>[] extensions = extendsWith.value();
+        ObjectArraySubject<Class<? extends Extension>> assertExtensions = assertThat(extensions);
+        assertExtensions.hasLength(1);
+        assertExtensions.asList().contains(MuteLoggingExtension.class);
+    }
+}


### PR DESCRIPTION
In this PR we introduce a test utility for turning off a particular test logging.

To mute a test case or a test suite, mark it with the `@MuteTests` annotation. 