### PR TITLE
Generate a UUID message using `Identifier`

### DIFF
--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -22,6 +22,8 @@ package io.spine.base;
 
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.Any;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.Message;
@@ -36,11 +38,13 @@ import io.spine.string.StringifierRegistry;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.protobuf.TextFormat.shortDebugString;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -222,6 +226,24 @@ public final class Identifier<I> {
         String id = UUID.randomUUID()
                         .toString();
         return id;
+    }
+
+    /**
+     * Generates a UUID message of the specified class.
+     *
+     * <p>A UUID message should have a single string field named {@code uuid}.
+     *
+     * @param idClass
+     *         the class of the message to generate
+     * @param <I>
+     *         the type of the message to generate
+     * @return a message with the initialized {@code uuid} field
+     * @throws java.lang.IllegalStateException
+     *         if the message is not a UUID message
+     */
+    public static <I extends Message> I generate(Class<I> idClass) {
+        UuidMessage<I> uuidMessage = UuidMessage.of(idClass);
+        return uuidMessage.generate();
     }
 
     /**
@@ -508,6 +530,50 @@ public final class Identifier<I> {
             Message msg = toMessage(id);
             Any result = AnyPacker.pack(msg);
             return result;
+        }
+    }
+
+    /**
+     * A message containing a single string field with the {@linkplain #FIELD_NAME name}.
+     */
+    private static class UuidMessage<I extends Message> {
+
+        private static final String FIELD_NAME = "uuid";
+        private static final FieldDescriptor.Type TYPE = FieldDescriptor.Type.STRING;
+
+        private final Class<I> idClass;
+        private final FieldDescriptor uuidField;
+
+        private UuidMessage(Class<I> idClass, FieldDescriptor uuidField) {
+            this.idClass = idClass;
+            this.uuidField = uuidField;
+        }
+
+        private static <I extends Message> UuidMessage<I> of(Class<I> idClass) {
+            Descriptors.Descriptor message = Messages.newInstance(idClass)
+                                                     .getDescriptorForType();
+            List<FieldDescriptor> fields = message.getFields();
+            checkState(fields.size() == 1, "A UUID message should have a single field.");
+            FieldDescriptor uuidField = fields.get(0);
+            checkUuidField(uuidField);
+            return new UuidMessage<>(idClass, uuidField);
+        }
+
+        @SuppressWarnings("unchecked" /* It is OK as the builder is obtained by the specified class. */)
+        private I generate() {
+            Message initializedId = Messages.builderFor(idClass)
+                                            .setField(uuidField, newUuid())
+                                            .build();
+            return (I) initializedId;
+        }
+
+        private static void checkUuidField(FieldDescriptor field) {
+            boolean nameMatches = field.getName()
+                                       .equals(FIELD_NAME);
+            boolean typeMatches = field.getType() == TYPE;
+            boolean isUuidField = nameMatches && typeMatches;
+            checkState(isUuidField,
+                       "A UUID message should have a single string field named %s.", FIELD_NAME);
         }
     }
 }

--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -22,8 +22,6 @@ package io.spine.base;
 
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.Any;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Int32Value;
 import com.google.protobuf.Int64Value;
 import com.google.protobuf.Message;
