### PR TITLE
Add support for repeated fields in field mask tests

### DIFF
--- a/base/src/main/java/io/spine/code/proto/RejectionDeclaration.java
+++ b/base/src/main/java/io/spine/code/proto/RejectionDeclaration.java
@@ -55,7 +55,7 @@ public final class RejectionDeclaration extends AbstractMessageDeclaration {
     }
 
     /**
-     * Returns {@code true} if the class name ends with {@code “Rejections”},
+     * Returns {@code true} if the class name ends with {@code "Rejections"},
      * {@code false} otherwise.
      */
     public static boolean isValidOuterClassName(SimpleClassName className) {

--- a/base/src/main/java/io/spine/code/proto/SourceFile.java
+++ b/base/src/main/java/io/spine/code/proto/SourceFile.java
@@ -70,11 +70,11 @@ public class SourceFile extends AbstractSourceFile {
      * <p>A valid rejections file must have:
      * <ul>
      *     <li>The file name which ends on
-     *         {@link io.spine.base.RejectionMessage.File#suffix() “rejections.proto”}.
+     *         {@link io.spine.base.RejectionMessage.File#suffix() "rejections.proto"}.
      *     <li>The option {@code java_multiple_files} set to {@code false}.
      *     <li>Do not have the option {@code java_outer_classname} or have the value, which
      *         ends with {@linkplain RejectionDeclaration#isValidOuterClassName(SimpleClassName)}
-     *         “Rejections”}.
+     *         "Rejections"}.
      * </ul>
      */
     public boolean isRejections() {

--- a/base/src/main/java/io/spine/reflect/IsDirectParent.java
+++ b/base/src/main/java/io/spine/reflect/IsDirectParent.java
@@ -28,7 +28,7 @@ import java.util.function.Predicate;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Verifiers if a package is direct “parent” of the specified.
+ * Verifiers if a package is direct "parent" of the specified.
  *
  * @author Alexander Yevsyukov
  */

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -49,7 +49,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
     @DisplayName("Create Stringifier with a delimeter for")
     class Delimited {
 
-        private static final char DELIMITER = '❤';
+        private static final char DELIMITER = '#';
         private static final int SIZE = 5;
 
         @Test

--- a/testlib/build.gradle
+++ b/testlib/build.gradle
@@ -31,3 +31,12 @@ dependencies {
     api deps.test.mockito
     api deps.test.hamcrest
 }
+
+protobuf {
+    // Configure the protoc executable
+    protoc {
+        // Download from repositories
+        artifact = "com.google.protobuf:protoc:$deps.versions.protobuf"
+    }
+
+}

--- a/testlib/src/main/java/io/spine/testing/Tests.java
+++ b/testlib/src/main/java/io/spine/testing/Tests.java
@@ -179,9 +179,15 @@ public final class Tests {
         // Assert that values match the field mask.
         for (FieldDescriptor field : fields) {
             if (field.isRepeated()) {
-                continue;
+                boolean pathsHasSuchField = paths.contains(field.getName());
+                if (pathsHasSuchField) {
+                    List<?> repeatedFieldValue = (List<?>) message.getField(field);
+                    boolean fieldValueAbsent = repeatedFieldValue.isEmpty();
+                    assertTrue(!fieldValueAbsent);
+                }
+            } else {
+                assertEquals(message.hasField(field), paths.contains(field.getName()));
             }
-            assertEquals(message.hasField(field), paths.contains(field.getName()));
         }
     }
 

--- a/testlib/src/test/java/io/spine/testing/TestsTest.java
+++ b/testlib/src/test/java/io/spine/testing/TestsTest.java
@@ -25,7 +25,6 @@ import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.FieldMaskUtil;
-import io.spine.testing.HospitalPolicy.PatientCondition;
 import io.spine.testing.given.TestsTestEnv.ClassThrowingExceptionInConstructor;
 import io.spine.testing.given.TestsTestEnv.ClassWithCtorWithArgs;
 import io.spine.testing.given.TestsTestEnv.ClassWithPrivateCtor;
@@ -38,7 +37,8 @@ import org.junit.jupiter.api.Test;
 import java.time.Instant;
 import java.util.UUID;
 
-import static io.spine.testing.HospitalPolicy.PatientCondition.*;
+import static io.spine.testing.HospitalPolicy.PatientCondition.CRITICAL;
+import static io.spine.testing.HospitalPolicy.PatientCondition.CRITICAL_BUT_STABLE;
 import static io.spine.testing.Tests.assertInDelta;
 import static io.spine.testing.Tests.assertMatchesMask;
 import static io.spine.testing.Tests.hasPrivateParameterlessCtor;
@@ -259,13 +259,13 @@ class TestsTest extends UtilityClassTest<Tests> {
 
             @DisplayName("not match absent repeated enum fields")
             @Test
-            void notMatchAbsentRepeatedEnumFields(){
+            void notMatchAbsentRepeatedEnumFields() {
                 HospitalPolicy emptyPolicy = HospitalPolicy
                         .newBuilder()
                         .build();
 
                 FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(HospitalPolicy.class, 1);
-                assertThrows(AssertionError.class, ()->assertMatchesMask(emptyPolicy, fieldMask));
+                assertThrows(AssertionError.class, () -> assertMatchesMask(emptyPolicy, fieldMask));
             }
 
             private Prescription prescribeFromCold() {

--- a/testlib/src/test/proto/spine/testing/hospital_policy.proto
+++ b/testlib/src/test/proto/spine/testing/hospital_policy.proto
@@ -1,0 +1,50 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+syntax = "proto3";
+
+package spine.testing;
+
+// Testlib module doesn't have a dependency on base, thus the use of Spine options, namely
+// (type_url) is omitted.
+option java_multiple_files = true;
+option java_outer_classname = "HospitalPolicyProto";
+option java_package = "io.spine.testing";
+
+import "spine/testing/prescription.proto";
+
+// A policy that regulates kinds of patients accepted by the hospital.
+message HospitalPolicy {
+
+    // Conditions accepted by the hospital
+    repeated PatientCondition accepted_condition = 1;
+
+    enum PatientCondition {
+        UNDETERMINED = 0;
+        GOOD = 1;
+        SATISFACTORY = 2;
+        FAIR = 3;
+        SERIOUS_BUT_STABLE = 4;
+        SERIOUS = 5;
+        CRITICAL_BUT_STABLE = 6;
+        CRITICAL = 7;
+        DEAD = 8;
+    }
+}

--- a/testlib/src/test/proto/spine/testing/patient_prescription_history.proto
+++ b/testlib/src/test/proto/spine/testing/patient_prescription_history.proto
@@ -1,0 +1,48 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+syntax = "proto3";
+
+package spine.testing;
+
+// Testlib module doesn't have a dependency on base, thus the use of Spine options, namely
+// (type_url) is omitted.
+option java_multiple_files = true;
+option java_outer_classname = "PatientPrescriptionHistoryProto";
+option java_package = "io.spine.testing";
+
+import "spine/testing/prescription.proto";
+
+// All prescriptions received by a patient.
+message PrescriptionHistory {
+
+    // ID of a patient that is the owner of the prescription history.
+    PatientId prescription_receiver = 1;
+
+    // All prescriptions received by this patient.
+    repeated Prescription received_prescription = 2;
+}
+
+// An ID of a patient.
+message PatientId {
+
+    // A UUID.
+    string value = 1;
+}

--- a/testlib/src/test/proto/spine/testing/prescription.proto
+++ b/testlib/src/test/proto/spine/testing/prescription.proto
@@ -1,0 +1,41 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+syntax = "proto3";
+
+package spine.testing;
+
+// Testlib module doesn't have a dependency on base, thus the use of Spine options, namely
+// (type_url) is omitted.
+option java_multiple_files = true;
+option java_outer_classname = "PrescriptionProto";
+option java_package = "io.spine.testing";
+
+import "google/protobuf/timestamp.proto";
+
+// A prescription of medication.
+message Prescription {
+
+    // Date the prescription was given to a patient.
+    google.protobuf.Timestamp prescribed_on = 1;
+
+    // Names of prescribed drugs.
+    repeated string prescribed_drug = 2;
+}


### PR DESCRIPTION
This PR addresses https://github.com/SpineEventEngine/base/issues/165.

Now `assertMatchesMask` doesn't skip repeated fields, and instead checks whether at least 1 value is present, and calls a respective `assert`.
