### PR TITLE
Release 1.0.0-pre3

### DIFF
--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.0.0-SNAPSHOT'
+final def SPINE_VERSION = '1.0.0-pre3'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR updates the version of `base` library to `1.0.0-pre3`.