### PR TITLE
Get rid of unused type parameters in formal parameters

### DIFF
--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -268,11 +268,11 @@ public final class Identifier<I> {
      * @param <I>
      *         the type of the ID
      * @return <ul>
-     *         <li>for classes implementing {@link Message} &mdash; a Json form;
-     *         <li>for {@code String}, {@code Long}, {@code Integer} &mdash;
-     *         the result of {@link Object#toString()};
-     *         <li>for {@code null} ID &mdash; the {@link #NULL_ID};
-     *         <li>if the result is empty or blank string &mdash; the {@link #EMPTY_ID}.
+     *         <li>for classes implementing {@link Message} — a Json form;
+     *           <li>for {@code String}, {@code Long}, {@code Integer} —
+     *               the result of {@link Object#toString()};
+     *           <li>for {@code null} ID — the {@link #NULL_ID};
+     *           <li>if the result is empty or blank string — the {@link #EMPTY_ID}.
      *         </ul>
      * @throws IllegalArgumentException
      *         if the passed type isn't one of the above or

--- a/base/src/main/java/io/spine/protobuf/TypeConverter.java
+++ b/base/src/main/java/io/spine/protobuf/TypeConverter.java
@@ -106,19 +106,31 @@ public final class TypeConverter {
      *
      * @param value the {@link Object} value to convert
      * @param <T>   the converted object type
+     * @return the wrapped value
+     */
+    public static <T> Message toMessage(T value) {
+        // Must be checked at runtime
+        @SuppressWarnings("unchecked") Class<T> srcClass = (Class<T>) value.getClass();
+        MessageCaster<Message, T> caster = MessageCaster.forType(srcClass);
+        Message message = caster.toMessage(value);
+        checkNotNull(message);
+        return message;
+    }
+
+    /**
+     * Converts the given value to a corresponding Protobuf {@link Message} type.
+     *
+     * <p>Unlike {@link #toMessage(Object)}, casts the message to the specified class.
+     *
+     * @param value the {@link Object} value to convert
+     * @param <T>   the converted object type
      * @param <M>   the resulting message type
      * @return the wrapped value
      */
-    @SuppressWarnings("TypeParameterUnusedInFormals")
-    // Parameters are handled by MessageCaster, that we wrap by this method.
-    public static <T, M extends Message> M toMessage(T value) {
-        @SuppressWarnings("unchecked") // Must be checked at runtime
-        Class<T> srcClass = (Class<T>) value.getClass();
-        MessageCaster<M, T> caster = MessageCaster.forType(srcClass);
-        M message = caster.reverse()
-                          .convert(value);
-        checkNotNull(message);
-        return message;
+    public static <T, M extends Message> M toMessage(T value, Class<M> messageClass) {
+        checkNotNull(messageClass);
+        Message message = toMessage(value);
+        return messageClass.cast(message);
     }
 
     /**

--- a/base/src/main/java/io/spine/protobuf/TypeConverter.java
+++ b/base/src/main/java/io/spine/protobuf/TypeConverter.java
@@ -109,8 +109,8 @@ public final class TypeConverter {
      * @return the wrapped value
      */
     public static <T> Message toMessage(T value) {
-        // Must be checked at runtime
-        @SuppressWarnings("unchecked") Class<T> srcClass = (Class<T>) value.getClass();
+        @SuppressWarnings("unchecked" /* Must be checked at runtime. */)
+        Class<T> srcClass = (Class<T>) value.getClass();
         MessageCaster<Message, T> caster = MessageCaster.forType(srcClass);
         Message message = caster.toMessage(value);
         checkNotNull(message);

--- a/base/src/main/java/io/spine/string/Stringifiers.java
+++ b/base/src/main/java/io/spine/string/Stringifiers.java
@@ -84,9 +84,7 @@ public final class Stringifiers {
      * @return the parsed value from string
      * @throws MissingStringifierException if passed value cannot be converted
      */
-    @SuppressWarnings("TypeParameterUnusedInFormals")
-    // We're pretty safe as we pass the type value as the parameter.
-    public static <T> T fromString(String str, Type typeOfT) {
+    public static <T> T fromString(String str, Class<T> typeOfT) {
         checkNotNull(str);
         checkNotNull(typeOfT);
         Stringifier<T> stringifier = StringifierRegistry.getStringifier(typeOfT);

--- a/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
@@ -30,7 +30,6 @@ import io.spine.protobuf.Messages;
 import io.spine.string.Stringifiers;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 
@@ -86,18 +85,19 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
     /**
      * Converts the passed `raw` value and returns it.
      *
-     * @param value   the value to convert
-     * @param typeOfV the key of the {@code StringifierRegistry} storage
-     *                to obtain the {@code Stringifier}
-     * @param <V>     the type of the converted value
+     * @param value
+     *         the value to convert
+     * @param valueClass
+     *         the {@code Class} of the value
+     * @param <V>
+     *         the type of the converted value
      * @return the converted value
-     * @throws ConversionException if passed value cannot be converted
+     * @throws ConversionException
+     *         if passed value cannot be converted
      */
-    @SuppressWarnings("TypeParameterUnusedInFormals")
-    // We're pretty safe as we pass the type value as the parameter.
-    protected <V> V convert(String value, Type typeOfV) throws ConversionException {
+    protected <V> V convert(String value, Class<V> valueClass) throws ConversionException {
         try {
-            V convertedValue = Stringifiers.fromString(value, typeOfV);
+            V convertedValue = Stringifiers.fromString(value, valueClass);
             return convertedValue;
         } catch (RuntimeException ex) {
             Throwable rootCause = getRootCause(ex);
@@ -108,13 +108,18 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
     /**
      * Converts the passed `raw` value to {@code Map}.
      *
-     * <p>Acts as a shortcut to {@linkplain #convert(String, Type) convert(String, Map)}.
+     * <p>Acts as a shortcut to {@linkplain #convert(String, java.lang.Class) convert(String, Map)}.
      *
-     * @param <K>        the type of the {@code Map} keys
-     * @param <V>        the type of the {@code Map} values
-     * @param value      the value to convert
-     * @param keyClass   the {@code Class} of the key
-     * @param valueClass the {@code Class} of the value
+     * @param <K>
+     *         the type of the {@code Map} keys
+     * @param <V>
+     *         the type of the {@code Map} values
+     * @param value
+     *         the value to convert
+     * @param keyClass
+     *         the {@code Class} of the key
+     * @param valueClass
+     *         the {@code Class} of the value
      * @return the converted value
      */
     protected <K, V> Map<K, V> convertToMap(String value, Class<K> keyClass, Class<V> valueClass) {
@@ -127,11 +132,14 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
     /**
      * Converts the passed `raw` value to {@code List}.
      *
-     * <p>Acts as a shortcut to {@linkplain #convert(String, Type) convert(String, List)}.
+     * <p>Acts as a shortcut to {@linkplain #convert(String, Class) convert(String, List)}.
      *
-     * @param <V>        the type of the {@code List} values
-     * @param value      the value to convert
-     * @param valueClass the {@code Class} of the list values
+     * @param <V>
+     *         the type of the {@code List} values
+     * @param value
+     *         the value to convert
+     * @param valueClass
+     *         the {@code Class} of the list values
      * @return the converted value
      */
     protected <V> List<V> convertToList(String value, Class<V> valueClass) {

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -316,6 +316,7 @@ class IdentifierTest {
     @DisplayName(NOT_ACCEPT_NULLS)
     void nullCheck() {
         new NullPointerTester()
+                .setDefault(Any.class, AnyPacker.pack(StringValue.of(TEST_ID)))
                 .testAllPublicStaticMethods(Identifier.class);
     }
 
@@ -373,29 +374,52 @@ class IdentifierTest {
         @Test
         @DisplayName("the field name is not `uuid`")
         void nameIsInvalid() {
-            assertThrows(IllegalStateException.class, () -> Identifier.generate(StringValue.class));
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> Identifier.generate(StringValue.class)
+            );
         }
 
         @Test
         @DisplayName("it contains more than one field")
         void moreThanOneField() {
-            assertThrows(IllegalStateException.class, () -> Identifier.generate(Any.class));
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> Identifier.generate(Any.class)
+            );
         }
 
         @Test
         @DisplayName("the field is not string")
         void fieldNotString() {
-            assertThrows(IllegalStateException.class, () -> Identifier.generate(Int32Value.class));
+            assertThrows(
+                    IllegalStateException.class,
+                    () -> Identifier.generate(Int32Value.class)
+            );
         }
     }
 
-    @Test
-    @DisplayName("do not unpack empty Any")
-    void rejectUnpackingEmptyAny() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> Identifier.unpack(Any.getDefaultInstance())
-        );
+    @Nested
+    @DisplayName("unpack")
+    class Unpack {
+
+        @Test
+        @DisplayName("Any with StringValue and cast")
+        void anyWithStringValue() {
+            StringValue testIdMessage = StringValue.of(TEST_ID);
+            Any any = AnyPacker.pack(testIdMessage);
+            String unpackedId = Identifier.unpack(any, String.class);
+            assertEquals(testIdMessage.getValue(), unpackedId);
+        }
+
+        @Test
+        @DisplayName("and throw if Any is empty")
+        void rejectEmptyAny() {
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> Identifier.unpack(Any.getDefaultInstance())
+            );
+        }
     }
 
     @Test

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -42,7 +42,6 @@ import static io.spine.base.Identifier.NULL_ID;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.protobuf.TypeConverter.toMessage;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
-import static io.spine.testing.TestValues.newUuidValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -388,13 +387,6 @@ class IdentifierTest {
         void fieldNotString() {
             assertThrows(IllegalStateException.class, () -> Identifier.generate(Int32Value.class));
         }
-    }
-
-    @Test
-    @DisplayName("unpack Any")
-    void unpackAny() {
-        StringValue id = newUuidValue();
-        assertEquals(id.getValue(), Identifier.toString(AnyPacker.pack(id)));
     }
 
     @Test

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -217,7 +217,7 @@ class IdentifierTest {
         @DisplayName("wrapped Integer")
         void ofWrappedInteger() {
             Integer value = 1024;
-            Int32Value id = toMessage(value);
+            Int32Value id = Int32Value.of(value);
             String expected = value.toString();
 
             String actual = Identifier.toString(id);
@@ -229,7 +229,7 @@ class IdentifierTest {
         @DisplayName("wrapped Long")
         void ofWrappedLong() {
             Long value = 100500L;
-            Int64Value id = toMessage(value);
+            Int64Value id = Int64Value.of(value);
             String expected = value.toString();
 
             String actual = Identifier.toString(id);
@@ -243,12 +243,10 @@ class IdentifierTest {
             assertEquals(TEST_ID, Identifier.toString(TEST_ID));
         }
 
-
         @Test
         @DisplayName("wrapped String")
         void ofWrappedString() {
-
-            StringValue id = toMessage(TEST_ID);
+            StringValue id = StringValue.of(TEST_ID);
 
             String result = Identifier.toString(id);
 
@@ -258,7 +256,7 @@ class IdentifierTest {
         @Test
         @DisplayName("Message with string field")
         void ofMessage() {
-            StringValue id = toMessage(TEST_ID);
+            StringValue id = StringValue.of(TEST_ID);
 
             String result = Identifier.toString(id);
 
@@ -268,7 +266,7 @@ class IdentifierTest {
         @Test
         @DisplayName("Message with nested Message")
         void ofNestedMessage() {
-            StringValue value = toMessage(TEST_ID);
+            StringValue value = StringValue.of(TEST_ID);
             NestedMessageId idToConvert = NestedMessageId
                     .newBuilder()
                     .setId(value)
@@ -282,7 +280,7 @@ class IdentifierTest {
         @Test
         @DisplayName("Any")
         void ofAny() {
-            StringValue messageToWrap = toMessage(TEST_ID);
+            StringValue messageToWrap = StringValue.of(TEST_ID);
             Any any = AnyPacker.pack(messageToWrap);
 
             String result = Identifier.toString(any);
@@ -298,7 +296,7 @@ class IdentifierTest {
         String outerString = "outer_string";
         Integer number = 256;
 
-        StringValue nestedMessageString = toMessage(nestedString);
+        StringValue nestedMessageString = StringValue.of(nestedString);
         SeveralFieldsId idToConvert = SeveralFieldsId.newBuilder()
                                                      .setString(outerString)
                                                      .setNumber(number)
@@ -364,7 +362,7 @@ class IdentifierTest {
         void clazz() {
             assertThrows(
                     IllegalArgumentException.class,
-                    () ->  Identifier.getType(Float.class)
+                    () -> Identifier.getType(Float.class)
             );
         }
     }

--- a/base/src/test/java/io/spine/json/JsonTest.java
+++ b/base/src/test/java/io/spine/json/JsonTest.java
@@ -39,7 +39,6 @@ import static io.spine.base.Identifier.newUuid;
 import static io.spine.json.Json.fromJson;
 import static io.spine.json.Json.toCompactJson;
 import static io.spine.json.Json.toJson;
-import static io.spine.protobuf.TypeConverter.toMessage;
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -80,7 +79,7 @@ class JsonTest extends UtilityClassTest<Json> {
     @Test
     @DisplayName("print to JSON")
     void print_to_json() {
-        StringValue value = toMessage("print_to_json");
+        StringValue value = StringValue.of("print_to_json");
         assertFalse(toJson(value).isEmpty());
     }
 

--- a/base/src/test/java/io/spine/protobuf/AnyPackerTest.java
+++ b/base/src/test/java/io/spine/protobuf/AnyPackerTest.java
@@ -36,7 +36,6 @@ import static io.spine.base.Identifier.newUuid;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.AnyPacker.unpack;
 import static io.spine.protobuf.AnyPacker.unpackFunc;
-import static io.spine.protobuf.TypeConverter.toMessage;
 import static io.spine.testing.DisplayNames.HAVE_PARAMETERLESS_CTOR;
 import static io.spine.testing.TestValues.newUuidValue;
 import static io.spine.testing.Tests.assertHasPrivateParameterlessCtor;
@@ -50,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class AnyPackerTest {
 
     /** A message with type URL standard to Google Protobuf. */
-    private final StringValue googleMsg = toMessage(newUuid());
+    private final StringValue googleMsg = StringValue.of(newUuid());
 
     /** A message with different type URL. */
     private final MessageToPack spineMsg = MessageToPack.newBuilder()

--- a/base/src/test/java/io/spine/protobuf/MessageFieldTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldTest.java
@@ -34,7 +34,6 @@ import static io.spine.protobuf.MessageField.getFieldCount;
 import static io.spine.protobuf.MessageField.getFieldDescriptor;
 import static io.spine.protobuf.MessageField.getFieldName;
 import static io.spine.protobuf.MessageField.toAccessorMethodName;
-import static io.spine.protobuf.TypeConverter.toMessage;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -46,7 +45,7 @@ class MessageFieldTest {
     @SuppressWarnings("DuplicateStringLiteralInspection")
     private static final String STR_VALUE_FIELD_NAME = "value";
 
-    private final StringValue stringValue = toMessage(newUuid());
+    private final StringValue stringValue = StringValue.of(newUuid());
 
     @Test
     @DisplayName("accept positive index")

--- a/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
+++ b/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
@@ -72,71 +72,57 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("Int32Value to int")
         void map_Int32Value_to_int() {
-            int rowValue = 42;
-            Message value = Int32Value.newBuilder()
-                                      .setValue(rowValue)
-                                      .build();
-            checkMapping(rowValue, value);
+            int rawValue = 42;
+            Message value = Int32Value.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("Int64Value to int")
         void map_Int64Value_to_long() {
-            long rowValue = 42;
-            Message value = Int64Value.newBuilder()
-                                      .setValue(rowValue)
-                                      .build();
-            checkMapping(rowValue, value);
+            long rawValue = 42;
+            Message value = Int64Value.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("FloatValue to float")
         void map_FloatValue_to_float() {
-            float rowValue = 42.0f;
-            Message value = FloatValue.newBuilder()
-                                      .setValue(rowValue)
-                                      .build();
-            checkMapping(rowValue, value);
+            float rawValue = 42.0f;
+            Message value = FloatValue.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("DoubleValue to double")
         void map_DoubleValue_to_double() {
-            double rowValue = 42.0;
-            Message value = DoubleValue.newBuilder()
-                                       .setValue(rowValue)
-                                       .build();
-            checkMapping(rowValue, value);
+            double rawValue = 42.0;
+            Message value = DoubleValue.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("BoolValue to boolean")
         void map_BoolValue_to_boolean() {
-            boolean rowValue = true;
-            Message value = BoolValue.newBuilder()
-                                     .setValue(rowValue)
-                                     .build();
-            checkMapping(rowValue, value);
+            boolean rawValue = true;
+            Message value = BoolValue.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("StringValue to String")
         void map_StringValue_to_String() {
-            String rowValue = "Hello";
-            Message value = StringValue.newBuilder()
-                                       .setValue(rowValue)
-                                       .build();
-            checkMapping(rowValue, value);
+            String rawValue = "Hello";
+            Message value = StringValue.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
         @DisplayName("BytesValue to ByteString")
         void map_BytesValue_to_ByteString() {
-            ByteString rowValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
-            Message value = BytesValue.newBuilder()
-                                      .setValue(rowValue)
-                                      .build();
-            checkMapping(rowValue, value);
+            ByteString rawValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
+            Message value = BytesValue.of(rawValue);
+            checkMapping(rawValue, value);
         }
 
         @Test
@@ -152,9 +138,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @DisplayName("UInt32 to int")
         void map_uint32_to_int() {
             int value = 42;
-            UInt32Value wrapped = UInt32Value.newBuilder()
-                                             .setValue(value)
-                                             .build();
+            UInt32Value wrapped = UInt32Value.of(value);
             Any packed = AnyPacker.pack(wrapped);
             int mapped = TypeConverter.toObject(packed, Integer.class);
             assertEquals(value, mapped);
@@ -164,9 +148,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @DisplayName("UInt64 to int")
         void map_uint64_to_long() {
             long value = 42L;
-            UInt64Value wrapped = UInt64Value.newBuilder()
-                                             .setValue(value)
-                                             .build();
+            UInt64Value wrapped = UInt64Value.of(value);
             Any packed = AnyPacker.pack(wrapped);
             long mapped = TypeConverter.toObject(packed, Long.class);
             assertEquals(value, mapped);

--- a/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
+++ b/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
@@ -37,9 +37,11 @@ import com.google.protobuf.UInt32Value;
 import com.google.protobuf.UInt64Value;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
+import static io.spine.protobuf.TypeConverter.toMessage;
 import static io.spine.protobuf.given.TypeConverterTestEnv.TaskStatus.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -56,123 +58,141 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         tester.setDefault(Any.class, Any.getDefaultInstance());
     }
 
-    @Test
-    @DisplayName("map arbitrary message to itself")
-    void map_arbitrary_message_to_itself() {
-        Message message = StringValue.of(newUuid());
-        checkMapping(message, message);
+    @Nested
+    @DisplayName("map")
+    class Map {
+
+        @Test
+        @DisplayName("arbitrary message to itself")
+        void map_arbitrary_message_to_itself() {
+            Message message = StringValue.of(newUuid());
+            checkMapping(message, message);
+        }
+
+        @Test
+        @DisplayName("Int32Value to int")
+        void map_Int32Value_to_int() {
+            int rowValue = 42;
+            Message value = Int32Value.newBuilder()
+                                      .setValue(rowValue)
+                                      .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("Int64Value to int")
+        void map_Int64Value_to_long() {
+            long rowValue = 42;
+            Message value = Int64Value.newBuilder()
+                                      .setValue(rowValue)
+                                      .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("FloatValue to float")
+        void map_FloatValue_to_float() {
+            float rowValue = 42.0f;
+            Message value = FloatValue.newBuilder()
+                                      .setValue(rowValue)
+                                      .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("DoubleValue to double")
+        void map_DoubleValue_to_double() {
+            double rowValue = 42.0;
+            Message value = DoubleValue.newBuilder()
+                                       .setValue(rowValue)
+                                       .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("BoolValue to boolean")
+        void map_BoolValue_to_boolean() {
+            boolean rowValue = true;
+            Message value = BoolValue.newBuilder()
+                                     .setValue(rowValue)
+                                     .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("StringValue to String")
+        void map_StringValue_to_String() {
+            String rowValue = "Hello";
+            Message value = StringValue.newBuilder()
+                                       .setValue(rowValue)
+                                       .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("BytesValue to ByteString")
+        void map_BytesValue_to_ByteString() {
+            ByteString rowValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
+            Message value = BytesValue.newBuilder()
+                                      .setValue(rowValue)
+                                      .build();
+            checkMapping(rowValue, value);
+        }
+
+        @Test
+        @DisplayName("EnumValue to Enum")
+        void map_EnumValue_to_Enum() {
+            Message value = EnumValue.newBuilder()
+                                     .setName(SUCCESS.name())
+                                     .build();
+            checkMapping(SUCCESS, value);
+        }
+
+        @Test
+        @DisplayName("UInt32 to int")
+        void map_uint32_to_int() {
+            int value = 42;
+            UInt32Value wrapped = UInt32Value.newBuilder()
+                                             .setValue(value)
+                                             .build();
+            Any packed = AnyPacker.pack(wrapped);
+            int mapped = TypeConverter.toObject(packed, Integer.class);
+            assertEquals(value, mapped);
+        }
+
+        @Test
+        @DisplayName("UInt64 to int")
+        void map_uint64_to_long() {
+            long value = 42L;
+            UInt64Value wrapped = UInt64Value.newBuilder()
+                                             .setValue(value)
+                                             .build();
+            Any packed = AnyPacker.pack(wrapped);
+            long mapped = TypeConverter.toObject(packed, Long.class);
+            assertEquals(value, mapped);
+        }
+
+        private void checkMapping(Object javaObject,
+                                  Message protoObject) {
+            Any wrapped = AnyPacker.pack(protoObject);
+            Object mappedJavaObject = TypeConverter.toObject(wrapped, javaObject.getClass());
+            assertEquals(javaObject, mappedJavaObject);
+            Any restoredWrapped = TypeConverter.toAny(mappedJavaObject);
+            Message restored = AnyPacker.unpack(restoredWrapped);
+            assertEquals(protoObject, restored);
+        }
     }
 
-    @Test
-    @DisplayName("map Int32Value to int")
-    void map_Int32Value_to_int() {
-        int rowValue = 42;
-        Message value = Int32Value.newBuilder()
-                                  .setValue(rowValue)
-                                  .build();
-        checkMapping(rowValue, value);
-    }
+    @Nested
+    @DisplayName("convert")
+    class Convert {
 
-    @Test
-    @DisplayName("map Int64Value to int")
-    void map_Int64Value_to_long() {
-        long rowValue = 42;
-        Message value = Int64Value.newBuilder()
-                                  .setValue(rowValue)
-                                  .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map FloatValue to float")
-    void map_FloatValue_to_float() {
-        float rowValue = 42.0f;
-        Message value = FloatValue.newBuilder()
-                                  .setValue(rowValue)
-                                  .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map DoubleValue to double")
-    void map_DoubleValue_to_double() {
-        double rowValue = 42.0;
-        Message value = DoubleValue.newBuilder()
-                                   .setValue(rowValue)
-                                   .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map BoolValue to boolean")
-    void map_BoolValue_to_boolean() {
-        boolean rowValue = true;
-        Message value = BoolValue.newBuilder()
-                                 .setValue(rowValue)
-                                 .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map StringValue to String")
-    void map_StringValue_to_String() {
-        String rowValue = "Hello";
-        Message value = StringValue.newBuilder()
-                                   .setValue(rowValue)
-                                   .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map BytesValue to ByteString")
-    void map_BytesValue_to_ByteString() {
-        ByteString rowValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
-        Message value = BytesValue.newBuilder()
-                                  .setValue(rowValue)
-                                  .build();
-        checkMapping(rowValue, value);
-    }
-
-    @Test
-    @DisplayName("map EnumValue to Enum")
-    void map_EnumValue_to_Enum() {
-        Message value = EnumValue.newBuilder()
-                                 .setName(SUCCESS.name())
-                                 .build();
-        checkMapping(SUCCESS, value);
-    }
-
-    @Test
-    @DisplayName("map UInt32 to int")
-    void map_uint32_to_int() {
-        int value = 42;
-        UInt32Value wrapped = UInt32Value.newBuilder()
-                                         .setValue(value)
-                                         .build();
-        Any packed = AnyPacker.pack(wrapped);
-        int mapped = TypeConverter.toObject(packed, Integer.class);
-        assertEquals(value, mapped);
-    }
-
-    @Test
-    @DisplayName("map UInt64 to int")
-    void map_uint64_to_long() {
-        long value = 42L;
-        UInt64Value wrapped = UInt64Value.newBuilder()
-                                         .setValue(value)
-                                         .build();
-        Any packed = AnyPacker.pack(wrapped);
-        long mapped = TypeConverter.toObject(packed, Long.class);
-        assertEquals(value, mapped);
-    }
-
-    private static void checkMapping(Object javaObject,
-                                     Message protoObject) {
-        Any wrapped = AnyPacker.pack(protoObject);
-        Object mappedJavaObject = TypeConverter.toObject(wrapped, javaObject.getClass());
-        assertEquals(javaObject, mappedJavaObject);
-        Any restoredWrapped = TypeConverter.toAny(mappedJavaObject);
-        Message restored = AnyPacker.unpack(restoredWrapped);
-        assertEquals(protoObject, restored);
+        @Test
+        @DisplayName("a value to a particular message")
+        void valueToParticularMessage() {
+            String stringValue = "a string value";
+            StringValue convertedValue = toMessage(stringValue, StringValue.class);
+            assertEquals(stringValue, convertedValue.getValue());
+        }
     }
 }

--- a/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
+++ b/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
@@ -20,49 +20,77 @@
 
 package io.spine.validate;
 
+import com.google.protobuf.Int32Value;
 import com.google.protobuf.UInt32Value;
+import io.spine.base.ConversionException;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("AbstractValidatingBuilder should")
 class AbstractValidatingBuilderTest {
 
-    @Test
-    @DisplayName("convert to map")
-    void convert_to_map() {
-        String key1 = "key1";
-        UInt32Value value = UInt32Value.newBuilder()
-                                       .setValue(123)
-                                       .build();
-        String mapStr = "\"key1\":\"123\",\"key2\":\"234\"";
+    @Nested
+    @DisplayName("convert a raw String to")
+    class Convert {
 
-        UInt32ValueVBuilder uInt32ValueVBuilder = UInt32ValueVBuilder.newBuilder();
-        Map<String, UInt32Value> convertedValue =
-                uInt32ValueVBuilder.convertToMap(mapStr,
-                                                 String.class,
-                                                 UInt32Value.class);
+        @Test
+        @DisplayName("Map")
+        void toMap() {
+            String key1 = "key1";
+            UInt32Value value = UInt32Value.newBuilder()
+                                           .setValue(123)
+                                           .build();
+            String mapStr = "\"key1\":\"123\",\"key2\":\"234\"";
 
-        assertTrue(convertedValue.containsKey(key1));
-        assertTrue(convertedValue.containsValue(value));
-    }
+            UInt32ValueVBuilder uInt32ValueVBuilder = UInt32ValueVBuilder.newBuilder();
+            Map<String, UInt32Value> convertedValue =
+                    uInt32ValueVBuilder.convertToMap(mapStr,
+                                                     String.class,
+                                                     UInt32Value.class);
 
-    @Test
-    @DisplayName("convert to list")
-    void convert_to_list() {
-        String key1 = "key1";
-        String value = "123";
-        String listStr = "\"key1\",\"123\",\"key2\",\"234\"";
+            assertTrue(convertedValue.containsKey(key1));
+            assertTrue(convertedValue.containsValue(value));
+        }
 
-        StringValueVBuilder stringValueVBuilder = StringValueVBuilder.newBuilder();
-        List<String> convertedValue = stringValueVBuilder.convertToList(listStr,
-                                                                        String.class);
+        @Test
+        @DisplayName("List")
+        void toList() {
+            String key1 = "key1";
+            String value = "123";
+            String listStr = "\"key1\",\"123\",\"key2\",\"234\"";
 
-        assertTrue(convertedValue.contains(key1));
-        assertTrue(convertedValue.contains(value));
+            StringValueVBuilder stringValueVBuilder = StringValueVBuilder.newBuilder();
+            List<String> convertedValue = stringValueVBuilder.convertToList(listStr,
+                                                                            String.class);
+
+            assertTrue(convertedValue.contains(key1));
+            assertTrue(convertedValue.contains(value));
+        }
+
+        @Test
+        @DisplayName("Class")
+        void toClass() throws ConversionException {
+            String value = "123";
+            StringValueVBuilder vBuilder = StringValueVBuilder.newBuilder();
+            Int32Value convertedValue = vBuilder.convert(value, Int32Value.class);
+            assertEquals(Integer.parseInt(value), convertedValue.getValue());
+        }
+
+        @Test
+        @DisplayName("wrong Class and fail")
+        void toWrongClass() {
+            String notInt = "notInt";
+            StringValueVBuilder vBuilder = StringValueVBuilder.newBuilder();
+            assertThrows(ConversionException.class,
+                         () -> vBuilder.convert(notInt, Int32Value.class));
+        }
     }
 }

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -83,7 +83,6 @@ import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.base.Time.getCurrentTime;
-import static io.spine.protobuf.TypeConverter.toMessage;
 import static io.spine.validate.MessageValidatorTestEnv.FIFTY_NANOSECONDS;
 import static io.spine.validate.MessageValidatorTestEnv.SECONDS_IN_5_MINUTES;
 import static io.spine.validate.MessageValidatorTestEnv.ZERO_NANOSECONDS;
@@ -1204,7 +1203,7 @@ class MessageValidatorTest {
     }
 
     private static StringValue newStringValue() {
-        return toMessage(newUuid());
+        return StringValue.of(newUuid());
     }
 
     private static ByteString newByteString() {

--- a/testlib/src/main/java/io/spine/testing/Tests.java
+++ b/testlib/src/main/java/io/spine/testing/Tests.java
@@ -21,7 +21,6 @@
 package io.spine.testing;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Message;
@@ -29,7 +28,6 @@ import com.google.protobuf.Message;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.truth.Truth.assertThat;
@@ -145,8 +143,11 @@ public final class Tests {
      *
      * <p>Use it when it is needed to pass {@code null} to a method in tests so that no
      * warnings suppression is needed.
+     *
+     * @apiNote The method doesn't take {@code Class<T>} to keep
+     *         the test API small and convenient
      */
-    @SuppressWarnings("TypeParameterUnusedInFormals")
+    @SuppressWarnings("TypeParameterUnusedInFormals" /* See api note. */)
     public static <T> T nullRef() {
         T nullRef = null;
         return nullRef;
@@ -155,10 +156,12 @@ public final class Tests {
     /**
      * Asserts that the passed message has a field that matches the passed field mask.
      *
-     * @param message   the message to assert
-     * @param fieldMask which is matched against the message field
-     *
-     * @throws AssertionError if the check fails
+     * @param message
+     *         the message to assert
+     * @param fieldMask
+     *         which is matched against the message field
+     * @throws AssertionError
+     *         if the check fails
      */
     public static void assertMatchesMask(Message message, FieldMask fieldMask) {
         List<String> paths = fieldMask.getPathsList();
@@ -188,9 +191,12 @@ public final class Tests {
      *
      * <p>The assertion will be passed if the actual delta equals to the set one.
      *
-     * @param expectedValue expected value
-     * @param actualValue   actual value
-     * @param delta         the maximum expected difference between the values
+     * @param expectedValue
+     *         expected value
+     * @param actualValue
+     *         actual value
+     * @param delta
+     *         the maximum expected difference between the values
      */
     public static void assertInDelta(long expectedValue, long actualValue, long delta) {
         long actualDelta = abs(expectedValue - actualValue);

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '0.11.12-SNAPSHOT'
+final def SPINE_VERSION = '0.11.13-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes #200, #201.

The API Changes:
- `Stringifiers.fromString(...)` now takes `Class` instead of `Type`.
- `Identifier.unpack(Any)` now returns `Object`. If a result type is important, use `Identifier.unpack(Any, Class)`.
- `TypeConverter.toMessage(Object)` now returns `Message`. If a result type is important , use `TypeConverter.toMessage(Object, Class)`.
- `AbstractValidatingBuilder.convert(...)` now takes `Class` instead of `Type`.

The version was bumped to `0.11.13-SNAPSHOT`.