### PR TITLE
Assume entity IDs required by default

### DIFF
--- a/base/src/main/java/io/spine/code/proto/Option.java
+++ b/base/src/main/java/io/spine/code/proto/Option.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.code.proto;
+
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.GeneratedMessage.GeneratedExtension;
+
+/**
+ * An option of a Protobuf declaration.
+ *
+ * @param <T>
+ *         the type of the option value
+ */
+public class Option<T> {
+
+    private final T value;
+    private final boolean explicitlySet;
+
+    private Option(T value, boolean explicitlySet) {
+        this.value = value;
+        this.explicitlySet = explicitlySet;
+    }
+
+    /**
+     * Creates the option from the value.
+     *
+     * @param value
+     *         the value of the option
+     * @param <T>
+     *         the type of the option value
+     * @return a new option, which is considered explicitly set
+     */
+    public static <T> Option<T> explicitlySet(T value) {
+        return new Option<>(value, true);
+    }
+
+    /**
+     * Creates the options by obtaining it from the descriptor.
+     *
+     * @param field
+     *         the descriptor of the field
+     * @param option
+     *         the option to extract
+     * @param <T>
+     *         the type of the option value
+     * @return a new option
+     */
+    public static <T> Option<T> from(FieldDescriptor field,
+                                     GeneratedExtension<FieldOptions, T> option) {
+        FieldOptions options = field.getOptions();
+        T value = options.getExtension(option);
+        boolean explicitlySet = options.hasExtension(option);
+        return new Option<>(value, explicitlySet);
+    }
+
+    /**
+     * Obtains the value of the option.
+     *
+     * @return the value of the option
+     */
+    public T value() {
+        return value;
+    }
+
+    /**
+     * Determines whether the option was explicitly set.
+     *
+     * @return {@code true} if the option was explicitly set, {@code false} otherwise
+     */
+    public boolean isExplicitlySet() {
+        return explicitlySet;
+    }
+}