@@ -38,7 +36,6 @@ import io.spine.string.StringifierRegistry;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -530,49 +527,6 @@ public final class Identifier<I> {
             Message msg = toMessage(id);
             Any result = AnyPacker.pack(msg);
             return result;
-        }
-    }
-
-    /**
-     * A message containing a single string field with the {@linkplain #FIELD_NAME name}.
-     */
-    private static class UuidMessage<I extends Message> {
-
-        private static final String FIELD_NAME = "uuid";
-
-        private final Class<I> idClass;
-        private final FieldDescriptor uuidField;
-
-        private UuidMessage(Class<I> idClass, FieldDescriptor uuidField) {
-            this.idClass = idClass;
-            this.uuidField = uuidField;
-        }
-
-        private static <I extends Message> UuidMessage<I> of(Class<I> idClass) {
-            Descriptors.Descriptor message = Messages.newInstance(idClass)
-                                                     .getDescriptorForType();
-            List<FieldDescriptor> fields = message.getFields();
-            checkState(fields.size() == 1, "A UUID message should have a single field.");
-            FieldDescriptor uuidField = fields.get(0);
-            checkUuidField(uuidField);
-            return new UuidMessage<>(idClass, uuidField);
-        }
-
-        @SuppressWarnings("unchecked" /* It is OK as the builder is obtained by the specified class. */)
-        private I generate() {
-            Message initializedId = Messages.builderFor(idClass)
-                                            .setField(uuidField, newUuid())
-                                            .build();
-            return (I) initializedId;
-        }
-
-        private static void checkUuidField(FieldDescriptor field) {
-            boolean nameMatches = field.getName()
-                                       .equals(FIELD_NAME);
-            boolean typeMatches = field.getType() == FieldDescriptor.Type.STRING;
-            boolean isUuidField = nameMatches && typeMatches;
-            checkState(isUuidField,
-                       "A UUID message should have a single string field named %s.", FIELD_NAME);
         }
     }
 }

