### PR TITLE
Simplify dependency for generation of vbuilders for `base`

### DIFF
--- a/base-validating-builders/build.gradle
+++ b/base-validating-builders/build.gradle
@@ -57,6 +57,10 @@ sourceSets {
     main.java.srcDirs "$projectDir/generated/main/spine"
 }
 
+modelCompiler {
+    mainProtoSrcDir = "/Users/sanders/Projects/Spine/base/src/main/proto"
+}
+
 protobuf {
     generateProtoTasks {
         all().each {
@@ -98,7 +102,7 @@ build.doLast {
 }
 
 task cleanGenerated(type: Delete) {
-    delete = files("$projectDir/generated", buildersDir)
+    delete = files("$projectDir/generated", "$projectDir/build", "$projectDir/.spine", buildersDir)
 }
 
 clean.dependsOn cleanGenerated

--- a/base-validating-builders/build.gradle
+++ b/base-validating-builders/build.gradle
@@ -64,22 +64,30 @@ apply plugin: 'io.spine.tools.spine-model-compiler'
 apply plugin: 'idea'
 
 repositories {
+    // This defines the `libs` directory under the `base/build` project as a local repository.
+    // See `dependencies` section below for definition of the dependency on the JAR
+    // produced by the `base` module.
+    flatDir {
+        dirs "$projectDir/../base/build/libs/"
+    }
     mavenLocal()
-    mavenCentral()
     jcenter()
     google()
+    mavenCentral()
 }
 
 dependencies {
     compileClasspath deps.build.protobuf
+    compileClasspath deps.build.guava
+    compileClasspath deps.build.slf4j
+    compileClasspath deps.build.checkerAnnotations
+    compileClasspath deps.build.errorProneAnnotations
+    compileClasspath deps.build.jsr305Annotations
+    compileClasspath deps.build.errorProneAnnotations
 
-    compileClasspath  deps.build.guava
-    compileClasspath  deps.build.slf4j
-    compileClasspath  deps.build.checkerAnnotations
-    compileClasspath  deps.build.errorProneAnnotations
-    compileClasspath  deps.build.jsr305Annotations
-    compileClasspath  deps.build.errorProneAnnotations
-    compileClasspath  deps.build.gradlePlugins.protobuf
+    // The below dependency refers to `/base/build/libs/base-{version}.jar`
+    // See `repositories.flatDir` definition above.
+    compileClasspath name: "base-${spineVersion}"
 }
 
 modelCompiler {

--- a/base-validating-builders/build.gradle
+++ b/base-validating-builders/build.gradle
@@ -27,8 +27,34 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "io.spine.tools:spine-model-compiler:$spineVersion"
+        classpath deps.build.protobuf
+        classpath deps.build.guava
+        classpath deps.build.slf4j
+        classpath deps.build.checkerAnnotations
+        classpath deps.build.errorProneAnnotations
+        classpath deps.build.jsr305Annotations
+        classpath deps.build.errorProneAnnotations
         classpath deps.build.gradlePlugins.protobuf
+
+        classpath deps.gen.javaPoet
+
+        // A library for parsing Java sources.
+        // Used for parsing Java sources generated from Protobuf files
+        // to make their annotation more convenient.
+        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-api', 
+                   version: deps.versions.roaster) {
+            exclude group: 'com.google.guava'
+        }
+        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-jdt', 
+                   version: deps.versions.roaster) {
+            exclude group: 'com.google.guava'
+        }
+
+        classpath files([
+                "$projectDir/../tools/model-compiler/build/libs/model-compiler-${spineVersion}.jar",
+                "$projectDir/../tools/plugin-base/build/libs/plugin-base-${spineVersion}.jar",
+                "$projectDir/../base/build/libs/base-${spineVersion}.jar"
+        ])
     }
 }
 
