### PR TITLE
Remove `decimal` number options

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,7 +3,6 @@
     <option name="RIGHT_MARGIN" value="100" />
     <JavaCodeStyleSettings>
       <option name="PREFER_LONGER_NAMES" value="false" />
-      <option name="CLASS_NAMES_IN_JAVADOC" value="2" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
       <option name="JD_P_AT_EMPTY_LINES" value="false" />

--- a/base/src/main/java/io/spine/validate/NumberFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/NumberFieldValidator.java
@@ -117,8 +117,8 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
         }
         int comparison = compareToValueOf(value, minAsString);
         return min.getExclusive()
-               ? comparison > 0
-               : comparison >= 0;
+               ? comparison <= 0
+               : comparison < 0;
     }
 
     private boolean notFitToMax(V value) {
@@ -128,8 +128,8 @@ abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends Fi
         }
         int comparison = compareToValueOf(value, maxAsString);
         return max.getExclusive()
-               ? comparison < 0
-               : comparison <= 0;
+               ? comparison >= 0
+               : comparison > 0;
     }
 
     private int compareToValueOf(V value, String number) {

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -90,13 +90,12 @@ extend google.protobuf.FieldOptions {
 
     IfMissingOption if_missing = 73813;
 
-    // The option to define maximal decimal value.
-    DecimalMaxOption decimal_max = 73814;
+    // reserved 73814 and 73815 for deleted options `decimal_max` and `decimal_min`.
 
-    // The option to define minimal decimal value.
-    DecimalMinOption decimal_min = 73815;
-
+    // A higher boundary to the range of values of a number.
     MaxOption max = 73816;
+
+    // A lower boundary to the range of values of a number.
     MinOption min = 73817;
 
     DigitsOption digits = 73818;
@@ -550,68 +549,6 @@ message IfMissingOption {
     string msg_format = 1;
 }
 
-// The field value must be greater than (or equal to, if the `inclusive` parameter is true) the
-// given minimum number.
-//
-// Is applicable only to numbers.
-// Repeated fields are supported.
-//
-// Example:
-//
-//     double value = 1 [(decimal_min).value = "10.5", (decimal_min).inclusive = true];
-//
-message DecimalMinOption {
-
-    // The default error message format string.
-    //
-    // The format parameters are:
-    //   1) "or equal to " string (if the `inclusive` parameter is true) or an empty one;
-    //   2) the minimum number.
-    //
-    option (default_message) = "Number must be greater than %s%s.";
-
-    // The string representation of the minimum field value.
-    string value = 1;
-
-    // Specifies if the field can be equal to the minimum value.
-    // The default value is false.
-    bool inclusive = 2;
-
-    // A user-defined validation error format message.
-    string msg_format = 3;
-}
-
-// The field value must be less than (or equal to, if the `inclusive` option is true) the given
-// maximum number.
-// Is applicable only to numbers.
-// Repeated fields are supported.
-//
-// Example:
-//     double value = 1 [(decimal_max).value = "10.5", (decimal_max).inclusive = true];
-//
-message DecimalMaxOption {
-
-    // The default error message format string.
-    //
-    // The format parameters are:
-    //   1) "or equal to " string (if the `inclusive` parameter is true) or an empty string;
-    //   2) the maximum number.
-    //
-    option (default_message) = "Number must be less than %s%s.";
-
-    // The string representation of the maximum field value.
-    string value = 1;
-
-    // Specifies if the field can be equal to the maximum value.
-    //
-    // The default value is false.
-    //
-    bool inclusive = 2;
-
-    // A user-defined validation error format message.
-    string msg_format = 3;
-}
-
 // The field value must be greater than or equal to the given minimum number.
 //
 // Is applicable only to numbers.
@@ -624,15 +561,23 @@ message MinOption {
 
     // The default error message format string.
     //
-    // The format parameter is the minimum number.
+    // The format parameters are:
+    //   1) "or equal to " string (if the `exclusive` parameter is false) or an empty string;
+    //   2) the minimum number.
     //
-    option (default_message) = "Number must be greater than or equal to %s.";
+    option (default_message) = "Number must be greater than %s %s.";
 
     // The string representation of the minimum field value.
     string value = 1;
 
+    // Specifies if the field should be strictly greater than the specified minimum.
+    //
+    // The default value is false, i.e. the bound is inclusive.
+    //
+    bool exclusive = 2;
+
     // A user-defined validation error format message.
-    string msg_format = 2;
+    string msg_format = 3;
 }
 
 // The field value must be less than or equal to the given maximum number.
@@ -647,14 +592,23 @@ message MaxOption {
 
     // The default error message format string.
     //
-    // The format parameter is the maximum number.
-    option (default_message) = "Number must be less than or equal to %s.";
+    // The format parameters are:
+    //   1) "or equal to " string (if the `exclusive` parameter is false) or an empty string;
+    //   2) the maximum number.
+    //
+    option (default_message) = "Number must be less than %s %s.";
 
     // The string representation of the maximum field value.
     string value = 1;
 
+    // Specifies if the field should be strictly less than the specified maximum
+    //
+    // The default value is false, i.e. the bound is inclusive.
+    //
+    bool exclusive = 2;
+
     // A user-defined validation error format message.
-    string msg_format = 2;
+    string msg_format = 3;
 }
 
 // The field value must be a number with the certain integral/fractional digit count.
@@ -681,13 +635,13 @@ message DigitsOption {
     //
     // Must be greater than zero.
     //
-    int32 integer_max = 1;
+    uint32 integer_max = 1;
 
     // Maximum count of fractional digits of the number (inclusive).
     //
     // Must be greater than or equal to zero.
     //
-    int32 fraction_max = 2;
+    uint32 fraction_max = 2;
 
     // A user-defined validation error format message.
     string msg_format = 3;

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -40,10 +40,10 @@ import io.spine.test.validate.CustomMessageRequiredMsgFieldValue;
 import io.spine.test.validate.CustomMessageRequiredRepeatedMsgFieldValue;
 import io.spine.test.validate.CustomMessageRequiredStringFieldValue;
 import io.spine.test.validate.CustomMessageWithNoRequiredOption;
-import io.spine.test.validate.DecimalMaxIncNumberFieldValue;
-import io.spine.test.validate.DecimalMaxNotIncNumberFieldValue;
-import io.spine.test.validate.DecimalMinIncNumberFieldValue;
-import io.spine.test.validate.DecimalMinNotIncNumberFieldValue;
+import io.spine.test.validate.MaxInclusiveNumberFieldValue;
+import io.spine.test.validate.MaxExclusiveNumberFieldValue;
+import io.spine.test.validate.MinInclusiveNumberFieldValue;
+import io.spine.test.validate.MinExclusiveNumberFieldValue;
 import io.spine.test.validate.DigitsCountNumberFieldValue;
 import io.spine.test.validate.EnclosedMessageFieldValue;
 import io.spine.test.validate.EnclosedMessageFieldValueWithCustomInvalidMessage;
@@ -1029,10 +1029,10 @@ class MessageValidatorTest {
 
     private void minDecimalNumberTest(double value, boolean inclusive, boolean isValid) {
         Message msg = inclusive ?
-                      DecimalMinIncNumberFieldValue.newBuilder()
+                      MinInclusiveNumberFieldValue.newBuilder()
                                                    .setValue(value)
                                                    .build() :
-                      DecimalMinNotIncNumberFieldValue.newBuilder()
+                      MinExclusiveNumberFieldValue.newBuilder()
                                                       .setValue(value)
                                                       .build();
         validate(msg);
@@ -1041,10 +1041,10 @@ class MessageValidatorTest {
 
     private void maxDecimalNumberTest(double value, boolean inclusive, boolean isValid) {
         Message msg = inclusive ?
-                      DecimalMaxIncNumberFieldValue.newBuilder()
+                      MaxInclusiveNumberFieldValue.newBuilder()
                                                    .setValue(value)
                                                    .build() :
-                      DecimalMaxNotIncNumberFieldValue.newBuilder()
+                      MaxExclusiveNumberFieldValue.newBuilder()
                                                       .setValue(value)
                                                       .build();
         validate(msg);

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -40,17 +40,17 @@ import io.spine.test.validate.CustomMessageRequiredMsgFieldValue;
 import io.spine.test.validate.CustomMessageRequiredRepeatedMsgFieldValue;
 import io.spine.test.validate.CustomMessageRequiredStringFieldValue;
 import io.spine.test.validate.CustomMessageWithNoRequiredOption;
-import io.spine.test.validate.MaxInclusiveNumberFieldValue;
-import io.spine.test.validate.MaxExclusiveNumberFieldValue;
-import io.spine.test.validate.MinInclusiveNumberFieldValue;
-import io.spine.test.validate.MinExclusiveNumberFieldValue;
 import io.spine.test.validate.DigitsCountNumberFieldValue;
 import io.spine.test.validate.EnclosedMessageFieldValue;
 import io.spine.test.validate.EnclosedMessageFieldValueWithCustomInvalidMessage;
 import io.spine.test.validate.EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage;
 import io.spine.test.validate.EnclosedMessageWithRequiredString;
 import io.spine.test.validate.EnclosedMessageWithoutAnnotationFieldValue;
+import io.spine.test.validate.MaxExclusiveNumberFieldValue;
+import io.spine.test.validate.MaxInclusiveNumberFieldValue;
 import io.spine.test.validate.MaxNumberFieldValue;
+import io.spine.test.validate.MinExclusiveNumberFieldValue;
+import io.spine.test.validate.MinInclusiveNumberFieldValue;
 import io.spine.test.validate.MinNumberFieldValue;
 import io.spine.test.validate.PatternStringFieldValue;
 import io.spine.test.validate.ProjectionState;
@@ -413,43 +413,43 @@ class MessageValidatorTest {
     @Test
     @DisplayName("find out that number is greater than decimal min inclusive")
     void find_out_that_number_is_greater_than_decimal_min_inclusive() {
-        minDecimalNumberTest(GREATER_THAN_MIN, true, true);
+        minNumberTest(GREATER_THAN_MIN, true, true);
     }
 
     @Test
     @DisplayName("find out that number is equal to decimal min inclusive")
     void find_out_that_number_is_equal_to_decimal_min_inclusive() {
-        minDecimalNumberTest(EQUAL_MIN, true, true);
+        minNumberTest(EQUAL_MIN, true, true);
     }
 
     @Test
     @DisplayName("find out that number is less than decimal min inclusive")
     void find_out_that_number_is_less_than_decimal_min_inclusive() {
-        minDecimalNumberTest(LESS_THAN_MIN, true, false);
+        minNumberTest(LESS_THAN_MIN, true, false);
     }
 
     @Test
     @DisplayName("find out that number is grated than decimal min NOT inclusive")
     void find_out_that_number_is_greater_than_decimal_min_NOT_inclusive() {
-        minDecimalNumberTest(GREATER_THAN_MIN, false, true);
+        minNumberTest(GREATER_THAN_MIN, false, true);
     }
 
     @Test
     @DisplayName("find out that number is equal to decimal min NOT inclusive")
     void find_out_that_number_is_equal_to_decimal_min_NOT_inclusive() {
-        minDecimalNumberTest(EQUAL_MIN, false, false);
+        minNumberTest(EQUAL_MIN, false, false);
     }
 
     @Test
     @DisplayName("find out that number is less than decimal min NOT inclusive")
     void find_out_that_number_is_less_than_decimal_min_NOT_inclusive() {
-        minDecimalNumberTest(LESS_THAN_MIN, false, false);
+        minNumberTest(LESS_THAN_MIN, false, false);
     }
 
     @Test
     @DisplayName("provide one valid violation if number is less than decimal min")
     void provide_one_valid_violation_if_number_is_less_than_decimal_min() {
-        minDecimalNumberTest(LESS_THAN_MIN, true, false);
+        minNumberTest(LESS_THAN_MIN, true, false);
         assertSingleViolation(LESS_THAN_MIN_MSG, VALUE);
     }
 
@@ -460,43 +460,43 @@ class MessageValidatorTest {
     @Test
     @DisplayName("find out that number is greater than decimal max inclusive")
     void find_out_that_number_is_greater_than_decimal_max_inclusive() {
-        maxDecimalNumberTest(GREATER_THAN_MAX, true, false);
+        maxNumberTest(GREATER_THAN_MAX, true, false);
     }
 
     @Test
     @DisplayName("find out that number is equal to decimal max inclusive")
     void find_out_that_number_is_equal_to_decimal_max_inclusive() {
-        maxDecimalNumberTest(EQUAL_MAX, true, true);
+        maxNumberTest(EQUAL_MAX, true, true);
     }
 
     @Test
     @DisplayName("find out that number is less than decimal max inclusive")
     void find_out_that_number_is_less_than_decimal_max_inclusive() {
-        maxDecimalNumberTest(LESS_THAN_MAX, true, true);
+        maxNumberTest(LESS_THAN_MAX, true, true);
     }
 
     @Test
     @DisplayName("find out that number is greated than decimal max NOT inclusive")
     void find_out_that_number_is_greater_than_decimal_max_NOT_inclusive() {
-        maxDecimalNumberTest(GREATER_THAN_MAX, false, false);
+        maxNumberTest(GREATER_THAN_MAX, false, false);
     }
 
     @Test
     @DisplayName("find out that number is equal to decimal max NOT inclusive")
     void find_out_that_number_is_equal_to_decimal_max_NOT_inclusive() {
-        maxDecimalNumberTest(EQUAL_MAX, false, false);
+        maxNumberTest(EQUAL_MAX, false, false);
     }
 
     @Test
     @DisplayName("find out that number is less than decimal max NOT inclusive")
     void find_out_that_number_is_less_than_decimal_max_NOT_inclusive() {
-        maxDecimalNumberTest(LESS_THAN_MAX, false, true);
+        maxNumberTest(LESS_THAN_MAX, false, true);
     }
 
     @Test
     @DisplayName("provide one valid violation if number is greater than decimal max")
     void provide_one_valid_violation_if_number_is_greater_than_decimal_max() {
-        maxDecimalNumberTest(GREATER_THAN_MAX, true, false);
+        maxNumberTest(GREATER_THAN_MAX, true, false);
         assertSingleViolation(GREATER_MAX_MSG, VALUE);
     }
 
@@ -1027,28 +1027,32 @@ class MessageValidatorTest {
      * Utility methods.
      */
 
-    private void minDecimalNumberTest(double value, boolean inclusive, boolean isValid) {
-        Message msg = inclusive ?
-                      MinInclusiveNumberFieldValue.newBuilder()
-                                                   .setValue(value)
-                                                   .build() :
-                      MinExclusiveNumberFieldValue.newBuilder()
-                                                      .setValue(value)
-                                                      .build();
+    private void minNumberTest(double value, boolean inclusive, boolean valid) {
+        Message msg = inclusive
+                      ? MinInclusiveNumberFieldValue
+                              .newBuilder()
+                              .setValue(value)
+                              .build()
+                      : MinExclusiveNumberFieldValue
+                              .newBuilder()
+                              .setValue(value)
+                              .build();
         validate(msg);
-        assertIsValid(isValid);
+        assertIsValid(valid);
     }
 
-    private void maxDecimalNumberTest(double value, boolean inclusive, boolean isValid) {
-        Message msg = inclusive ?
-                      MaxInclusiveNumberFieldValue.newBuilder()
-                                                   .setValue(value)
-                                                   .build() :
-                      MaxExclusiveNumberFieldValue.newBuilder()
-                                                      .setValue(value)
-                                                      .build();
+    private void maxNumberTest(double value, boolean inclusive, boolean valid) {
+        Message msg = inclusive
+                      ? MaxInclusiveNumberFieldValue
+                              .newBuilder()
+                              .setValue(value)
+                              .build()
+                      : MaxExclusiveNumberFieldValue
+                              .newBuilder()
+                              .setValue(value)
+                              .build();
         validate(msg);
-        assertIsValid(isValid);
+        assertIsValid(valid);
     }
 
     private void validate(Message msg) {

--- a/base/src/test/proto/spine/test/validate/messages.proto
+++ b/base/src/test/proto/spine/test/validate/messages.proto
@@ -111,20 +111,20 @@ message CustomMessageWithNoRequiredOption {
 
 // Messages for "decimal_min", "decimal_max" options tests.
 
-message DecimalMinIncNumberFieldValue {
-    double value = 1 [(decimal_min).value = "16.5", (decimal_min).inclusive = true];
+message MinInclusiveNumberFieldValue {
+    double value = 1 [(min).value = "16.5", (min).exclusive = false];
 }
 
-message DecimalMinNotIncNumberFieldValue {
-    double value = 1 [(decimal_min).value = "16.5", (decimal_min).inclusive = false];
+message MinExclusiveNumberFieldValue {
+    double value = 1 [(min).value = "16.5", (min).exclusive = true];
 }
 
-message DecimalMaxIncNumberFieldValue {
-    double value = 1 [(decimal_max).value = "64.5", (decimal_max).inclusive = true];
+message MaxInclusiveNumberFieldValue {
+    double value = 1 [(max).value = "64.5", (max).exclusive = false];
 }
 
-message DecimalMaxNotIncNumberFieldValue {
-    double value = 1 [(decimal_max).value = "64.5", (decimal_max).inclusive = false];
+message MaxExclusiveNumberFieldValue {
+    double value = 1 [(max).value = "64.5", (max).exclusive = true];
 }
 
 // Messages for "min" and "max" options tests.

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/MessageValidatorTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/MessageValidatorTest.java
@@ -18,13 +18,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.validate;
+package io.spine.test.validate;
 
 import com.google.protobuf.Message;
 import io.spine.test.validate.FirstRuleTarget;
 import io.spine.test.validate.InvalidMessage;
 import io.spine.test.validate.RuleTargetAggregate;
 import io.spine.test.validate.SecondRuleTarget;
+import io.spine.validate.ConstraintViolation;
+import io.spine.validate.MessageValidator;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.validate;
+package io.spine.test.validate;
 
 import com.google.protobuf.Timestamp;
 import io.spine.base.Identifier;
@@ -30,6 +30,9 @@ import io.spine.test.validate.msg.builder.Member;
 import io.spine.test.validate.msg.builder.ProjectVBuilder;
 import io.spine.test.validate.msg.builder.Task;
 import io.spine.test.validate.msg.builder.TaskVBuilder;
+import io.spine.validate.AbstractValidatingBuilder;
+import io.spine.validate.ValidatingBuilder;
+import io.spine.validate.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatorTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatorTest.java
@@ -21,10 +21,6 @@
 package io.spine.test.validate;
 
 import com.google.protobuf.Message;
-import io.spine.test.validate.FirstRuleTarget;
-import io.spine.test.validate.InvalidMessage;
-import io.spine.test.validate.RuleTargetAggregate;
-import io.spine.test.validate.SecondRuleTarget;
 import io.spine.validate.ConstraintViolation;
 import io.spine.validate.MessageValidator;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +31,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("MessageValidator should")
-class MessageValidatorTest {
+class ValidatorTest {
 
     private List<ConstraintViolation> violations;
 


### PR DESCRIPTION
Before this PR, we had two sets of number range options: `(min)`/`(max)` and `(decimal_min)`/`(decimal_max)`. The former used to be inclusive only and the latter—exlusive by default and configurable.

This approach is borrowed from the `java.bean.validation` framework. Though, it does not mean that it's good.

Starting from now, we will have only `(min)`/`(max)` options to configure the accepted range of a number.

Both bounds are inclusive by default. In order to make them exclusive, a user should specify `(min).exclusive = true`.

Both options expect a decimal number representation as the `value`.

This PR fixes #289.