--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -539,7 +539,6 @@ public final class Identifier<I> {
     private static class UuidMessage<I extends Message> {
 
         private static final String FIELD_NAME = "uuid";
-        private static final FieldDescriptor.Type TYPE = FieldDescriptor.Type.STRING;
 
         private final Class<I> idClass;
         private final FieldDescriptor uuidField;
@@ -570,7 +569,7 @@ public final class Identifier<I> {
         private static void checkUuidField(FieldDescriptor field) {
             boolean nameMatches = field.getName()
                                        .equals(FIELD_NAME);
-            boolean typeMatches = field.getType() == TYPE;
+            boolean typeMatches = field.getType() == FieldDescriptor.Type.STRING;
             boolean isUuidField = nameMatches && typeMatches;
             checkState(isUuidField,
                        "A UUID message should have a single string field named %s.", FIELD_NAME);

--- a/base/src/main/java/io/spine/base/UuidMessage.java
+++ b/base/src/main/java/io/spine/base/UuidMessage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base;
+
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import io.spine.protobuf.Messages;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * A message containing a single string field with the {@linkplain #FIELD_NAME name}.
+ */
+class UuidMessage<I extends Message> {
+
+    private static final String FIELD_NAME = "uuid";
+
+    private final Class<I> idClass;
+    private final Descriptors.FieldDescriptor uuidField;
+
+    private UuidMessage(Class<I> idClass, Descriptors.FieldDescriptor uuidField) {
+        this.idClass = idClass;
+        this.uuidField = uuidField;
+    }
+
+    /**
+     * Creates a new instance by the specified class.
+     *
+     * @param idClass
+     *         the class of the Protobuf message
+     * @param <I>
+     *         the type of the Protobuf message
+     * @return a new instance
+     */
+    static <I extends Message> UuidMessage<I> of(Class<I> idClass) {
+        Descriptors.Descriptor message = Messages.newInstance(idClass)
+                                                 .getDescriptorForType();
+        List<Descriptors.FieldDescriptor> fields = message.getFields();
+        checkState(fields.size() == 1, "A UUID message should have a single field.");
+        Descriptors.FieldDescriptor uuidField = fields.get(0);
+        checkUuidField(uuidField);
+        return new UuidMessage<>(idClass, uuidField);
+    }
+
+    /**
+     * Generates an instance of the UUID message.
+     *
+     * @return a message instance with the initialized {@code uuid} field
+     */
+    @SuppressWarnings("unchecked" /* It is OK as the builder is obtained by the specified class. */)
+    I generate() {
+        Message initializedId = Messages.builderFor(idClass)
+                                        .setField(uuidField, Identifier.newUuid())
+                                        .build();
+        return (I) initializedId;
+    }
+
+    private static void checkUuidField(Descriptors.FieldDescriptor field) {
+        boolean nameMatches = field.getName()
+                                   .equals(FIELD_NAME);
+        boolean typeMatches = field.getType() == Descriptors.FieldDescriptor.Type.STRING;
+        boolean isUuidField = nameMatches && typeMatches;
+        checkState(isUuidField,
+                   "A UUID message should have a single string field named %s.", FIELD_NAME);
+    }
+}

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -381,7 +381,7 @@ class IdentifierTest {
 
         @Test
         @DisplayName("it contains more than one field")
-        void moreThanTwoFields() {
+        void moreThanOneField() {
             assertThrows(IllegalStateException.class, () -> Identifier.generate(Any.class));
         }
 

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -31,6 +31,7 @@ import io.spine.protobuf.AnyPacker;
 import io.spine.test.identifiers.NestedMessageId;
 import io.spine.test.identifiers.SeveralFieldsId;
 import io.spine.test.identifiers.TimestampFieldId;
+import io.spine.test.identifiers.UuidMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -368,6 +369,29 @@ class IdentifierTest {
         }
     }
 
+    @Nested
+    @DisplayName("not generate UUID-based value if")
+    class NotGenerateMessageUuid {
+
+        @Test
+        @DisplayName("the field name is not `uuid`")
+        void nameIsInvalid() {
+            assertThrows(IllegalStateException.class, () -> Identifier.generate(StringValue.class));
+        }
+
+        @Test
+        @DisplayName("it contains more than one field")
+        void moreThanTwoFields() {
+            assertThrows(IllegalStateException.class, () -> Identifier.generate(Any.class));
+        }
+
+        @Test
+        @DisplayName("the field is not string")
+        void fieldNotString() {
+            assertThrows(IllegalStateException.class, () -> Identifier.generate(Int32Value.class));
+        }
+    }
+
     @Test
     @DisplayName("unpack Any")
     void unpackAny() {
@@ -404,5 +428,13 @@ class IdentifierTest {
     @DisplayName("declare ID_PROPERTY_SUFFIX")
     void idPropSuffix() {
         assertThat(Identifier.ID_PROPERTY_SUFFIX).isEqualTo("id");
+    }
+
+    @Test
+    @DisplayName("generate UUID-based message")
+    void generateUuidMessage() {
+        UuidMessage uuidMessage = Identifier.generate(UuidMessage.class);
+        String uuid = uuidMessage.getUuid();
+        assertFalse(uuid.isEmpty());
     }
 }

--- a/base/src/test/proto/spine/test/identifiers_should.proto
+++ b/base/src/test/proto/spine/test/identifiers_should.proto
@@ -26,13 +26,13 @@ import "spine/options.proto";
 option (type_url_prefix) = "type.spine.io";
 option java_package="io.spine.test.identifiers";
 option java_multiple_files = true;
-option java_outer_classname = "IdentifiersShouldProto";
+option java_outer_classname = "IdentifierTestProto";
 
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
 
-// Only for usage in `IdentifiersShould` class.
+// Only for usage in `IdentifierTest` class.
 
 message NestedMessageId {
     google.protobuf.StringValue id = 1;
@@ -52,4 +52,9 @@ message IdWithPrimitiveFields {
     string name = 1;
     int32 number = 2;
     bool flag = 3;
+}
+
+// A message with a single `uuid` field.
+message UuidMessage {
+    string uuid = 1;
 }

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.11.8-SNAPSHOT'
+final def SPINE_VERSION = '0.11.9-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes #206.

Now, it is possible to generate a so-called `UuidMessage` using `Identifier`. The message is a Protobuf `Message` with a single string field named `uuid`. During the generation, the `uuid` field is filled with a value obtained from `Identifier.newUuid()`.

So, if you have a message like:

```proto
message SessionId {
    string uuid = 1;
}
```

You can generate it in this way:

```java
SessionId id = Identifier.generate(SessionId.class);
```

If a message doesn't match the requirements, an exception is thrown.

The framework version was bumped to `0.11.9-SNAPSHOT`.