@@ -45,12 +71,19 @@ repositories {
 }
 
 dependencies {
-    final def spineBase = "io.spine:spine-base:$spineVersion"
-
-    protobuf spineBase
-
     compileClasspath deps.build.protobuf
-    compileClasspath spineBase
+
+    protobuf files([
+            "$projectDir/../base/build/libs/base-${spineVersion}.jar"
+    ])
+
+    compileClasspath  deps.build.guava
+    compileClasspath  deps.build.slf4j
+    compileClasspath  deps.build.checkerAnnotations
+    compileClasspath  deps.build.errorProneAnnotations
+    compileClasspath  deps.build.jsr305Annotations
+    compileClasspath  deps.build.errorProneAnnotations
+    compileClasspath  deps.build.gradlePlugins.protobuf
 }
 
 sourceSets {

--- a/base-validating-builders/build.gradle
+++ b/base-validating-builders/build.gradle
@@ -91,7 +91,7 @@ sourceSets {
 }
 
 modelCompiler {
-    mainProtoSrcDir = "/Users/sanders/Projects/Spine/base/src/main/proto"
+    mainProtoSrcDir = "$projectDir/../base/src/main/proto"
 }
 
 protobuf {

--- a/base-validating-builders/build.gradle
+++ b/base-validating-builders/build.gradle
@@ -41,11 +41,11 @@ buildscript {
         // A library for parsing Java sources.
         // Used for parsing Java sources generated from Protobuf files
         // to make their annotation more convenient.
-        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-api', 
+        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-api',
                    version: deps.versions.roaster) {
             exclude group: 'com.google.guava'
         }
-        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-jdt', 
+        classpath (group: 'org.jboss.forge.roaster', name: 'roaster-jdt',
                    version: deps.versions.roaster) {
             exclude group: 'com.google.guava'
         }
@@ -73,10 +73,6 @@ repositories {
 dependencies {
     compileClasspath deps.build.protobuf
 
-    protobuf files([
-            "$projectDir/../base/build/libs/base-${spineVersion}.jar"
-    ])
-
     compileClasspath  deps.build.guava
     compileClasspath  deps.build.slf4j
     compileClasspath  deps.build.checkerAnnotations
@@ -86,12 +82,13 @@ dependencies {
     compileClasspath  deps.build.gradlePlugins.protobuf
 }
 
-sourceSets {
-    main.java.srcDirs "$projectDir/generated/main/spine"
-}
-
 modelCompiler {
     mainProtoSrcDir = "$projectDir/../base/src/main/proto"
+}
+
+sourceSets {
+    main.java.srcDirs "$projectDir/generated/main/spine"
+    main.proto.srcDirs = [modelCompiler.mainProtoSrcDir]
 }
 
 protobuf {

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -88,6 +88,7 @@ build.doLast {
     command.add('build')
     command.add('--console=plain')
     command.add('--debug')
+    command.add('--stacktrace')
 
     // Ensure build error output log. 
     // Since we're executing this task in another process, we redirect error output to 

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -62,10 +62,13 @@ protobuf {
 sourceSets {
     main {
         resources.srcDirs += "$buildDir/descriptors/main"
+        proto.srcDirs = ["$projectDir/src/main/proto"]
     }
     test {
         resources.srcDirs += "$buildDir/descriptors/test"
+        proto.srcDirs = ["$projectDir/src/test/proto"]
     }
+
 }
 
 jar {
@@ -84,6 +87,7 @@ build.doLast {
     }
     command.add('build')
     command.add('--console=plain')
+    command.add('--debug')
 
     // Ensure build error output log. 
     // Since we're executing this task in another process, we redirect error output to 
@@ -93,11 +97,13 @@ build.doLast {
         buildDir.mkdir()
     }
     final File errorOut = new File(buildDir, 'error-out.txt')
+    final File debugOut = new File(buildDir, 'debug-out.txt')
 
     final def process = new ProcessBuilder()
             .command(command)
             .directory(file(directory))
             .redirectError(errorOut)
+            .redirectOutput(debugOut)
             .start()
     if (process.waitFor() != 0) {
         throw new GradleException("Unable to build validating builders. See $errorOut for details.")

--- a/base/src/main/java/io/spine/code/AbstractSourceFile.java
+++ b/base/src/main/java/io/spine/code/AbstractSourceFile.java
@@ -20,11 +20,7 @@
 
 package io.spine.code;
 
-import java.io.File;
 import java.nio.file.Path;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Abstract base for source code files.
@@ -33,29 +29,5 @@ public abstract class AbstractSourceFile extends FsObject {
 
     protected AbstractSourceFile(Path path) {
         super(path);
-    }
-
-    /**
-     * Tells if this source file belongs to the passed directory.
-     *
-     * @param directory
-     *         the passed instance must be a {@linkplain java.io.File#isDirectory() directory}
-     * @return {@code true} if the file belongs to the directory,
-     *         {@code false} if the directory does not exist, or the file is in another directory
-     */
-    public boolean isUnder(File directory) {
-        checkNotNull(directory);
-
-        if(!directory.exists()) {
-            return false;
-        }
-
-        checkArgument(directory.isDirectory(), "%s is not a directory.", directory);
-
-        String thisFile = getPath().toAbsolutePath()
-                                   .toString();
-        String dir = directory.getAbsolutePath();
-        boolean result = thisFile.startsWith(dir);
-        return result;
     }
 }

--- a/base/src/main/java/io/spine/code/AbstractSourceFile.java
+++ b/base/src/main/java/io/spine/code/AbstractSourceFile.java
@@ -20,16 +20,42 @@
 
 package io.spine.code;
 
+import java.io.File;
 import java.nio.file.Path;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Abstract base for source code files.
- *
- * @author Alexander Yevsyukov
  */
 public abstract class AbstractSourceFile extends FsObject {
 
     protected AbstractSourceFile(Path path) {
         super(path);
+    }
+
+    /**
+     * Tells if this source file belongs to the passed directory.
+     *
+     * @param directory
+     *         the passed instance must be a {@linkplain java.io.File#isDirectory() directory}
+     * @return {@code true} if the file belongs to the directory,
+     *         {@code false} if the directory does not exist, or the file is in another directory
+     */
+    public boolean isUnder(File directory) {
+        checkNotNull(directory);
+
+        if(!directory.exists()) {
+            return false;
+        }
+
+        checkArgument(directory.isDirectory(), "%s is not a directory.", directory);
+
+        String thisFile = getPath().toAbsolutePath()
+                                   .toString();
+        String dir = directory.getAbsolutePath();
+        boolean result = thisFile.startsWith(dir);
+        return result;
     }
 }

--- a/base/src/main/java/io/spine/code/java/DefaultJavaProject.java
+++ b/base/src/main/java/io/spine/code/java/DefaultJavaProject.java
@@ -50,8 +50,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  * <li>{@code .spine} — temporary build artifacts directory used by the Spine Model Compiler.
  * </ul>
- *
- * @author Alexander Yevsyukov
  */
 public final class DefaultJavaProject extends DefaultProject {
 
@@ -70,7 +68,6 @@ public final class DefaultJavaProject extends DefaultProject {
         return at(projectDir.toPath());
     }
 
-    @SuppressWarnings("DuplicateStringLiteralInspection") /* Tests use directory names. */
     public HandmadeCodeRoot src() {
         return new HandmadeCodeRoot(this, "src");
     }

--- a/base/src/main/java/io/spine/code/proto/Directory.java
+++ b/base/src/main/java/io/spine/code/proto/Directory.java
@@ -29,8 +29,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * A proto source code directory.
- *
- * @author Alexander Yevsyukov
  */
 public final class Directory extends SourceCodeDirectory {
 

--- a/base/src/main/java/io/spine/code/proto/MessageType.java
+++ b/base/src/main/java/io/spine/code/proto/MessageType.java
@@ -111,6 +111,13 @@ public class MessageType extends Type<Descriptor, DescriptorProto> {
     }
 
     /**
+     * Obtains source file with the declaration of this message type.
+     */
+    public SourceFile sourceFile() {
+        return SourceFile.from(descriptor().getFile());
+    }
+
+    /**
      * Tells if this message is under the "google" package.
      */
     public boolean isGoogle() {

--- a/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
+++ b/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
@@ -64,5 +64,12 @@ class MessageTypeTest {
             MessageType type = MessageType.of(TestRejections.MttSampleRejection.getDescriptor());
             assertTrue(type.isRejection());
         }
+
+        @DisplayName("is a non-Google or a Spine options type")
+        @Test
+        void custom() {
+            MessageType type = MessageType.of(Url.getDescriptor());
+            assertTrue(type.isCustom());
+        }
     }
 }

--- a/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
+++ b/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
@@ -20,56 +20,88 @@
 
 package io.spine.code.proto;
 
+import com.google.common.base.Predicates;
 import com.google.protobuf.Descriptors.Descriptor;
+import com.google.protobuf.Timestamp;
 import io.spine.net.Uri;
 import io.spine.net.Url;
+import io.spine.option.EntityOption;
+import io.spine.option.GoesOption;
+import io.spine.option.MinOption;
 import io.spine.test.code.proto.rejections.TestRejections;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.function.Function;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("MessageType should")
 class MessageTypeTest {
 
+    @SuppressWarnings("Guava")
+      // Using `Predicates.not()` is more concise until `Predicate.not()` is available from Java 11.
     @Nested
     @DisplayName("Tell if message is")
     class Tell {
 
+        /** Tests a certain method of {@code MessageType} created on the passed descriptor. */
+        void assertQuality(Predicate<MessageType> method, Descriptor descriptor) {
+            MessageType type = MessageType.of(descriptor);
+            boolean result = method.test(type);
+            assertTrue(result);
+        }
+
         @DisplayName("nested")
         @Test
         void nested() {
-            assertQuality(Uri.Protocol.getDescriptor(), MessageType::isNested);
+            assertQuality(MessageType::isNested, Uri.Protocol.getDescriptor());
+            assertQuality(Predicates.not(MessageType::isNested), Url.getDescriptor());
         }
 
         @DisplayName("top-level")
         @Test
         void topLevel() {
-            assertQuality(Url.getDescriptor(), MessageType::isTopLevel);
-        }
-
-        /** Tests a certain method of {@code MessageType} created on the passed descriptor. */
-        void assertQuality(Descriptor descriptor, Function<MessageType, Boolean> method) {
-            MessageType type = MessageType.of(descriptor);
-            boolean result = method.apply(type);
-            assertTrue(result);
+            assertQuality(MessageType::isTopLevel, Url.getDescriptor());
+            assertQuality(Predicates.not(MessageType::isTopLevel), Uri.Protocol.getDescriptor());
         }
 
         @DisplayName("a rejection")
         @Test
         void rejection() {
-            MessageType type = MessageType.of(TestRejections.MttSampleRejection.getDescriptor());
-            assertTrue(type.isRejection());
+            assertQuality(MessageType::isRejection,
+                          TestRejections.MttSampleRejection.getDescriptor()
+            );
         }
 
-        @DisplayName("is a non-Google or a Spine options type")
-        @Test
-        void custom() {
-            MessageType type = MessageType.of(Url.getDescriptor());
-            assertTrue(type.isCustom());
+        @Nested
+        @DisplayName("a non-Google or a Spine options type")
+        class Custom {
+
+            @Test
+            @DisplayName("positively for a custom type")
+            void custom() {
+                assertQuality(MessageType::isCustom, Url.getDescriptor());
+            }
+
+            @Test
+            @DisplayName("negatively for Google type")
+            void google() {
+                assertNotCustom(Timestamp.getDescriptor());
+            }
+
+            @Test
+            @DisplayName("negatively for Spine options type")
+            void options() {
+                assertNotCustom(GoesOption.getDescriptor());
+                assertNotCustom(EntityOption.getDescriptor());
+                assertNotCustom(MinOption.getDescriptor());
+            }
+
+            void assertNotCustom(Descriptor descriptor) {
+                assertQuality(Predicates.not(MessageType::isCustom), descriptor);
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,12 @@ allprojects {
 
     // Use the same version numbering for the Spine Base library.
     version = versionToPublish
+
+    gradle.projectsEvaluated {
+        tasks.withType(JavaCompile) {
+            options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        }
+    }    
 }
 
 subprojects {

--- a/tools/model-compiler/README.md
+++ b/tools/model-compiler/README.md
@@ -55,13 +55,3 @@ modelCompiler {
 
 By default, the value is `4`.
 
-There is also a flag that forces Compiler to generate all validating builders from the classpath. 
-It can be used as follows:
-
-```groovy
-modelCompiler {
-    generateBuildersFromClasspath = true
-}
-```
-
-By default, builders are generated only for the Protobuf messages from the current module.

--- a/tools/model-compiler/spine-protoc.gradle.template
+++ b/tools/model-compiler/spine-protoc.gradle.template
@@ -139,8 +139,9 @@ protobuf {
             }
             task.generateDescriptorSet = true
             final def tests = task.sourceSet.name.contains("test")
-            final def descPath = (tests ? project.extensions.getByName("modelCompiler").testDescriptorSetPath
-                                        : project.extensions.getByName("modelCompiler").mainDescriptorSetPath) ?:
+            final def extension = project.extensions.getByName("modelCompiler")
+            final def descPath = (tests ? extension.testDescriptorSetPath
+                                        : extension.mainDescriptorSetPath) ?:
                                  "${buildDir}/descriptors/${task.sourceSet.name}/known_types.desc"
             task.descriptorSetOptions.path = descPath
             task.descriptorSetOptions.includeImports = true

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
@@ -206,8 +206,6 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
      * @param visitor
      *         the source visitor
      */
-    @SuppressWarnings("unchecked" /* There is no way to specify generic parameter
-                                     for `AbstractJavaSource.class` value. */)
     static <T extends JavaSource<T>>
     void rewriteSource(String sourcePathPrefix, SourceFile sourcePath, SourceVisitor<T> visitor) {
         AbstractJavaSource<T> javaSource;
@@ -219,7 +217,11 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
         }
 
         try {
-            javaSource = Roaster.parse(AbstractJavaSource.class, absoluteSourcePath.toFile());
+            @SuppressWarnings("unchecked" /* There is no way to specify generic parameter
+                                     for `AbstractJavaSource.class` value. */)
+            AbstractJavaSource<T> parsed = Roaster.parse(AbstractJavaSource.class,
+                                                         absoluteSourcePath.toFile());
+            javaSource = parsed;
         } catch (FileNotFoundException e) {
             throw illegalStateWithCauseOf(e);
         }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/Annotator.java
@@ -243,12 +243,13 @@ public abstract class Annotator<O extends ExtendableMessage, D extends Generated
      *
      * @param source the program element to annotate
      */
-    protected final void addAnnotation(AnnotationTargetSource source) {
-        if (source.getAnnotation(annotation) != null) {
+    protected final void addAnnotation(AnnotationTargetSource<?, ?> source) {
+        AnnotationSource<?> annotation = source.getAnnotation(this.annotation);
+        if (annotation != null) {
             return;
         }
 
-        String annotationFQN = annotation.getCanonicalName();
+        String annotationFQN = this.annotation.getCanonicalName();
         AnnotationSource newAnnotation = source.addAnnotation();
         newAnnotation.setName(annotationFQN);
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
@@ -109,13 +109,15 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
         String methodName = fieldType.getSetterPrefix() + methodNamePart;
         ParameterSpec parameter = createParameterSpec(field.toProto(), false);
 
+        String descriptorDeclaration = descriptorDeclaration();
+        String validateStatement = validateStatement(fieldName, field.getName());
         String setStatement = format("%s.%s(%s)", getMessageBuilder(), methodName, fieldName);
         MethodSpec methodSpec =
                 newBuilderSetter(methodName)
                           .addParameter(parameter)
                           .addException(ValidationException.class)
-                          .addStatement(descriptorDeclaration())
-                          .addStatement(validateStatement(fieldName, field.getName()))
+                          .addStatement(descriptorDeclaration)
+                          .addStatement(validateStatement)
                           .addStatement(setStatement)
                           .addStatement(returnThis())
                           .build();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
@@ -114,14 +114,14 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
         String setStatement = format("%s.%s(%s)", getMessageBuilder(), methodName, fieldName);
         MethodSpec methodSpec =
                 newBuilderSetter(methodName)
-                          .addParameter(parameter)
-                          .addException(ValidationException.class)
-                          .addStatement(descriptorDeclaration)
-                          .addStatement(validateSetOnce())
-                          .addStatement(validateStatement)
-                          .addStatement(setStatement)
-                          .addStatement(returnThis())
-                          .build();
+                        .addParameter(parameter)
+                        .addException(ValidationException.class)
+                        .addStatement(descriptorDeclaration)
+                        .addStatement(validateSetOnce())
+                        .addStatement(validateStatement)
+                        .addStatement(setStatement)
+                        .addStatement(returnThis())
+                        .build();
         _debug("The setters construction for the singular field is finished.");
         return methodSpec;
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
@@ -142,8 +142,10 @@ final class VBuilderMethods {
         }
 
         private ClassName messageClass() {
-            return ClassName.bestGuess(type.javaClassName()
-                                           .value());
+            String fullyQualifiedDotted = type.javaClassName()
+                                              .toDotted()
+                                              .value();
+            return ClassName.bestGuess(fullyQualifiedDotted);
         }
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ErrorProneChecksExtension.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ErrorProneChecksExtension.java
@@ -28,10 +28,9 @@ import org.gradle.api.Project;
  * <p>Allows configuring severity for all the Spine-custom Error Prone checks applied to the
  * project.
  *
- * @author Dmytro Kuzmin
  * @see Severity
  */
-@SuppressWarnings({"PublicField", "WeakerAccess", "TypeMayBeWeakened"})
+@SuppressWarnings("PublicField" /* required for exposing the property in Gradle. */)
 public class ErrorProneChecksExtension {
 
     public Severity useValidatingBuilder;

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
@@ -158,7 +158,12 @@ public class Extension {
     }
 
     public static String getMainProtoSrcDir(Project project) {
-        return pathOrDefault(spineProtobuf(project).mainProtoSrcDir,
+        Logger log = log();
+        Extension extension = spineProtobuf(project);
+        log.debug("Extension is {}", extension);
+        String protoDir = extension.mainProtoSrcDir;
+        log.debug("modelCompiler.mainProtoSrcDir is {}", protoDir);
+        return pathOrDefault(protoDir,
                              def(project).src()
                                          .mainProto());
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ModelCompilerPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ModelCompilerPlugin.java
@@ -45,7 +45,7 @@ public class ModelCompilerPlugin implements Plugin<Project>, Logging {
     @SuppressWarnings("OverlyCoupledMethod") // OK as we need to launch all sub-plugins.
     @Override
     public void apply(Project project) {
-        log().debug("Adding the extension to the project.");
+        _debug("Adding the extension to the project.");
         project.getExtensions()
                .create(extensionName(), Extension.class);
 
@@ -66,7 +66,7 @@ public class ModelCompilerPlugin implements Plugin<Project>, Logging {
     }
 
     private void apply(SpinePlugin plugin, Project project) {
-        log().debug("Applying {}", plugin.getClass()
+        _debug("Applying {}", plugin.getClass()
                                          .getName());
         plugin.apply(project);
     }

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Severity.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Severity.java
@@ -25,8 +25,6 @@ package io.spine.tools.gradle.compiler;
  *
  * <p>Values of this enum correspond to the possible Error Prone severity command line flags.
  * See <a href="http://errorprone.info/docs/flags">the flags specification</a>.
- *
- * @author Dmytro Kuzmin
  */
 public enum Severity {
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ValidatingBuilderGenPlugin.java
@@ -166,8 +166,8 @@ public class ValidatingBuilderGenPlugin extends SpinePlugin {
             }
 
             Indent indent = getIndent(project);
-            VBuilderGenerator generator =
-                    new VBuilderGenerator(targetDirPath, indent);
+            File protoSrcDir = new File(protoSrcDirPath);
+            VBuilderGenerator generator = new VBuilderGenerator(protoSrcDir, targetDirPath, indent);
             generator.process(setFile);
         }
     }

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/VBuilderCodeTest.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/VBuilderCodeTest.java
@@ -23,6 +23,7 @@ package io.spine.tools.compiler.validation;
 import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.code.Indent;
 import io.spine.code.proto.MessageType;
+import io.spine.test.tools.validation.builder.VbtProcess;
 import io.spine.test.tools.validation.builder.VbtProject;
 import io.spine.test.tools.validation.builder.VbtScalarFields;
 import org.junit.jupiter.api.BeforeEach;
@@ -69,7 +70,12 @@ class VBuilderCodeTest {
     @Nested
     @DisplayName("a message nested into another message")
     class NestedSecondLevel {
-        //TODO:2018-12-24:alexander.yevsyukov: Implement.
+
+        @Test
+        @DisplayName("2nd level")
+        void doSomething() {
+            assertGeneratesFor(VbtProcess.Point.getDescriptor());
+        }
     }
 
     private void assertGeneratesFor(Descriptor descriptor) {

--- a/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/VBuilderCodeTest.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/compiler/validation/VBuilderCodeTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.compiler.validation;
 
+import com.google.protobuf.Descriptors.Descriptor;
 import io.spine.code.Indent;
 import io.spine.code.proto.MessageType;
 import io.spine.test.tools.validation.builder.VbtProject;
@@ -37,7 +38,7 @@ import java.nio.file.Path;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(TempDirectory.class)
-@DisplayName("VBuilderCode should")
+@DisplayName("VBuilderCode should generate code for")
 class VBuilderCodeTest {
 
     private File targetDir;
@@ -48,26 +49,31 @@ class VBuilderCodeTest {
     }
 
     @Nested
-    @DisplayName("generate code for top-level message")
+    @DisplayName("top-level message")
     class TopLevel {
 
         @Test
         @DisplayName("with message fields")
         void messageFields() {
-            MessageType type = MessageType.of(VbtProject.getDescriptor());
-            assertGeneratesFor(type);
+            assertGeneratesFor(VbtProject.getDescriptor());
         }
 
         @Test
         @DisplayName("with scalar fields")
         void scalarFields() {
-            MessageType type = MessageType.of(VbtScalarFields.getDescriptor());
-            assertGeneratesFor(type);
+            assertGeneratesFor(VbtScalarFields.getDescriptor());
         }
 
     }
 
-    private void assertGeneratesFor(MessageType type) {
+    @Nested
+    @DisplayName("a message nested into another message")
+    class NestedSecondLevel {
+        //TODO:2018-12-24:alexander.yevsyukov: Implement.
+    }
+
+    private void assertGeneratesFor(Descriptor descriptor) {
+        MessageType type = MessageType.of(descriptor);
         VBuilderCode code = new VBuilderCode(targetDir, Indent.of4(), type);
         File file = code.write();
         assertTrue(file.exists());

--- a/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/nested.proto
+++ b/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/nested.proto
@@ -40,18 +40,7 @@ message VbtProcess {
 
     string id = 1 [(required) = true];
 
-    // Describes the process start.
-    message Start {
-
-        // The moment the process was started.
-        google.protobuf.Timestamp time = 1 [(required) = true];
-
-        // Who started the process.
-        string initiator = 2 [(required) = true];
-    }
-
-    Start start = 2 [(required) = true];
-
+    // Describes the point in time related to the process.
     message Point {
         // The moment the process was started.
         google.protobuf.Timestamp time = 1 [(required) = true];
@@ -60,5 +49,42 @@ message VbtProcess {
         string initiator = 2 [(required) = true];
     }
 
+    // A process when it appears must be already started.
+    Point start = 2 [(required) = true];
+
+    // If this field is not defined, the process is not finished.
     Point finish = 3;
+}
+
+// A message with three levels of nesting.
+message VbtTree {
+
+    string id = 1 [(required) = true];
+
+    message Branch {
+
+        // 3-rd level of nesting.
+        message Leaf {
+            string data = 1 [(required) = true];
+        }
+
+        // A branch may not have leaves.
+        repeated Leaf leaf = 1;
+
+        // A branch may have child branches.
+        repeated Branch branch = 2;
+    }
+
+    // A trunc may have one or more branches.
+    message Trunc {
+        repeated Branch branch = 1;
+    }
+
+    // A tree mush have a trunc.
+    Trunc trunc = 2 [(required) = true];
+}
+
+// A forest is one or more trees.
+message VbtForest {
+    repeated VbtTree tree = 1 [(required) = true];
 }

--- a/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/nested.proto
+++ b/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/nested.proto
@@ -1,0 +1,64 @@
+//
+// Copyright 2018, TeamDev. All rights reserved.
+//
+// Redistribution and use in source and/or binary forms, with or without
+// modification, must retain the above copyright notice and the following
+// disclaimer.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+syntax = "proto3";
+
+package spine.test.tools.validation.builder;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "NestedMessagesProto";
+option java_package = "io.spine.test.tools.validation.builder";
+
+import "google/protobuf/timestamp.proto";
+
+// This file defines messages for testing generation of validating builders.
+//
+// Use only for `VBuilderCodeTest.java`.
+
+// A top level message with a nested message.
+message VbtProcess {
+
+    string id = 1 [(required) = true];
+
+    // Describes the process start.
+    message Start {
+
+        // The moment the process was started.
+        google.protobuf.Timestamp time = 1 [(required) = true];
+
+        // Who started the process.
+        string initiator = 2 [(required) = true];
+    }
+
+    Start start = 2 [(required) = true];
+
+    message Point {
+        // The moment the process was started.
+        google.protobuf.Timestamp time = 1 [(required) = true];
+
+        // Who started the process.
+        string initiator = 2 [(required) = true];
+    }
+
+    Point finish = 3;
+}

--- a/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/top_level.proto
+++ b/tools/model-compiler/src/test/proto/spine/test/tools/validation/builder/top_level.proto
@@ -31,7 +31,6 @@ import "google/protobuf/timestamp.proto";
 
 import "spine/options.proto";
 
-import "spine/net/email_address.proto";
 import "spine/net/url.proto";
 
 // This file defines messages for testing generation of validating builders.

--- a/tools/smoke-tests/known-types-tests/build.gradle
+++ b/tools/smoke-tests/known-types-tests/build.gradle
@@ -24,3 +24,8 @@
     See smoke-tests/build.gradle for all the config of the project.
     
 */
+
+//TODO:2018-12-27:alexander.yevsyukov: Disable generation of validating builders until nested types are supported.  
+modelCompiler {
+    generateValidatingBuilders = false
+}


### PR DESCRIPTION
This PR migrates generation of Validating Builders of types defined in the `base`  from dependency on locally deployed JAR to dependencies to interim artifacts. 

The primary purpose of this change is to avoid double dependency on both source code of the `base` module, and classes from the locally deployed artifact.

The notable fix in this PR is restored filtering of proto types by the module which declares them.
