### PR TITLE
Skip imports when generating marker interfaces

### DIFF
--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorTest.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/MarkerInterfaceGeneratorTest.java
@@ -95,8 +95,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate insertion point contents for EveryIs option")
     void generateInsertionPointContentsForEveryIsOption() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/every_is_test.proto";
+        String filePath = "spine/tools/protoc/every_is_test.proto";
 
         FileDescriptorProto descriptor = EveryIsTestProto.getDescriptor()
                                                          .toProto();
@@ -122,8 +121,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate insertion point contents for Is option")
     void generateInsertionPointContentsForIsOption() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/is_test.proto";
+        String filePath = "spine/tools/protoc/is_test.proto";
 
         FileDescriptorProto descriptor = IsTestProto.getDescriptor()
                                                     .toProto();
@@ -149,8 +147,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate insertion point contents for EveryIs in singe file")
     void generateInsertionPointContentsForEveryIsInSingleFile() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/every_is_in_one_file.proto";
+        String filePath = "spine/tools/protoc/every_is_in_one_file.proto";
 
         FileDescriptorProto descriptor = EveryIsInOneFileProto.getDescriptor()
                                                               .toProto();
@@ -175,8 +172,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate insertion point contents for Is in single file")
     void generateInsertionPointContentsForIsInSingleFile() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/is_in_one_file.proto";
+        String filePath = "spine/tools/protoc/is_in_one_file.proto";
 
         FileDescriptorProto descriptor = IsInOneFileProto.getDescriptor()
                                                          .toProto();
@@ -199,8 +195,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate EventMessage insertion points")
     void generateEventMessageInsertionPoints() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/test_events.proto";
+        String filePath = "spine/tools/protoc/test_events.proto";
 
         FileDescriptorProto descriptor = TestEventsProto.getDescriptor()
                                                         .toProto();
@@ -219,8 +214,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate CommandMessage insertion points")
     void generateCommandMessageInsertionPoints() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/test_commands.proto";
+        String filePath = "spine/tools/protoc/test_commands.proto";
 
         FileDescriptorProto descriptor = TestCommandsProto.getDescriptor()
                                                           .toProto();
@@ -239,8 +233,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate RejectionMessage insertion points")
     void generateRejectionMessageInsertionPoints() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/test_rejections.proto";
+        String filePath = "spine/tools/protoc/test_rejections.proto";
 
         FileDescriptorProto descriptor = Rejections.getDescriptor()
                                                    .toProto();
@@ -289,8 +282,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate marker interfaces for (is) if `generate = true`")
     void generateMarkersForIs() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/is_generate.proto";
+        String filePath = "spine/tools/protoc/is_generated.proto";
 
         FileDescriptorProto descriptor = IsGeneratedProto.getDescriptor()
                                                          .toProto();
@@ -324,8 +316,7 @@ class MarkerInterfaceGeneratorTest {
     @Test
     @DisplayName("generate marker interfaces for (every_is) if `generate = true`")
     void generateMarkersForEveryIs() {
-        // Sample path; never resolved
-        String filePath = "/proto/spine/tools/protoc/every_is_generate.proto";
+        String filePath = "spine/tools/protoc/every_is_generated.proto";
 
         FileDescriptorProto descriptor = EveryIsGeneratedProto.getDescriptor()
                                                               .toProto();

--- a/tools/protoc-plugin/src/test/proto/spine/tools/protoc/user.proto
+++ b/tools/protoc-plugin/src/test/proto/spine/tools/protoc/user.proto
@@ -1,0 +1,38 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "UserProto";
+option java_package = "io.spine.tools.protoc";
+
+import "spine/tools/protoc/user_name.proto";
+
+message User {
+    option (is).java_type = "LawSubject";
+    option (is).generate = true;
+
+    UserName name = 1;
+}

--- a/tools/protoc-plugin/src/test/proto/spine/tools/protoc/user_name.proto
+++ b/tools/protoc-plugin/src/test/proto/spine/tools/protoc/user_name.proto
@@ -1,0 +1,37 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "UserNameProto";
+option java_package = "io.spine.tools.protoc";
+
+message UserName {
+    option (is).java_type = "Name";
+
+    string given_name = 1;
+
+    string family_name = 2;
+}


### PR DESCRIPTION
Before, we tried to generate marker interfaces and insertion points for Protobuf sources which are _included_ for a Proto compilation but are not requested, i.e. Protobuf imports. This led to failures in multi-project Gradle builds when several projects depending on each other had some marker interfaces to generate.

From now, the markers are generated for the requested types only.