--- a/base/src/main/java/io/spine/validate/BooleanFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/BooleanFieldValidator.java
@@ -24,8 +24,6 @@ import io.spine.logging.Logging;
 
 /**
  * Validates fields of type {@link Boolean}.
- *
- * @author Dmitry Kashcheiev
  */
 class BooleanFieldValidator extends FieldValidator<Boolean> implements Logging {
 

--- a/base/src/main/java/io/spine/validate/ByteStringFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/ByteStringFieldValidator.java
@@ -24,8 +24,6 @@ import com.google.protobuf.ByteString;
 
 /**
  * Validates fields of type {@link ByteString}.
- *
- * @author Alexander Litus
  */
 class ByteStringFieldValidator extends FieldValidator<ByteString> {
 

--- a/base/src/main/java/io/spine/validate/EmptyMapFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/EmptyMapFieldValidator.java
@@ -26,8 +26,6 @@ import java.util.Map;
 
 /**
  * Performs the validation for a {@code map} field which has no values set.
- *
- * @author Dmytro Dashenkov
  */
 final class EmptyMapFieldValidator extends FieldValidator<Map<?, ?>> {
 

--- a/base/src/main/java/io/spine/validate/EnumFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/EnumFieldValidator.java
@@ -24,8 +24,6 @@ import com.google.protobuf.Descriptors.EnumValueDescriptor;
 
 /**
  * Validates fields of type {@link EnumValueDescriptor}.
- *
- * @author Dmitry Kashcheiev
  */
 class EnumFieldValidator extends FieldValidator<EnumValueDescriptor> {
 

--- a/base/src/main/java/io/spine/validate/FieldDeclaration.java
+++ b/base/src/main/java/io/spine/validate/FieldDeclaration.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validate;
+
+import com.google.protobuf.DescriptorProtos.FieldOptions;
+import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Descriptors.FileDescriptor;
+import com.google.protobuf.GeneratedMessage.GeneratedExtension;
+import io.spine.base.CommandMessage;
+import io.spine.code.proto.Option;
+import io.spine.option.EntityOption;
+import io.spine.option.OptionsProto;
+
+import java.util.Optional;
+
+import static io.spine.validate.rule.ValidationRuleOptions.getOptionValue;
+
+/**
+ * Declaration of a Protobuf field.
+ *
+ * <p>The field can be declared in a message or enum.
+ *
+ * <p>Unlike {@link io.spine.code.proto.FieldDeclaration}, the class uses
+ * {@link com.google.protobuf.Descriptors} instead of {@link com.google.protobuf.DescriptorProtos}.
+ * The former descriptors provide a more powerful API.
+ */
+final class FieldDeclaration {
+
+    private final FieldDescriptor field;
+    private final FieldContext context;
+
+    FieldDeclaration(FieldContext context) {
+        this.field = context.getTarget();
+        this.context = context;
+    }
+
+    /**
+     * Obtains the desired option for the field.
+     *
+     * @param extension
+     *         an extension key used to obtain an option
+     * @param <T>
+     *         the type of the option value
+     */
+    <T> Option<T> option(GeneratedExtension<FieldOptions, T> extension) {
+        Optional<Option<T>> validationRuleOption = getOptionValue(context, extension);
+        if (validationRuleOption.isPresent()) {
+            return validationRuleOption.get();
+        }
+
+        Option<T> ownOption = Option.from(field, extension);
+        return ownOption;
+    }
+
+    /**
+     * Determines whether the field is an entity ID.
+     *
+     * <p>An entity ID is a field, which:
+     *
+     * <ul>
+     *     <li>The first field.</li>
+     *     <li>Named {@code id} or the named ends with {@code _id}.</li>
+     *     <li>An entity kind is specified via the {@linkplain EntityOption#getKind() option}.
+     * </ul>
+     *
+     * @return {@code true} if the field is an entity ID, {@code false} otherwise
+     */
+    boolean isEntityId() {
+        return isFirstField() && matchesIdName() && isEntityField();
+    }
+
+    /**
+     * Determines whether the field is a command ID.
+     *
+     * <p>A command ID is the first field of a message declared in a
+     * {@link io.spine.base.CommandMessage.File command file}.
+     *
+     * @return {@code true} if the field is a command ID, {@code false} otherwise
+     */
+    boolean isCommandId() {
+        return isFirstField() && isCommandsFile();
+    }
+
+    boolean isNotRepeatedOrMap() {
+        return !isRepeated()
+                && !field.isMapField();
+    }
+
+    boolean isRepeated() {
+        return field.isRepeated();
+    }
+
+    private boolean isEntityField() {
+        EntityOption entityOption = field.getContainingType()
+                                         .getOptions()
+                                         .getExtension(OptionsProto.entity);
+        EntityOption.Kind entityKind = entityOption.getKind();
+        return entityKind.getNumber() > 0;
+    }
+
+    private boolean matchesIdName() {
+        String name = field.getName();
+        return name.equals("id") || name.endsWith("_id");
+    }
+
+    private boolean isFirstField() {
+        return field.getIndex() == 0;
+    }
+
+    private boolean isCommandsFile() {
+        FileDescriptor file = field.getFile();
+        boolean commandsFile = CommandMessage.File.predicate()
+                                                  .test(file);
+        return commandsFile;
+    }
+}

--- a/base/src/main/java/io/spine/validate/FieldDeclaration.java
+++ b/base/src/main/java/io/spine/validate/FieldDeclaration.java
@@ -73,12 +73,11 @@ final class FieldDeclaration {
     /**
      * Determines whether the field is an entity ID.
      *
-     * <p>An entity ID is a field, which:
-     *
+     * <p>An entity ID satisfies the following conditions:
      * <ul>
-     *     <li>The first field.</li>
-     *     <li>Named {@code id} or the named ends with {@code _id}.</li>
-     *     <li>An entity kind is specified via the {@linkplain EntityOption#getKind() option}.
+     *     <li>Declared as the first field.</li>
+     *     <li>Named {@code id} or the name ends with {@code _id}.</li>
+     *     <li>Declared inside an {@linkplain EntityOption#getKind() entity state message}.
      * </ul>
      *
      * @return {@code true} if the field is an entity ID, {@code false} otherwise

--- a/base/src/main/java/io/spine/validate/FieldDeclaration.java
+++ b/base/src/main/java/io/spine/validate/FieldDeclaration.java
@@ -117,7 +117,7 @@ final class FieldDeclaration {
 
     private boolean matchesIdName() {
         String name = field.getName();
-        return name.equals("id") || name.endsWith("_id");
+        return "id".equals(name) || name.endsWith("_id");
     }
 
     private boolean isFirstField() {

--- a/base/src/main/java/io/spine/validate/FieldValidator.java
+++ b/base/src/main/java/io/spine/validate/FieldValidator.java
@@ -49,8 +49,8 @@ import static io.spine.validate.rule.ValidationRuleOptions.getOptionValue;
  * Validates messages according to Spine custom protobuf options and
  * provides constraint violations found.
  *
- * @param <V> a type of field values
- * @author Alexander Litus
+ * @param <V>
+ *         a type of field values
  */
 abstract class FieldValidator<V> implements Logging {
 
@@ -79,10 +79,13 @@ abstract class FieldValidator<V> implements Logging {
     /**
      * Creates a new validator instance.
      *
-     * @param fieldContext the context of the field to validate
-     * @param values       values to validate
-     * @param strict       if {@code true} the validator would assume that the field
-     *                     is required, even if corresponding field option is not present
+     * @param fieldContext
+     *         the context of the field to validate
+     * @param values
+     *         values to validate
+     * @param strict
+     *         if {@code true} the validator would assume that the field
+     *         is required, even if corresponding field option is not present
      */
     protected FieldValidator(FieldContext fieldContext,
                              ImmutableList<V> values,
@@ -139,7 +142,8 @@ abstract class FieldValidator<V> implements Logging {
      * if it is {@link String} or {@link com.google.protobuf.ByteString ByteString}, it must be
      * set to a non-empty string or array.
      *
-     * @param value a field value to check
+     * @param value
+     *         a field value to check
      * @return {@code true} if the field is not set, {@code false} otherwise
      */
     protected abstract boolean isNotSet(V value);
@@ -252,7 +256,8 @@ abstract class FieldValidator<V> implements Logging {
     /**
      * Adds a validation constraint validation to the collection of violations.
      *
-     * @param violation a violation to add
+     * @param violation
+     *         a violation to add
      */
     protected void addViolation(ConstraintViolation violation) {
         violations.add(violation);
@@ -271,8 +276,10 @@ abstract class FieldValidator<V> implements Logging {
     /**
      * Returns a validation error message (a custom one (if present) or the default one).
      *
-     * @param option    a validation option used to get the default message
-     * @param customMsg a user-defined error message
+     * @param option
+     *         a validation option used to get the default message
+     * @param customMsg
+     *         a user-defined error message
      */
     protected String getErrorMsgFormat(Message option, String customMsg) {
         String defaultMsg = option.getDescriptorForType()
@@ -285,8 +292,10 @@ abstract class FieldValidator<V> implements Logging {
     /**
      * Returns a field validation option.
      *
-     * @param extension an extension key used to obtain a validation option
-     * @param <T>       the type of the option
+     * @param extension
+     *         an extension key used to obtain a validation option
+     * @param <T>
+     *         the type of the option
      */
     protected final <T> T getFieldOption(GeneratedExtension<FieldOptions, T> extension) {
         Optional<T> externalOption = getOptionValue(fieldContext, extension);
@@ -328,7 +337,6 @@ abstract class FieldValidator<V> implements Logging {
     /**
      * This test-only method is used from the module {@code smoke-tests}.
      */
-    @SuppressWarnings("unused")
     @VisibleForTesting
     boolean isRepeatedOrMap() {
         return !isNotRepeatedOrMap();

--- a/base/src/main/java/io/spine/validate/FieldValidator.java
+++ b/base/src/main/java/io/spine/validate/FieldValidator.java
@@ -42,7 +42,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.copyOf;
 import static com.google.common.collect.ImmutableList.of;
 import static com.google.common.collect.Lists.newLinkedList;
-import static io.spine.validate.rules.ValidationRuleOptions.getOptionValue;
+import static io.spine.validate.Validate.isNotDefault;
+import static io.spine.validate.rule.ValidationRuleOptions.getOptionValue;
 
 /**
  * Validates messages according to Spine custom protobuf options and
@@ -218,7 +219,7 @@ abstract class FieldValidator<V> implements Logging {
      * Returns {@code true} in case `if_missing` option is set with a non-default error message.
      */
     private boolean hasCustomMissingMessage() {
-        boolean result = !ifMissingOption.equals(IfMissingOption.getDefaultInstance());
+        boolean result = isNotDefault(ifMissingOption);
         return result;
     }
 

--- a/base/src/main/java/io/spine/validate/FloatFieldValidatorBase.java
+++ b/base/src/main/java/io/spine/validate/FloatFieldValidatorBase.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableList;
 
 /**
  * A base for floating point number field validators.
- *
- * @author Alexander Litus
  */
 abstract class FloatFieldValidatorBase<V extends Number & Comparable<V>>
          extends NumberFieldValidator<V> {

--- a/base/src/main/java/io/spine/validate/IntegerFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/IntegerFieldValidator.java
@@ -24,8 +24,6 @@ import static java.lang.Math.abs;
 
 /**
  * Validates fields of {@link Integer} types.
- *
- * @author Alexander Litus
  */
 class IntegerFieldValidator extends NumberFieldValidator<Integer> {
 

--- a/base/src/main/java/io/spine/validate/LongFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/LongFieldValidator.java
@@ -24,8 +24,6 @@ import static java.lang.Math.abs;
 
 /**
  * Validates fields of {@link Long} number types.
- *
- * @author Alexander Litus
  */
 class LongFieldValidator extends NumberFieldValidator<Long> {
 

--- a/base/src/main/java/io/spine/validate/MessageFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidator.java
@@ -62,7 +62,7 @@ class MessageFieldValidator extends FieldValidator<Message> {
                           Object fieldValues,
                           boolean strict) {
         super(fieldContext, toValueList(fieldValues), strict);
-        this.timeConstraint = getFieldOption(OptionsProto.when);
+        this.timeConstraint = optionValue(OptionsProto.when);
     }
 
     @Override

--- a/base/src/main/java/io/spine/validate/MessageFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidator.java
@@ -40,8 +40,6 @@ import static io.spine.validate.Validate.isDefault;
 
 /**
  * Validates fields of type {@link Message}.
- *
- * @author Alexander Litus
  */
 class MessageFieldValidator extends FieldValidator<Message> {
 

--- a/base/src/main/java/io/spine/validate/NumberFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/NumberFieldValidator.java
@@ -63,13 +63,13 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
      */
     NumberFieldValidator(FieldContext fieldContext, ImmutableList<V> fieldValues) {
         super(fieldContext, fieldValues, false);
-        this.minDecimalOpt = getFieldOption(OptionsProto.decimalMin);
+        this.minDecimalOpt = optionValue(OptionsProto.decimalMin);
         this.isMinDecimalInclusive = minDecimalOpt.getInclusive();
-        this.maxDecimalOpt = getFieldOption(OptionsProto.decimalMax);
+        this.maxDecimalOpt = optionValue(OptionsProto.decimalMax);
         this.isMaxDecimalInclusive = maxDecimalOpt.getInclusive();
-        this.minOption = getFieldOption(OptionsProto.min);
-        this.maxOption = getFieldOption(OptionsProto.max);
-        this.digitsOption = getFieldOption(OptionsProto.digits);
+        this.minOption = optionValue(OptionsProto.min);
+        this.maxOption = optionValue(OptionsProto.max);
+        this.digitsOption = optionValue(OptionsProto.digits);
     }
 
     /** Converts a string representation to a number. */

--- a/base/src/main/java/io/spine/validate/NumberFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/NumberFieldValidator.java
@@ -38,7 +38,6 @@ import static io.spine.protobuf.TypeConverter.toAny;
  * Validates fields of number types (protobuf: int32, double, etc).
  *
  * @param <V> the type of the field value
- * @author Alexander Litus
  */
 abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends FieldValidator<V> {
 

--- a/base/src/main/java/io/spine/validate/StringFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/StringFieldValidator.java
@@ -47,7 +47,7 @@ class StringFieldValidator extends FieldValidator<String> {
                          Object fieldValues,
                          boolean strict) {
         super(fieldContext, FieldValidator.<String>toValueList(fieldValues), strict);
-        this.patternOption = getFieldOption(OptionsProto.pattern);
+        this.patternOption = optionValue(OptionsProto.pattern);
         this.regex = patternOption.getRegex();
     }
 

--- a/base/src/main/java/io/spine/validate/StringFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/StringFieldValidator.java
@@ -27,8 +27,6 @@ import static io.spine.protobuf.TypeConverter.toAny;
 
 /**
  * Validates fields of type {@link String}.
- *
- * @author Alexander Litus
  */
 class StringFieldValidator extends FieldValidator<String> {
 

--- a/base/src/main/java/io/spine/validate/rule/ValidationRule.java
+++ b/base/src/main/java/io/spine/validate/rule/ValidationRule.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.validate.rules;
+package io.spine.validate.rule;
 
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;

--- a/base/src/main/java/io/spine/validate/rule/ValidationRuleOptions.java
+++ b/base/src/main/java/io/spine/validate/rule/ValidationRuleOptions.java
@@ -25,6 +25,7 @@ import com.google.protobuf.DescriptorProtos.FieldOptions;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.GeneratedMessage.GeneratedExtension;
+import io.spine.code.proto.Option;
 import io.spine.validate.FieldContext;
 
 import java.util.Collection;
@@ -35,8 +36,6 @@ import static com.google.common.collect.ImmutableMap.builder;
 
 /**
  * Utilities for obtaining Protobuf options extracted from validation rules.
- *
- * @author Dmytro Grankin
  */
 public final class ValidationRuleOptions {
 
@@ -52,22 +51,26 @@ public final class ValidationRuleOptions {
     /**
      * Obtains value of the specified option by the specified field context.
      *
-     * @param fieldContext the field descriptor to obtain the option
-     * @param option       the option to obtain
-     * @param <T>          the type of the option
+     * @param fieldContext
+     *         the field descriptor to obtain the option
+     * @param option
+     *         the option to obtain
+     * @param <T>
+     *         the type of the option value
      * @return the {@code Optional} of option value
      *         or {@code Optional.empty()} if there is not option for the field descriptor
      */
-    public static <T> Optional<T> getOptionValue(FieldContext fieldContext,
-                                                 GeneratedExtension<FieldOptions, T> option) {
+    public static <T> Optional<Option<T>> getOptionValue(FieldContext fieldContext,
+                                                         GeneratedExtension<FieldOptions, T> option) {
         for (FieldContext context : options.keySet()) {
             if (fieldContext.hasSameTargetAndParent(context)) {
                 FieldOptions fieldOptions = options.get(context);
                 T optionValue = fieldOptions.getExtension(option);
-                return Optional.of(optionValue);
+                // A option is set explicitly if it was found in validation rules
+                Option<T> fieldOption = Option.explicitlySet(optionValue);
+                return Optional.of(fieldOption);
             }
         }
-
         return Optional.empty();
     }
 

--- a/base/src/main/java/io/spine/validate/rule/ValidationRuleOptions.java
+++ b/base/src/main/java/io/spine/validate/rule/ValidationRuleOptions.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.validate.rules;
+package io.spine.validate.rule;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.DescriptorProtos.FieldOptions;

--- a/base/src/main/java/io/spine/validate/rule/ValidationRules.java
+++ b/base/src/main/java/io/spine/validate/rule/ValidationRules.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.validate.rules;
+package io.spine.validate.rule;
 
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableCollection;

--- a/base/src/main/java/io/spine/validate/rule/package-info.java
+++ b/base/src/main/java/io/spine/validate/rule/package-info.java
@@ -25,7 +25,7 @@
 @Internal
 @CheckReturnValue
 @ParametersAreNonnullByDefault
-package io.spine.validate.rules;
+package io.spine.validate.rule;
 
 import com.google.errorprone.annotations.CheckReturnValue;
 import io.spine.annotation.Internal;

--- a/base/src/test/java/io/spine/validate/FieldValidatorShould.java
+++ b/base/src/test/java/io/spine/validate/FieldValidatorShould.java
@@ -20,8 +20,6 @@
 
 package io.spine.validate;
 
-import io.spine.validate.ConstraintViolation;
-import io.spine.validate.FieldValidator;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -1039,7 +1039,7 @@ class MessageValidatorTest {
                 EntityIdRepeatedFieldValue msg = EntityIdRepeatedFieldValue.newBuilder()
                                                                            .addValue(newUuid())
                                                                            .build();
-                assertValid(msg);
+                assertNotValid(msg);
             }
 
             @Test

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -935,122 +935,6 @@ class MessageValidatorTest {
                                  .isEmpty());
     }
 
-    /*
-     * Entity ID in command validation tests.
-     */
-
-    @Test
-    @DisplayName("find out that Message entity ID in command is valid")
-    void find_out_that_Message_entity_id_in_command_is_valid() {
-        EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.newBuilder()
-                                                         .setValue(newStringValue())
-                                                         .build();
-        validate(msg);
-        assertIsValid(true);
-    }
-
-    @Test
-    @DisplayName("find out that Message entity ID in command is NOT valid")
-    void find_out_that_Message_entity_id_in_command_is_NOT_valid() {
-        validate(EntityIdMsgFieldValue.getDefaultInstance());
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that String entity ID in command is valid")
-    void find_out_that_String_entity_id_in_command_is_valid() {
-        EntityIdStringFieldValue msg = EntityIdStringFieldValue.newBuilder()
-                                                               .setValue(newUuid())
-                                                               .build();
-        validate(msg);
-        assertIsValid(true);
-    }
-
-    @Test
-    @DisplayName("find out that String entity ID in command is NOT valid")
-    void find_out_that_String_entity_id_in_command_is_NOT_valid() {
-        validate(EntityIdStringFieldValue.getDefaultInstance());
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that entity ID in command cannot be ByteString")
-    void find_out_that_entity_id_in_command_cannot_be_ByteString() {
-        EntityIdByteStringFieldValue msg = EntityIdByteStringFieldValue.newBuilder()
-                                                                       .setValue(newByteString())
-                                                                       .build();
-        validate(msg);
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that entity ID in command cannot be float number")
-    void find_out_that_entity_id_in_command_cannot_be_float_number() {
-        @SuppressWarnings("MagicNumber") EntityIdDoubleFieldValue msg =
-                EntityIdDoubleFieldValue.newBuilder()
-                                        .setValue(1.1)
-                                        .build();
-        validate(msg);
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that Integer entity ID in command is valid")
-    void find_out_that_Integer_entity_id_in_command_is_valid() {
-        EntityIdIntFieldValue msg = EntityIdIntFieldValue.newBuilder()
-                                                         .setValue(5)
-                                                         .build();
-        validate(msg);
-        assertIsValid(true);
-    }
-
-    @Test
-    @DisplayName("find out that Integer entity ID in command is NOT valid")
-    void find_out_that_Integer_entity_id_in_command_is_NOT_valid() {
-        validate(EntityIdIntFieldValue.getDefaultInstance());
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that Long entity ID in command is valid")
-    void find_out_that_Long_entity_id_in_command_is_valid() {
-        EntityIdLongFieldValue msg = EntityIdLongFieldValue.newBuilder()
-                                                           .setValue(5)
-                                                           .build();
-        validate(msg);
-        assertIsValid(true);
-    }
-
-    @Test
-    @DisplayName("find out that Long entity ID in command is NOT valid")
-    void find_out_that_Long_entity_id_in_command_is_NOT_valid() {
-        validate(EntityIdLongFieldValue.getDefaultInstance());
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("find out that repeated entity ID in command is NOT valid")
-    void find_out_that_repeated_entity_id_in_command_is_not_valid() {
-        EntityIdRepeatedFieldValue msg = EntityIdRepeatedFieldValue.newBuilder()
-                                                                   .addValue(newUuid())
-                                                                   .build();
-        validate(msg);
-        assertIsValid(false);
-    }
-
-    @Test
-    @DisplayName("provide one valid violation if entity ID in command is not valid")
-    void provide_one_valid_violation_if_entity_id_in_command_is_not_valid() {
-        validate(EntityIdMsgFieldValue.getDefaultInstance());
-
-        assertEquals(1, violations.size());
-        ConstraintViolation violation = firstViolation();
-        assertEquals(NO_VALUE_MSG, violation.getMsgFormat());
-        assertFieldPathIs(violation, VALUE);
-        assertTrue(violation.getViolationList()
-                            .isEmpty());
-    }
-
     @Test
     @DisplayName("provide custom invalid field message if specified")
     void provide_custom_invalid_field_message_if_specified() {
@@ -1082,6 +966,97 @@ class MessageValidatorTest {
     class EntityId {
 
         @Nested
+        @DisplayName("in a command file and")
+        class InCommandFile {
+
+            @Test
+            @DisplayName("find out that Message is valid")
+            void find_out_that_Message_entity_id_in_command_is_valid() {
+                EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.newBuilder()
+                                                                 .setValue(newStringValue())
+                                                                 .build();
+                assertValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that Message is NOT valid")
+            void find_out_that_Message_entity_id_in_command_is_NOT_valid() {
+                EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.getDefaultInstance();
+                assertNotValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that String is valid")
+            void find_out_that_String_entity_id_in_command_is_valid() {
+                EntityIdStringFieldValue msg = EntityIdStringFieldValue.newBuilder()
+                                                                       .setValue(newUuid())
+                                                                       .build();
+                assertValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that String is NOT valid")
+            void find_out_that_String_entity_id_in_command_is_NOT_valid() {
+                EntityIdStringFieldValue msg = EntityIdStringFieldValue.getDefaultInstance();
+                assertNotValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that Integer is valid")
+            void find_out_that_Integer_entity_id_in_command_is_valid() {
+                EntityIdIntFieldValue msg = EntityIdIntFieldValue.newBuilder()
+                                                                 .setValue(5)
+                                                                 .build();
+                assertValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that Integer is NOT valid")
+            void find_out_that_Integer_entity_id_in_command_is_NOT_valid() {
+                EntityIdIntFieldValue msg = EntityIdIntFieldValue.getDefaultInstance();
+                assertNotValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that Long is valid")
+            void find_out_that_Long_entity_id_in_command_is_valid() {
+                EntityIdLongFieldValue msg = EntityIdLongFieldValue.newBuilder()
+                                                                   .setValue(5)
+                                                                   .build();
+                assertValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that Long is NOT valid")
+            void find_out_that_Long_entity_id_in_command_is_NOT_valid() {
+                EntityIdLongFieldValue msg = EntityIdLongFieldValue.getDefaultInstance();
+                assertNotValid(msg);
+            }
+
+            @Test
+            @DisplayName("find out that repeated is NOT valid")
+            void find_out_that_repeated_entity_id_in_command_is_not_valid() {
+                EntityIdRepeatedFieldValue msg = EntityIdRepeatedFieldValue.newBuilder()
+                                                                           .addValue(newUuid())
+                                                                           .build();
+                assertValid(msg);
+            }
+
+            @Test
+            @DisplayName("provide one valid violation if is not valid")
+            void provide_one_valid_violation_if_entity_id_in_command_is_not_valid() {
+                validate(EntityIdMsgFieldValue.getDefaultInstance());
+
+                assertEquals(1, violations.size());
+                ConstraintViolation violation = firstViolation();
+                assertEquals(NO_VALUE_MSG, violation.getMsgFormat());
+                assertFieldPathIs(violation, VALUE);
+                assertTrue(violation.getViolationList()
+                                    .isEmpty());
+            }
+        }
+
+        @Nested
         @DisplayName("in state and")
         class InState {
 
@@ -1106,6 +1081,30 @@ class MessageValidatorTest {
             void notRequiredIfOptionIsFalse() {
                 ProjectionState stateWithDefaultId = ProjectionState.getDefaultInstance();
                 assertValid(stateWithDefaultId);
+            }
+        }
+
+        @Nested
+        @DisplayName("and reject")
+        class Reject {
+
+            @Test
+            @DisplayName("ByteString")
+            void find_out_that_entity_id_in_command_cannot_be_ByteString() {
+                EntityIdByteStringFieldValue msg = EntityIdByteStringFieldValue.newBuilder()
+                                                                               .setValue(newByteString())
+                                                                               .build();
+                assertNotValid(msg);
+            }
+
+            @Test
+            @DisplayName("Float")
+            void find_out_that_entity_id_in_command_cannot_be_float_number() {
+                @SuppressWarnings("MagicNumber") EntityIdDoubleFieldValue msg =
+                        EntityIdDoubleFieldValue.newBuilder()
+                                                .setValue(1.1)
+                                                .build();
+                assertNotValid(msg);
             }
         }
     }

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -69,7 +69,8 @@ import io.spine.test.validate.command.EntityIdLongFieldValue;
 import io.spine.test.validate.command.EntityIdMsgFieldValue;
 import io.spine.test.validate.command.EntityIdRepeatedFieldValue;
 import io.spine.test.validate.command.EntityIdStringFieldValue;
-import org.junit.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -87,12 +88,13 @@ import static io.spine.validate.MessageValidatorTestEnv.currentTimeWithNanos;
 import static io.spine.validate.MessageValidatorTestEnv.freezeTime;
 import static io.spine.validate.MessageValidatorTestEnv.timeWithNanos;
 import static java.lang.String.format;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings({"ClassWithTooManyMethods", "OverlyCoupledClass", "OverlyComplexClass"})
-public class MessageValidatorShould {
+@DisplayName("MessageValidator should")
+class MessageValidatorTest {
 
     private static final double EQUAL_MIN = 16.5;
     private static final double GREATER_THAN_MIN = EQUAL_MIN + 5;
@@ -129,7 +131,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_required_Message_field_is_set() {
+    @DisplayName("find out that required Message field is set")
+    void find_out_that_required_Message_field_is_set() {
         RequiredMsgFieldValue validMsg = RequiredMsgFieldValue
                 .newBuilder()
                 .setValue(newStringValue())
@@ -139,14 +142,16 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_required_Message_field_is_NOT_set() {
+    @DisplayName("find out that required message field is NOT set")
+    void find_out_that_required_Message_field_is_NOT_set() {
         RequiredMsgFieldValue invalidMsg = RequiredMsgFieldValue.getDefaultInstance();
         validate(invalidMsg);
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_required_String_field_is_set() {
+    @DisplayName("find out that required String field is set")
+    void find_out_that_required_String_field_is_set() {
         RequiredStringFieldValue validMsg = RequiredStringFieldValue.newBuilder()
                                                                     .setValue(newUuid())
                                                                     .build();
@@ -155,14 +160,16 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_required_String_field_is_NOT_set() {
+    @DisplayName("find out that required String field is NOT set")
+    void find_out_that_required_String_field_is_NOT_set() {
         RequiredStringFieldValue invalidMsg = RequiredStringFieldValue.getDefaultInstance();
         validate(invalidMsg);
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_required_ByteString_field_is_set() {
+    @DisplayName("find out that required ByteString field is set")
+    void find_out_that_required_ByteString_field_is_set() {
         RequiredByteStringFieldValue validMsg =
                 RequiredByteStringFieldValue.newBuilder()
                                             .setValue(newByteString())
@@ -172,21 +179,24 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_required_ByteString_field_is_NOT_set() {
+    @DisplayName("find out that required ByteString field is NOT set")
+    void find_out_that_required_ByteString_field_is_NOT_set() {
         RequiredByteStringFieldValue invalidMsg = RequiredByteStringFieldValue.getDefaultInstance();
         validate(invalidMsg);
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_required_Enum_field_is_NOT_set() {
+    @DisplayName("find out that required Enum field is set")
+    void find_out_that_required_Enum_field_is_NOT_set() {
         RequiredEnumFieldValue invalidMsg = RequiredEnumFieldValue.getDefaultInstance();
         validate(invalidMsg);
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_required_Enum_field_is_set() {
+    @DisplayName("find out that required Enum field is NOT set")
+    void find_out_that_required_Enum_field_is_set() {
         RequiredEnumFieldValue invalidMsg = RequiredEnumFieldValue.newBuilder()
                                                                   .setValue(Time.FUTURE)
                                                                   .build();
@@ -195,13 +205,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_required_NOT_set_Boolean_field_pass_validation() {
+    @DisplayName("find out that required NOT set Boolean field passes validation")
+    void find_out_that_required_NOT_set_Boolean_field_pass_validation() {
         validate(RequiredBooleanFieldValue.getDefaultInstance());
         assertIsValid(true);
     }
 
     @Test
-    public void find_out_that_repeated_required_field_has_valid_values() {
+    @DisplayName("find out that repeated required field has valid values")
+    void find_out_that_repeated_required_field_has_valid_values() {
         RepeatedRequiredMsgFieldValue invalidMsg =
                 RepeatedRequiredMsgFieldValue.newBuilder()
                                              .addValue(newStringValue())
@@ -212,30 +224,35 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_repeated_required_field_has_no_values() {
+    @DisplayName("find out that repeated required field has not values")
+    void find_out_that_repeated_required_field_has_no_values() {
         validate(RepeatedRequiredMsgFieldValue.getDefaultInstance());
         assertIsValid(false);
     }
 
     @Test
-    public void ignore_repeated_required_field_with_empty_value() {
+    @DisplayName("ignore repeated required field with an empty value")
+    void ignore_repeated_required_field_with_empty_value() {
         RepeatedRequiredMsgFieldValue msg =
                 RepeatedRequiredMsgFieldValue.newBuilder()
                                              .addValue(newStringValue()) // valid value
-                                             .addValue(StringValue.getDefaultInstance()) // empty value
+                                             .addValue(
+                                                     StringValue.getDefaultInstance()) // empty value
                                              .build();
         validate(msg);
         assertIsValid(true);
     }
 
     @Test
-    public void consider_field_is_valid_if_no_required_option_set() {
+    @DisplayName("consider field is valid if no required option set")
+    void consider_field_is_valid_if_no_required_option_set() {
         validate(StringValue.getDefaultInstance());
         assertIsValid(true);
     }
 
     @Test
-    public void provide_one_valid_violation_if_required_field_is_not_set() {
+    @DisplayName("provide one valid violation if required field is NOT set")
+    void provide_one_valid_violation_if_required_field_is_NOT_set() {
         RequiredStringFieldValue invalidMsg = RequiredStringFieldValue.getDefaultInstance();
 
         validate(invalidMsg);
@@ -249,7 +266,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void propagate_proper_error_message_if_custom_message_set_and_required_Message_field_is_NOT_set() {
+    @DisplayName("propagate proper error message if custom message set and required Message field is NOT set")
+    void propagate_proper_error_message_if_custom_message_set_and_required_Message_field_is_NOT_set() {
         CustomMessageRequiredMsgFieldValue invalidMsg =
                 CustomMessageRequiredMsgFieldValue.getDefaultInstance();
         String expectedMessage =
@@ -262,7 +280,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void propagate_proper_error_message_if_custom_message_set_and_required_String_field_is_NOT_set() {
+    @DisplayName("propagate proper error message if custom message set and required String field is NOT set")
+    void propagate_proper_error_message_if_custom_message_set_and_required_String_field_is_NOT_set() {
         CustomMessageRequiredStringFieldValue invalidMsg =
                 CustomMessageRequiredStringFieldValue.getDefaultInstance();
         String expectedMessage = getCustomErrorMessage(
@@ -275,7 +294,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void propagate_proper_error_message_if_custom_message_set_and_required_ByteString_field_is_NOT_set() {
+    @DisplayName("propagate proper error message if custom message set and required ByteString field is NOT set")
+    void propagate_proper_error_message_if_custom_message_set_and_required_ByteString_field_is_NOT_set() {
         CustomMessageRequiredByteStringFieldValue invalidMsg =
                 CustomMessageRequiredByteStringFieldValue.getDefaultInstance();
         String expectedMessage =
@@ -288,7 +308,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void propagate_proper_error_message_if_custom_message_set_and_required_RepeatedMsg_field_is_NOT_set() {
+    @DisplayName("propagate proper error message if custom message set and required repeated field is NOT set")
+    void propagate_proper_error_message_if_custom_message_set_and_required_RepeatedMsg_field_is_NOT_set() {
         CustomMessageRequiredRepeatedMsgFieldValue invalidMsg =
                 CustomMessageRequiredRepeatedMsgFieldValue.getDefaultInstance();
         String expectedMessage =
@@ -301,7 +322,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void propagate_proper_error_message_if_custom_message_set_and_required_Enum_field_is_NOT_set() {
+    @DisplayName("propagate proper error message if custom message set and required Enum field is NOT set")
+    void propagate_proper_error_message_if_custom_message_set_and_required_Enum_field_is_NOT_set() {
         CustomMessageRequiredEnumFieldValue invalidMsg =
                 CustomMessageRequiredEnumFieldValue.getDefaultInstance();
         String expectedMessage =
@@ -314,7 +336,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void ignore_if_missing_option_if_field_not_marked_required() {
+    @DisplayName("ignore IfMissingOption if field is not marked required")
+    void ignore_if_missing_option_if_field_not_marked_required() {
         CustomMessageWithNoRequiredOption invalidMsg =
                 CustomMessageWithNoRequiredOption.getDefaultInstance();
 
@@ -342,7 +365,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_time_is_in_future() {
+    @DisplayName("find out that time is in future")
+    void find_out_that_time_is_in_future() {
         TimeInFutureFieldValue validMsg = TimeInFutureFieldValue.newBuilder()
                                                                 .setValue(getFuture())
                                                                 .build();
@@ -351,7 +375,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_time_is_NOT_in_future() {
+    @DisplayName("find out that time is NOT in future")
+    void find_out_that_time_is_NOT_in_future() {
         TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue.newBuilder()
                                                                   .setValue(getPast())
                                                                   .build();
@@ -360,7 +385,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_time_is_in_past() {
+    @DisplayName("find out that time is in past")
+    void find_out_that_time_is_in_past() {
         TimeInPastFieldValue validMsg = TimeInPastFieldValue.newBuilder()
                                                             .setValue(getPast())
                                                             .build();
@@ -369,7 +395,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_time_is_NOT_in_past() {
+    @DisplayName("find out that time is NOT in past")
+    void find_out_that_time_is_NOT_in_past() {
         TimeInPastFieldValue invalidMsg = TimeInPastFieldValue.newBuilder()
                                                               .setValue(getFuture())
                                                               .build();
@@ -378,7 +405,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_time_is_NOT_in_the_past_by_nanos() {
+    @DisplayName("find out that time is NOT in the past by nanoseconds")
+    void find_out_that_time_is_NOT_in_the_past_by_nanos() {
         Timestamp currentTime = currentTimeWithNanos(ZERO_NANOSECONDS);
         Timestamp timeInFuture = timeWithNanos(currentTime, FIFTY_NANOSECONDS);
         freezeTime(currentTime);
@@ -391,7 +419,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_time_is_in_the_past_by_nanos() {
+    @DisplayName("find out that time is in the past by nanoseconds")
+    void find_out_that_time_is_in_the_past_by_nanos() {
         Timestamp currentTime = currentTimeWithNanos(FIFTY_NANOSECONDS);
         Timestamp timeInPast = timeWithNanos(currentTime, ZERO_NANOSECONDS);
         freezeTime(currentTime);
@@ -404,13 +433,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_timestamp_field_is_valid_if_no_time_option_set() {
+    @DisplayName("consider Timestamp field valid if no TimeOption set")
+    void consider_timestamp_field_is_valid_if_no_time_option_set() {
         validate(TimeWithoutOptsFieldValue.getDefaultInstance());
         assertIsValid(true);
     }
 
     @Test
-    public void provide_one_valid_violation_if_time_is_invalid() {
+    @DisplayName("provide one valid violation if time is invalid")
+    void provide_one_valid_violation_if_time_is_invalid() {
         TimeInFutureFieldValue invalidMsg = TimeInFutureFieldValue.newBuilder()
                                                                   .setValue(getPast())
                                                                   .build();
@@ -433,7 +464,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void consider_Any_valid_if_content_is_valid() {
+    @DisplayName("consider Any valid if content is valid")
+    void consider_Any_valid_if_content_is_valid() {
         RequiredMsgFieldValue value = RequiredMsgFieldValue
                 .newBuilder()
                 .setValue(newStringValue())
@@ -448,7 +480,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_Any_not_valid_if_content_is_not_valid() {
+    @DisplayName("consider Any not valid if content is not valid")
+    void consider_Any_not_valid_if_content_is_not_valid() {
         RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
         Any content = AnyPacker.pack(value);
         AnyContainer container = AnyContainer
@@ -460,7 +493,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_Any_valid_if_validation_is_not_required() {
+    @DisplayName("consider Any valid if validation is not required")
+    void consider_Any_valid_if_validation_is_not_required() {
         RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
         Any content = AnyPacker.pack(value);
         UncheckedAnyContainer container = UncheckedAnyContainer
@@ -472,7 +506,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void validate_recursive_messages() {
+    @DisplayName("validate recursive messages")
+    void validate_recursive_messages() {
         RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
         Any internalAny = AnyPacker.pack(value);
         AnyContainer internal = AnyContainer
@@ -493,7 +528,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void consider_number_field_is_valid_if_no_number_options_set() {
+    @DisplayName("Consider number field is valid if no number options set")
+    void consider_number_field_is_valid_if_no_number_options_set() {
         Message nonZeroValue = DoubleValue.newBuilder()
                                           .setValue(5)
                                           .build();
@@ -502,37 +538,44 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_number_is_greater_than_decimal_min_inclusive() {
+    @DisplayName("find out that number is greater than decimal min inclusive")
+    void find_out_that_number_is_greater_than_decimal_min_inclusive() {
         minDecimalNumberTest(GREATER_THAN_MIN, true, true);
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_decimal_min_inclusive() {
+    @DisplayName("find out that number is equal to decimal min inclusive")
+    void find_out_that_number_is_equal_to_decimal_min_inclusive() {
         minDecimalNumberTest(EQUAL_MIN, true, true);
     }
 
     @Test
-    public void find_out_that_number_is_less_than_decimal_min_inclusive() {
+    @DisplayName("find out that number is less than decimal min inclusive")
+    void find_out_that_number_is_less_than_decimal_min_inclusive() {
         minDecimalNumberTest(LESS_THAN_MIN, true, false);
     }
 
     @Test
-    public void find_out_that_number_is_greater_than_decimal_min_NOT_inclusive() {
+    @DisplayName("find out that number is grated than decimal min NOT inclusive")
+    void find_out_that_number_is_greater_than_decimal_min_NOT_inclusive() {
         minDecimalNumberTest(GREATER_THAN_MIN, false, true);
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_decimal_min_NOT_inclusive() {
+    @DisplayName("find out that number is equal to decimal min NOT inclusive")
+    void find_out_that_number_is_equal_to_decimal_min_NOT_inclusive() {
         minDecimalNumberTest(EQUAL_MIN, false, false);
     }
 
     @Test
-    public void find_out_that_number_is_less_than_decimal_min_NOT_inclusive() {
+    @DisplayName("find out that number is less than decimal min NOT inclusive")
+    void find_out_that_number_is_less_than_decimal_min_NOT_inclusive() {
         minDecimalNumberTest(LESS_THAN_MIN, false, false);
     }
 
     @Test
-    public void provide_one_valid_violation_if_number_is_less_than_decimal_min() {
+    @DisplayName("provide one valid violation if number is less than decimal min")
+    void provide_one_valid_violation_if_number_is_less_than_decimal_min() {
         minDecimalNumberTest(LESS_THAN_MIN, true, false);
 
         assertEquals(1, violations.size());
@@ -549,37 +592,44 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_number_is_greater_than_decimal_max_inclusive() {
+    @DisplayName("find out that number is greater than decimal max inclusive")
+    void find_out_that_number_is_greater_than_decimal_max_inclusive() {
         maxDecimalNumberTest(GREATER_THAN_MAX, true, false);
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_decimal_max_inclusive() {
+    @DisplayName("find out that number is equal to decimal max inclusive")
+    void find_out_that_number_is_equal_to_decimal_max_inclusive() {
         maxDecimalNumberTest(EQUAL_MAX, true, true);
     }
 
     @Test
-    public void find_out_that_number_is_less_than_decimal_max_inclusive() {
+    @DisplayName("find out that number is less than decimal max inclusive")
+    void find_out_that_number_is_less_than_decimal_max_inclusive() {
         maxDecimalNumberTest(LESS_THAN_MAX, true, true);
     }
 
     @Test
-    public void find_out_that_number_is_greater_than_decimal_max_NOT_inclusive() {
+    @DisplayName("find out that number is greated than decimal max NOT inclusive")
+    void find_out_that_number_is_greater_than_decimal_max_NOT_inclusive() {
         maxDecimalNumberTest(GREATER_THAN_MAX, false, false);
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_decimal_max_NOT_inclusive() {
+    @DisplayName("find out that number is equal to decimal max NOT inclusive")
+    void find_out_that_number_is_equal_to_decimal_max_NOT_inclusive() {
         maxDecimalNumberTest(EQUAL_MAX, false, false);
     }
 
     @Test
-    public void find_out_that_number_is_less_than_decimal_max_NOT_inclusive() {
+    @DisplayName("find out that number is less than decimal max NOT inclusive")
+    void find_out_that_number_is_less_than_decimal_max_NOT_inclusive() {
         maxDecimalNumberTest(LESS_THAN_MAX, false, true);
     }
 
     @Test
-    public void provide_one_valid_violation_if_number_is_greater_than_decimal_max() {
+    @DisplayName("provide one valid violation if number is greater than decimal max")
+    void provide_one_valid_violation_if_number_is_greater_than_decimal_max() {
         maxDecimalNumberTest(GREATER_THAN_MAX, true, false);
 
         assertEquals(1, violations.size());
@@ -596,7 +646,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_number_is_greater_than_min() {
+    @DisplayName("find out that number is greater than min")
+    void find_out_that_number_is_greater_than_min() {
         MinNumberFieldValue msg = MinNumberFieldValue.newBuilder()
                                                      .setValue(GREATER_THAN_MIN)
                                                      .build();
@@ -605,7 +656,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_min() {
+    @DisplayName("find out that number is equal to min")
+    void find_out_that_number_is_equal_to_min() {
         MinNumberFieldValue msg = MinNumberFieldValue.newBuilder()
                                                      .setValue(EQUAL_MIN)
                                                      .build();
@@ -614,7 +666,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_number_is_less_than_min() {
+    @DisplayName("find out that number is less than min")
+    void find_out_that_number_is_less_than_min() {
         MinNumberFieldValue msg = MinNumberFieldValue.newBuilder()
                                                      .setValue(LESS_THAN_MIN)
                                                      .build();
@@ -623,7 +676,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void provide_one_valid_violation_if_number_is_less_than_min() {
+    @DisplayName("provide one valid violation if number is less than min")
+    void provide_one_valid_violation_if_number_is_less_than_min() {
         MinNumberFieldValue msg = MinNumberFieldValue.newBuilder()
                                                      .setValue(LESS_THAN_MIN)
                                                      .build();
@@ -643,7 +697,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_number_is_greater_than_max_inclusive() {
+    @DisplayName("find out that number is greater than max inclusive")
+    void find_out_that_number_is_greater_than_max_inclusive() {
         MaxNumberFieldValue msg = MaxNumberFieldValue.newBuilder()
                                                      .setValue(GREATER_THAN_MAX)
                                                      .build();
@@ -652,7 +707,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_number_is_equal_to_max_inclusive() {
+    @DisplayName("find out that number is equal to max inclusive")
+    void find_out_that_number_is_equal_to_max_inclusive() {
         MaxNumberFieldValue msg = MaxNumberFieldValue.newBuilder()
                                                      .setValue(EQUAL_MAX)
                                                      .build();
@@ -661,7 +717,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_number_is_less_than_max_inclusive() {
+    @DisplayName("find out that number is less than max inclusive")
+    void find_out_that_number_is_less_than_max_inclusive() {
         MaxNumberFieldValue msg = MaxNumberFieldValue.newBuilder()
                                                      .setValue(LESS_THAN_MAX)
                                                      .build();
@@ -670,7 +727,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void provide_one_valid_violation_if_number_is_greater_than_max() {
+    @DisplayName("provide one valid violation if number is greater than max")
+    void provide_one_valid_violation_if_number_is_greater_than_max() {
         MaxNumberFieldValue msg = MaxNumberFieldValue.newBuilder()
                                                      .setValue(GREATER_THAN_MAX)
                                                      .build();
@@ -684,43 +742,49 @@ public class MessageValidatorShould {
         assertTrue(violation.getViolationList()
                             .isEmpty());
     }
-
     /*
      * Digits option tests.
      */
 
     @Test
-    public void find_out_that_integral_digit_count_is_greater_than_max() {
+    @DisplayName("find out that integral digit count is greater than max")
+    void find_out_that_integral_digit_count_is_greater_than_max() {
         digitsCountTest(INT_DIGIT_COUNT_GREATER_THAN_MAX, false);
     }
 
     @Test
-    public void find_out_that_integral_digits_count_is_equal_to_max() {
+    @DisplayName("find out that integral digits count is equal to max")
+    void find_out_that_integral_digits_count_is_equal_to_max() {
         digitsCountTest(INT_DIGIT_COUNT_EQUAL_MAX, true);
     }
 
     @Test
-    public void find_out_that_integral_digit_count_is_less_than_max() {
+    @DisplayName("find out that integral digit count is less than max")
+    void find_out_that_integral_digit_count_is_less_than_max() {
         digitsCountTest(INT_DIGIT_COUNT_LESS_THAN_MAX, true);
     }
 
     @Test
-    public void find_out_that_fractional_digit_count_is_greater_than_max() {
+    @DisplayName("find out that fractional digit count is greater than max")
+    void find_out_that_fractional_digit_count_is_greater_than_max() {
         digitsCountTest(FRACTIONAL_DIGIT_COUNT_GREATER_THAN_MAX, false);
     }
 
     @Test
-    public void find_out_that_fractional_digit_count_is_equal_to_max() {
+    @DisplayName("find out that fractional digit count is equal to max")
+    void find_out_that_fractional_digit_count_is_equal_to_max() {
         digitsCountTest(FRACTIONAL_DIGIT_COUNT_EQUAL_MAX, true);
     }
 
     @Test
-    public void find_out_that_fractional_digit_count_is_less_than_max() {
+    @DisplayName("find out that fractional digit count is less than max")
+    void find_out_that_fractional_digit_count_is_less_than_max() {
         digitsCountTest(FRACTIONAL_DIGIT_COUNT_LESS_THAN_MAX, true);
     }
 
     @Test
-    public void provide_one_valid_violation_if_integral_digit_count_is_greater_than_max() {
+    @DisplayName("provide one valid violation if integral digit count is greater than max")
+    void provide_one_valid_violation_if_integral_digit_count_is_greater_than_max() {
         digitsCountTest(INT_DIGIT_COUNT_GREATER_THAN_MAX, false);
 
         assertEquals(1, violations.size());
@@ -739,7 +803,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_string_matches_to_regex_pattern() {
+    @DisplayName("find out that string matches to regex pattern")
+    void find_out_that_string_matches_to_regex_pattern() {
         PatternStringFieldValue msg = PatternStringFieldValue.newBuilder()
                                                              .setEmail("valid.email@mail.com")
                                                              .build();
@@ -748,7 +813,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_string_does_not_match_to_regex_pattern() {
+    @DisplayName("find out that string does not match to regex pattern")
+    void find_out_that_string_does_not_match_to_regex_pattern() {
         PatternStringFieldValue msg = PatternStringFieldValue.newBuilder()
                                                              .setEmail("invalid email")
                                                              .build();
@@ -757,13 +823,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_field_is_valid_if_no_pattern_option_set() {
+    @DisplayName("consider field is valid if PatternOption is not set")
+    void consider_field_is_valid_if_no_pattern_option_set() {
         validate(StringValue.getDefaultInstance());
         assertIsValid(true);
     }
 
     @Test
-    public void provide_one_valid_violation_if_string_does_not_match_to_regex_pattern() {
+    @DisplayName("provide one valid violation if string does not match to regex pattern")
+    void provide_one_valid_violation_if_string_does_not_match_to_regex_pattern() {
         PatternStringFieldValue msg = PatternStringFieldValue.newBuilder()
                                                              .setEmail("invalid email")
                                                              .build();
@@ -786,7 +854,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_enclosed_message_field_is_valid() {
+    @DisplayName("find out that enclosed message field is valid")
+    void find_out_that_enclosed_message_field_is_valid() {
         PatternStringFieldValue enclosedMsg =
                 PatternStringFieldValue.newBuilder()
                                        .setEmail("valid.email@mail.com")
@@ -800,7 +869,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_enclosed_message_field_is_NOT_valid() {
+    @DisplayName("find out enclosed message field is NOT valid")
+    void find_out_that_enclosed_message_field_is_NOT_valid() {
         PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
                                                                      .setEmail("invalid email")
                                                                      .build();
@@ -813,7 +883,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_field_valid_if_no_valid_option_is_set() {
+    @DisplayName("consider field valid if no valid option is set")
+    void consider_field_valid_if_no_valid_option_is_set() {
         PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
                                                                      .setEmail("invalid email")
                                                                      .build();
@@ -827,7 +898,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void consider_field_valid_if_it_is_not_set() {
+    @DisplayName("consider field valid if it is not set")
+    void consider_field_valid_if_it_is_not_set() {
         EnclosedMessageWithRequiredString msg = EnclosedMessageWithRequiredString.newBuilder()
                                                                                  .build();
         validate(msg);
@@ -836,7 +908,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void provide_valid_violations_if_enclosed_message_field_is_not_valid() {
+    @DisplayName("provide valid violations if enclosed message field is not valid")
+    void provide_valid_violations_if_enclosed_message_field_is_not_valid() {
         PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
                                                                      .setEmail("invalid email")
                                                                      .build();
@@ -864,7 +937,8 @@ public class MessageValidatorShould {
      */
 
     @Test
-    public void find_out_that_Message_entity_id_in_command_is_valid() {
+    @DisplayName("find out that Message entity ID in command is valid")
+    void find_out_that_Message_entity_id_in_command_is_valid() {
         EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.newBuilder()
                                                          .setValue(newStringValue())
                                                          .build();
@@ -873,13 +947,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_Message_entity_id_in_command_is_NOT_valid() {
+    @DisplayName("find out that Message entity ID in command is NOT valid")
+    void find_out_that_Message_entity_id_in_command_is_NOT_valid() {
         validate(EntityIdMsgFieldValue.getDefaultInstance());
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_String_entity_id_in_command_is_valid() {
+    @DisplayName("find out that String entity ID in command is valid")
+    void find_out_that_String_entity_id_in_command_is_valid() {
         EntityIdStringFieldValue msg = EntityIdStringFieldValue.newBuilder()
                                                                .setValue(newUuid())
                                                                .build();
@@ -888,13 +964,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_String_entity_id_in_command_is_NOT_valid() {
+    @DisplayName("find out that String entity ID in command is NOT valid")
+    void find_out_that_String_entity_id_in_command_is_NOT_valid() {
         validate(EntityIdStringFieldValue.getDefaultInstance());
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_entity_id_in_command_cannot_be_ByteString() {
+    @DisplayName("find out that entity ID in command cannot be ByteString")
+    void find_out_that_entity_id_in_command_cannot_be_ByteString() {
         EntityIdByteStringFieldValue msg = EntityIdByteStringFieldValue.newBuilder()
                                                                        .setValue(newByteString())
                                                                        .build();
@@ -903,18 +981,19 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_entity_id_in_command_cannot_be_float_number() {
+    @DisplayName("find out that entity ID in command cannot be float number")
+    void find_out_that_entity_id_in_command_cannot_be_float_number() {
         @SuppressWarnings("MagicNumber") EntityIdDoubleFieldValue msg =
                 EntityIdDoubleFieldValue.newBuilder()
-                                        .setValue(
-                                                1.1)
+                                        .setValue(1.1)
                                         .build();
         validate(msg);
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_Integer_entity_id_in_command_is_valid() {
+    @DisplayName("find out that Integer entity ID in command is valid")
+    void find_out_that_Integer_entity_id_in_command_is_valid() {
         EntityIdIntFieldValue msg = EntityIdIntFieldValue.newBuilder()
                                                          .setValue(5)
                                                          .build();
@@ -923,13 +1002,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_Integer_entity_id_in_command_is_NOT_valid() {
+    @DisplayName("find out that Integer entity ID in command is NOT valid")
+    void find_out_that_Integer_entity_id_in_command_is_NOT_valid() {
         validate(EntityIdIntFieldValue.getDefaultInstance());
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_Long_entity_id_in_command_is_valid() {
+    @DisplayName("find out that Long entity ID in command is valid")
+    void find_out_that_Long_entity_id_in_command_is_valid() {
         EntityIdLongFieldValue msg = EntityIdLongFieldValue.newBuilder()
                                                            .setValue(5)
                                                            .build();
@@ -938,13 +1019,15 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void find_out_that_Long_entity_id_in_command_is_NOT_valid() {
+    @DisplayName("find out that Long entity ID in command is NOT valid")
+    void find_out_that_Long_entity_id_in_command_is_NOT_valid() {
         validate(EntityIdLongFieldValue.getDefaultInstance());
         assertIsValid(false);
     }
 
     @Test
-    public void find_out_that_repeated_entity_id_in_command_is_not_valid() {
+    @DisplayName("find out that repeated entity ID in command is NOT valid")
+    void find_out_that_repeated_entity_id_in_command_is_not_valid() {
         EntityIdRepeatedFieldValue msg = EntityIdRepeatedFieldValue.newBuilder()
                                                                    .addValue(newUuid())
                                                                    .build();
@@ -953,7 +1036,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void provide_one_valid_violation_if_entity_id_in_command_is_not_valid() {
+    @DisplayName("provide one valid violation if entity ID in command is not valid")
+    void provide_one_valid_violation_if_entity_id_in_command_is_not_valid() {
         validate(EntityIdMsgFieldValue.getDefaultInstance());
 
         assertEquals(1, violations.size());
@@ -965,7 +1049,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void provide_custom_invalid_field_message_if_specified() {
+    @DisplayName("provide custom invalid field message if specified")
+    void provide_custom_invalid_field_message_if_specified() {
         PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
                                                                      .setEmail("invalid email")
                                                                      .build();
@@ -982,7 +1067,8 @@ public class MessageValidatorShould {
     }
 
     @Test
-    public void ignore_custom_invalid_field_message_if_validation_is_disabled() {
+    @DisplayName("ignore custom invalid field message if validation is disabled")
+    void ignore_custom_invalid_field_message_if_validation_is_disabled() {
         validate(
                 EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage.getDefaultInstance());
         assertIsValid(true);
@@ -1034,7 +1120,7 @@ public class MessageValidatorShould {
 
     private void assertIsValid(boolean isValid) {
         if (isValid) {
-            assertTrue(violations.toString(), violations.isEmpty());
+            assertTrue(violations.isEmpty(), () -> violations.toString());
         } else {
             assertFalse(violations.isEmpty());
             for (ConstraintViolation violation : violations) {

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -1156,11 +1156,11 @@ class MessageValidatorTest {
 
     private void assertValid(Message msg) {
         validate(msg);
-        assertIsValid(false);
+        assertIsValid(true);
     }
     private void assertNotValid(Message msg) {
         validate(msg);
-        assertIsValid(true);
+        assertIsValid(false);
     }
 
     private void assertIsValid(boolean isValid) {

--- a/base/src/test/proto/spine/test/validate/messages.proto
+++ b/base/src/test/proto/spine/test/validate/messages.proto
@@ -250,3 +250,20 @@ message MessageWithMapDoubleField {
 message InvalidMessage {
     string invalid_field = 1 [(required) = true, (pattern).regex = "^$"];
 }
+
+message AggregateState {
+    option (entity).kind = AGGREGATE;
+
+    // An entity ID (ends with `_id` and declared first). The ID is required by default.
+    string entity_id = 1;
+
+    // Not an entity ID because it isn't the first field, even tough it ends with `_id`.
+    string another_id = 2;
+}
+
+message ProjectionState {
+    option (entity).kind = PROJECTION;
+
+    // An entity ID, but it isn't required since the option is set to `false`.
+    string not_important_id = 1 [(required) = false];
+}

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidationRulesLookup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/ValidationRulesLookup.java
@@ -27,6 +27,7 @@ import io.spine.code.proto.MessageDeclaration;
 import io.spine.logging.Logging;
 import io.spine.option.Options;
 import io.spine.type.TypeName;
+import io.spine.validate.rule.ValidationRules;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 
@@ -87,7 +88,7 @@ public final class ValidationRulesLookup {
             propsMap.put(typeName.value(), ruleTargets);
         }
 
-        String fileName = io.spine.validate.rules.ValidationRules.fileName();
+        String fileName = ValidationRules.fileName();
         log().debug("Writing the validation rules description to {}/{}.",
                     targetDir, fileName);
         PropertiesWriter writer = new PropertiesWriter(targetDir.getAbsolutePath(), fileName);

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/ValidationRulesLookupPluginShould.java
@@ -23,7 +23,7 @@ package io.spine.tools.gradle.compiler;
 import io.spine.code.java.DefaultJavaProject;
 import io.spine.code.properties.PropertyFile;
 import io.spine.tools.gradle.GradleProject;
-import io.spine.validate.rules.ValidationRules;
+import io.spine.validate.rule.ValidationRules;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.11.9-SNAPSHOT'
+final def SPINE_VERSION = '0.11.10-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes #179.

Now, the framework assumes, that an entity ID is required by default.

The only way to say that an entity ID is not required is to explicitly mark it as `[(required)=false]`.

A field is considered an entity ID if:
- The name is `id` or ends with `_id`.
- The field if the first in a containing message.
- A message containing the field has `(entity).kind` option set.

The version was bumped to `0.11.10-SNAPSHOT`.