### PR TITLE
Fix field masks

### DIFF
--- a/base/src/main/java/io/spine/code/java/DefaultJavaProject.java
+++ b/base/src/main/java/io/spine/code/java/DefaultJavaProject.java
@@ -104,7 +104,7 @@ public final class DefaultJavaProject extends DefaultProject {
      * A root source code directory for manually written code.
      *
      * <p>Adds a root directory for the proto code in addition to those exposed
-     * by {@link SourceRoot}.
+     * by {@link io.spine.code.DefaultProject.SourceRoot SourceRoot}.
      */
     public static class HandmadeCodeRoot extends JavaCodeRoot {
 

--- a/ext.gradle
+++ b/ext.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.10.92-SNAPSHOT'
+final def SPINE_VERSION = '0.10.93-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/testlib/src/main/java/io/spine/testing/Tests.java
+++ b/testlib/src/main/java/io/spine/testing/Tests.java
@@ -166,7 +166,7 @@ public final class Tests {
             if (field.isRepeated()) {
                 continue;
             }
-            assertEquals(message.hasField(field), paths.contains(field.getFullName()));
+            assertEquals(message.hasField(field), paths.contains(field.getName()));
         }
     }
 

--- a/testlib/src/main/java/io/spine/testing/Tests.java
+++ b/testlib/src/main/java/io/spine/testing/Tests.java
@@ -22,13 +22,17 @@ package io.spine.testing;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.truth.Truth.assertThat;
 import static java.lang.Math.abs;
 
 /**
@@ -161,8 +165,18 @@ public final class Tests {
     public static void assertMatchesMask(Message message, FieldMask fieldMask) {
         List<String> paths = fieldMask.getPathsList();
 
-        for (Descriptors.FieldDescriptor field : message.getDescriptorForType()
-                                                        .getFields()) {
+        List<FieldDescriptor> fields = message.getDescriptorForType()
+                                              .getFields();
+
+        List<String> fieldNames = fields.stream()
+                                        .map(FieldDescriptor::getName)
+                                        .collect(toImmutableList());
+
+        // Assert that the passed field mask contains the field of this message type.
+        assertThat(fieldNames).containsAllIn(paths);
+
+        // Assert that values match the field mask.
+        for (FieldDescriptor field : fields) {
             if (field.isRepeated()) {
                 continue;
             }

--- a/testlib/src/test/java/io/spine/testing/TestsShould.java
+++ b/testlib/src/test/java/io/spine/testing/TestsShould.java
@@ -24,6 +24,7 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.FieldMaskUtil;
 import io.spine.testing.given.TestsTestEnv.ClassThrowingExceptionInConstructor;
 import io.spine.testing.given.TestsTestEnv.ClassWithCtorWithArgs;
 import io.spine.testing.given.TestsTestEnv.ClassWithPrivateCtor;
@@ -43,10 +44,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * @author Alexander Yevsyukov
- */
-@SuppressWarnings({"InnerClassMayBeStatic", "ClassCanBeStatic"})
 @DisplayName("Tests utility class should")
 class TestsShould extends UtilityClassTest<Tests> {
 
@@ -157,13 +154,7 @@ class TestsShould extends UtilityClassTest<Tests> {
         @Test
         @DisplayName("when field is matched")
         void fieldIsPresent() {
-            String fieldPath = Timestamp.getDescriptor()
-                                        .getFields()
-                                        .get(0)
-                                        .getFullName();
-            FieldMask.Builder builder = FieldMask.newBuilder();
-            builder.addPaths(fieldPath);
-            FieldMask fieldMask = builder.build();
+            FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Timestamp.class, 1);
 
             assertMatchesMask(timestampMsg, fieldMask);
         }
@@ -171,13 +162,7 @@ class TestsShould extends UtilityClassTest<Tests> {
         @Test
         @DisplayName("throws the error when field is not present")
         void fieldIsNotPresent() {
-            String fieldPath = Any.getDescriptor()
-                                  .getFields()
-                                  .get(0)
-                                  .getFullName();
-            FieldMask.Builder builder = FieldMask.newBuilder();
-            builder.addPaths(fieldPath);
-            FieldMask fieldMask = builder.build();
+            FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Any.class, 1);
 
             assertThrows(AssertionError.class, () -> assertMatchesMask(timestampMsg, fieldMask));
         }
@@ -213,6 +198,7 @@ class TestsShould extends UtilityClassTest<Tests> {
         @DisplayName("when values are equal")
         void equalValues() {
             long expectedValue = getValue();
+            @SuppressWarnings("UnnecessaryLocalVariable") // For readability of this test.
             long actualValue = expectedValue;
             assertInDelta(expectedValue, actualValue, 0);
         }

--- a/testlib/src/test/java/io/spine/testing/logging/MuteLoggingExtensionTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MuteLoggingExtensionTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.testing.logging;
 
+import com.google.common.base.Charsets;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -86,7 +87,7 @@ class MuteLoggingExtensionTest {
         extension.afterEach(failedContext());
 
         assertEquals(0, out.size());
-        String actualErrorOutput = new String(err.toByteArray());
+        String actualErrorOutput = new String(err.toByteArray(), Charsets.UTF_8);
         assertThat(actualErrorOutput).contains(
                 outputMessage
               + System.lineSeparator()

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/GradleProject.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.gradle;
 
+import com.google.common.base.Charsets;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import org.gradle.api.Action;
 import org.gradle.testkit.runner.BuildResult;
@@ -28,7 +29,6 @@ import org.gradle.testkit.runner.GradleRunner;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -309,7 +309,7 @@ public final class GradleProject {
                                     .resolve(path);
             try {
                 Files.createDirectories(sourcePath.getParent());
-                Files.write(sourcePath, lines, Charset.forName("UTF-8"));
+                Files.write(sourcePath, lines, Charsets.UTF_8);
             } catch (IOException e) {
                 throw illegalStateWithCauseOf(e);
             }

--- a/tools/proto-js-plugin/src/main/java/io/spine/js/generate/JsFileWriter.java
+++ b/tools/proto-js-plugin/src/main/java/io/spine/js/generate/JsFileWriter.java
@@ -21,6 +21,8 @@
 package io.spine.js.generate;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import io.spine.code.js.Directory;
 import io.spine.code.js.FileName;
@@ -89,9 +91,10 @@ public final class JsFileWriter {
     public void write(JsOutput jsOutput) {
         checkNotNull(jsOutput);
         try {
-            byte[] bytes = jsOutput.toString()
-                                   .getBytes();
-            Files.write(filePath, bytes, CREATE, TRUNCATE_EXISTING);
+            Files.write(filePath,
+                        ImmutableList.of(jsOutput.toString()),
+                        Charsets.UTF_8,
+                        CREATE, TRUNCATE_EXISTING);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -108,9 +111,7 @@ public final class JsFileWriter {
     public void append(JsOutput jsOutput) {
         checkNotNull(jsOutput);
         try {
-            byte[] bytes = jsOutput.toString()
-                                   .getBytes();
-            Files.write(filePath, bytes, APPEND);
+            Files.write(filePath, ImmutableList.of(jsOutput.toString()), Charsets.UTF_8, APPEND);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/tools/proto-js-plugin/src/main/java/io/spine/js/generate/field/parser/primitive/PrimitiveParser.java
+++ b/tools/proto-js-plugin/src/main/java/io/spine/js/generate/field/parser/primitive/PrimitiveParser.java
@@ -32,8 +32,7 @@ import io.spine.js.generate.JsOutput;
  * method is not returning any generated code.
  *
  * @author Dmytro Kuzmin
- * @see <a href="https://developers.google.com/protocol-buffers/docs/proto3#json">Protobuf JSON
- * Mapping</a> for how the various primitive types are encoded in JSON
+ * @see <a href="https://developers.google.com/protocol-buffers/docs/proto3#json">Protobuf JSON Mapping</a>
  */
 public interface PrimitiveParser {
 

--- a/tools/proto-js-plugin/src/test/java/io/spine/js/generate/given/FileWriters.java
+++ b/tools/proto-js-plugin/src/test/java/io/spine/js/generate/given/FileWriters.java
@@ -20,6 +20,8 @@
 
 package io.spine.js.generate.given;
 
+import com.google.common.base.Charsets;
+
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -42,7 +44,7 @@ public final class FileWriters {
     assertFileContains(Path filePath, CharSequence toSearch) throws IOException {
         assertTrue(exists(filePath));
         byte[] bytes = readAllBytes(filePath);
-        String fileContent = new String(bytes);
+        String fileContent = new String(bytes, Charsets.UTF_8);
         assertThat(fileContent).contains(toSearch);
     }
 
@@ -50,7 +52,7 @@ public final class FileWriters {
     assertFileNotContains(Path filePath, CharSequence toSearch) throws IOException {
         assertTrue(exists(filePath));
         byte[] bytes = readAllBytes(filePath);
-        String fileContent = new String(bytes);
+        String fileContent = new String(bytes, Charsets.UTF_8);
         assertThat(fileContent).doesNotContain(toSearch);
     }
 }

--- a/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
+++ b/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
@@ -105,9 +105,9 @@ public class ReflectionsPlugin extends SpinePlugin {
         reflections.save(reflectionsOutputFilePath);
     }
 
-    private static Set<URL> toUrls(File outputDir) {
+    @SuppressWarnings({"CollectionContainsUrl", "URLEqualsHashCode"})
         // because they are file URIs, they will not cause any network-related issues.
-        @SuppressWarnings({"CollectionContainsUrl", "URLEqualsHashCode"})
+    private static Set<URL> toUrls(File outputDir) {
         ImmutableSet<URL> urls;
         try {
             urls = ImmutableSet.of(outputDir.toURI()

--- a/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
+++ b/tools/reflections-plugin/src/main/java/io/spine/tools/reflections/ReflectionsPlugin.java
@@ -106,7 +106,7 @@ public class ReflectionsPlugin extends SpinePlugin {
     }
 
     @SuppressWarnings({"CollectionContainsUrl", "URLEqualsHashCode"})
-        // because they are file URIs, they will not cause any network-related issues.
+    // because they are file URIs, they will not cause any network-related issues.
     private static Set<URL> toUrls(File outputDir) {
         ImmutableSet<URL> urls;
         try {


### PR DESCRIPTION
This PR fixes the way field masks are created and checked. Previously, we assumed that field masks contain full field names. The standard `FieldMaskUtil` creates masks with short names.

This PR also addresses Error Prone and Javadoc warnings.
