### PR TITLE
Remove the log buffer size limitation

### DIFF
--- a/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
@@ -35,9 +35,9 @@ import java.nio.ByteBuffer;
  */
 final class MemoizingStream extends OutputStream {
 
-    private static final int ONE_MEBI_BYTE = 1024 * 1024;
+    private static final int TEN_MEBI_BYTES = 10 * 1024 * 1024;
 
-    private final ByteBuffer memory = ByteBuffer.allocate(ONE_MEBI_BYTE);
+    private final ByteBuffer memory = ByteBuffer.allocate(TEN_MEBI_BYTES);
 
     @Override
     public void write(int b) {

--- a/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
@@ -36,7 +36,7 @@ final class MemoizingStream extends OutputStream {
     private final List<Byte> memory = newArrayListWithExpectedSize(ONE_MEBI_BYTE);
 
     @Override
-    public void write(int b) {
+    public synchronized void write(int b) {
         /*
            According to the `OutputStream` contract, a negative value may represent the end of
            the stream. The actual data is the lowest 8 bits of the int.
@@ -52,7 +52,7 @@ final class MemoizingStream extends OutputStream {
     /**
      * Clears the memoized input.
      */
-    void clear() {
+    synchronized void clear() {
         memory.clear();
     }
 
@@ -62,7 +62,7 @@ final class MemoizingStream extends OutputStream {
      * @param stream the target stream
      * @throws IOException if the target stream throws an {@link IOException} on a write operation
      */
-    void flushTo(OutputStream stream) throws IOException {
+    synchronized void flushTo(OutputStream stream) throws IOException {
         byte[] buffer = new byte[memory.size()];
         for (int i = 0; i < memory.size(); i++) {
             buffer[i] = memory.get(i);

--- a/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
@@ -25,14 +25,12 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.BufferOverflowException;
 
 import static com.google.common.primitives.Bytes.asList;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.TestValues.random;
 import static java.lang.Byte.MAX_VALUE;
 import static java.lang.Byte.MIN_VALUE;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("MemoizingStream should")
 class MemoizingStreamTest {
@@ -89,19 +87,6 @@ class MemoizingStreamTest {
         stream.clear();
 
         checkMemoized(stream, EMPTY_BYTES);
-    }
-
-    @Test
-    @DisplayName("store 1 MiB of data")
-    void capacity() throws IOException {
-        int mebiByte = 1024 * 1024;
-        byte[] input = randomBytes(mebiByte);
-
-        MemoizingStream stream = new MemoizingStream();
-        stream.write(input);
-
-        assertThrows(BufferOverflowException.class, () -> stream.write(42));
-        checkMemoized(stream, input);
     }
 
     @Test


### PR DESCRIPTION
Before now, tests marked with `@MuteTests` could log more than 1 MiB of data. In this PR we remove this limitation by migrating from `ByteBuffer` to `List<Byte>`.

Also, in this PR we allow such tests to be executed in parallel without a risk of losing logs. 