### PR TITLE
Fix a ClassCastException in FieldValue

### DIFF
--- a/base/src/main/java/io/spine/validate/FieldValue.java
+++ b/base/src/main/java/io/spine/validate/FieldValue.java
@@ -29,7 +29,7 @@ import com.google.protobuf.ProtocolMessageEnum;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.code.proto.Option;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 
@@ -134,12 +134,15 @@ final class FieldValue {
      *         the type of the list elements
      * @return the value as a list
      */
-    @SuppressWarnings("unchecked" /* specific validator must call with its type */)
+    @SuppressWarnings({
+            "unchecked", // Specific validator must call with its type.
+            "ChainOfInstanceofChecks" // No other possible way to check the value type.
+    })
     <T> ImmutableList<T> asList() {
-        if (declaration.isRepeated()) {
-            List<T> result = (List<T>) value;
+        if (value instanceof Collection) {
+            Collection<T> result = (Collection<T>) value;
             return ImmutableList.copyOf(result);
-        } else if (declaration.isMap()) {
+        } else if (value instanceof Map) {
             Map<?, T> map = (Map<?, T>) value;
             return ImmutableList.copyOf(map.values());
         } else {

--- a/tools/smoke-tests/build.gradle
+++ b/tools/smoke-tests/build.gradle
@@ -53,17 +53,16 @@ buildscript {
     }
 }
 
-repositories {
-    mavenCentral()
-    mavenLocal()
-    jcenter()
-}
-
 allprojects {
     apply from: EXT
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'project-report'
+
+    repositories {
+        mavenLocal()
+        jcenter()
+    }
 }
 
 subprojects {
@@ -78,6 +77,7 @@ subprojects {
         compile "io.spine:spine-base:$spineVersion"
 
         testImplementation "io.spine:spine-testlib:$spineVersion"
+        testRuntimeOnly deps.test.junit5Runner
     }
 
     idea.module {
@@ -104,6 +104,14 @@ subprojects {
                          "$projectDir/src/test/java"
             resources.srcDirs "$projectDir/generated/test/resources"
         }
+    }
+
+    test {
+        useJUnitPlatform {
+            includeEngines 'junit-jupiter'
+        }
+
+        include "**/*Test.class"
     }
 }
 

--- a/tools/smoke-tests/build.gradle
+++ b/tools/smoke-tests/build.gradle
@@ -69,6 +69,7 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'io.spine.tools.spine-model-compiler'
     apply plugin: 'idea'
+    apply from: deps.scripts.testOutput
 
     dependencies {
         // TODO:2018-06-23:dmytro.dashenkov: Migrate to the `implementation` config when resolved:

--- a/tools/smoke-tests/build.gradle
+++ b/tools/smoke-tests/build.gradle
@@ -69,7 +69,7 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'io.spine.tools.spine-model-compiler'
     apply plugin: 'idea'
-    apply from: deps.scripts.testOutput
+    apply from: "$rootDir/../../config/gradle/test-output.gradle"
 
     dependencies {
         // TODO:2018-06-23:dmytro.dashenkov: Migrate to the `implementation` config when resolved:


### PR DESCRIPTION
A `FieldValue` determines the Java type of its value by the field descriptor: if the field is `repeated`, the value is assumed to be a `List`.

However, when a `ValidatingBuilder` validates a value received in an `add<Field>` method (an item added to a repeated field), the runtime de-facto value is not of type `List` but of the field type, e.g. a message.

From now, `FieldValue` checks the actual Java type of the value instead of the descriptor.