### PR TITLE
Don't publish duplicated `javadoc-prettifier` artifact

### DIFF
--- a/tools/javadoc-prettifier/build.gradle
+++ b/tools/javadoc-prettifier/build.gradle
@@ -19,8 +19,6 @@
  */
 group 'io.spine.tools'
 
-apply plugin: 'java-gradle-plugin'
-
 dependencies {
     implementation deps.build.guava
 
@@ -28,6 +26,7 @@ dependencies {
     implementation project(':plugin-base')
 
     testImplementation project(':plugin-testlib')
+    testImplementation gradleTestKit()
 }
 
 test.dependsOn(publishToMavenLocal,

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.11.10-SNAPSHOT'
+final def SPINE_VERSION = '0.11.11-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes #213.

The redundant `javadoc-prettifier` artifact was published by `java-gradle-plugin`. The plugin is not applied not since it isn't required. Instead, a dependency on `gradleTestKit` was added.

The version was bumped to `0.11.11-SNAPSHOT`.
