### PR TITLE
Default message instance and improved build

### DIFF
--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -35,6 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.protobuf.Messages.defaultInstance;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
@@ -461,7 +462,7 @@ public final class Identifier<I> {
             @Override
             <I> I getDefaultValue(Class<I> idClass) {
                 Class<? extends Message> msgClass = (Class<? extends Message>) idClass;
-                Message result = Messages.newInstance(msgClass);
+                Message result = defaultInstance(msgClass);
                 return (I) result;
             }
         };

--- a/base/src/main/java/io/spine/base/UuidFactory.java
+++ b/base/src/main/java/io/spine/base/UuidFactory.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.spine.base.UuidValueClassifier.FIELD_NAME;
+import static io.spine.protobuf.Messages.defaultInstance;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
 
@@ -68,8 +69,7 @@ final class UuidFactory<I extends Message> {
      *         if the passed ID class does not obey {@link UuidValue} contract
      */
     static <I extends Message> UuidFactory<I> forClass(Class<I> idClass) {
-        Descriptor message = Messages.newInstance(idClass)
-                                     .getDescriptorForType();
+        Descriptor message = defaultInstance(idClass).getDescriptorForType();
         checkState(isUuidMessage(message), ERROR_MESSAGE, FIELD_NAME);
         List<FieldDescriptor> fields = message.getFields();
         FieldDescriptor uuidField = fields.get(0);

--- a/base/src/main/java/io/spine/protobuf/Messages.java
+++ b/base/src/main/java/io/spine/protobuf/Messages.java
@@ -76,6 +76,7 @@ public final class Messages {
      * @return default instance of the class
      */
     public static <M extends Message> M defaultInstance(Class<M> messageClass) {
+        checkNotNull(messageClass);
         // It is safe to use the `Internal` utility class from Protobuf since it relies on the
         // that fact that the generated class has the `getDefaultInstance()` static method.
         M result = com.google.protobuf.Internal.getDefaultInstance(messageClass);

--- a/base/src/main/java/io/spine/protobuf/Messages.java
+++ b/base/src/main/java/io/spine/protobuf/Messages.java
@@ -50,7 +50,9 @@ public final class Messages {
      * Reflection and then invokes it.
      *
      * @return new instance
+     * @deprecated use {@link #defaultInstance(Class)}
      */
+    @Deprecated
     public static <M extends Message> M newInstance(Class<M> messageClass) {
         checkNotNull(messageClass);
         try {
@@ -64,6 +66,20 @@ public final class Messages {
                 | InvocationTargetException e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    /**
+     * Obtains the default instance of the passed message class.
+     *
+     * @param messageClass the class for which to obtain the default instance
+     * @param <M> the type of the message
+     * @return default instance of the class
+     */
+    public static <M extends Message> M defaultInstance(Class<M> messageClass) {
+        // It is safe to use the `Internal` utility class from Protobuf since it relies on the
+        // that fact that the generated class has the `getDefaultInstance()` static method.
+        M result = com.google.protobuf.Internal.getDefaultInstance(messageClass);
+        return result;
     }
 
     /**

--- a/base/src/main/java/io/spine/reflect/PackageGraph.java
+++ b/base/src/main/java/io/spine/reflect/PackageGraph.java
@@ -61,8 +61,6 @@ import static java.util.stream.Collectors.toList;
  *     java.util.concurrent -&gt; java.util
  *     java.util.function -&gt; java.util
  * </pre>
- *
- * @author Alexander Yevsyukov
  */
 @Immutable
 public final class PackageGraph implements Graph<PackageInfo> {

--- a/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Throwables.getRootCause;
 import static io.spine.option.Options.option;
+import static io.spine.protobuf.Messages.defaultInstance;
 import static io.spine.util.Exceptions.illegalArgumentWithCauseOf;
 
 /**
@@ -219,8 +220,7 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
 
     private B createBuilder() {
         @SuppressWarnings("unchecked")  // OK, since it is guaranteed by the class declaration.
-        B result = (B) Messages.newInstance(messageClass)
-                               .newBuilderForType();
+        B result = (B) defaultInstance(messageClass).newBuilderForType();
         return result;
     }
 

--- a/base/src/test/java/io/spine/protobuf/MessagesTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessagesTest.java
@@ -50,21 +50,21 @@ class MessagesTest extends UtilityClassTest<Messages> {
 
     @Test
     @DisplayName("return the same any from toAny")
-    void return_the_same_any_from_toAny() {
+    void sameAny() {
         Any any = toAny(getClass().getSimpleName());
         assertSame(any, AnyPacker.pack(any));
     }
 
     @Test
     @DisplayName("pack to Any")
-    void pack_to_Any() {
+    void packToAny() {
         Timestamp timestamp = Time.getCurrentTime();
         assertEquals(timestamp, unpack(AnyPacker.pack(timestamp)));
     }
 
     @Test
     @DisplayName("return builder for the message")
-    void return_builder_for_the_message() {
+    void builderForMessage() {
         Message.Builder messageBuilder = builderFor(MessageWithStringValue.class);
         assertNotNull(messageBuilder);
         assertEquals(MessageWithStringValue.class,
@@ -74,26 +74,26 @@ class MessagesTest extends UtilityClassTest<Messages> {
 
     @Test
     @DisplayName("throw when try to get builder for a not generated message")
-    void throw_exception_when_try_to_get_builder_for_not_the_generated_message() {
+    void failGettingNonGeneratedBuilder() {
         assertThrows(IllegalArgumentException.class,
                      () -> builderFor(Message.class));
     }
 
     @Test
-    @DisplayName("return true when message is checked")
-    void return_true_when_message_is_checked() {
+    @DisplayName("tell if a class is a Message")
+    void tellIfMessage() {
         assertTrue(Messages.isMessage(MessageWithStringValue.class));
     }
 
     @Test
-    @DisplayName("return false when not message is checked")
-    void return_false_when_not_message_is_checked() {
+    @DisplayName("tell if a class is not Message")
+    void tellNotMessage() {
         assertFalse(Messages.isMessage(getClass()));
     }
 
     @Test
     @DisplayName("ensure Message")
-    void ensure_Message() {
+    void ensureMessageInstance() {
         StringValue value = TestValues.newUuidValue();
         assertEquals(value, ensureMessage(AnyPacker.pack(value)));
         assertSame(value, ensureMessage(value));

--- a/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
+++ b/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
@@ -39,6 +39,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -197,5 +199,12 @@ class AbstractValidatingBuilderTest {
         StringValueVBuilder builder = StringValueVBuilder.newBuilder();
         assertThrows(ConversionException.class,
                      () -> builder.convert(notInt, Int32Value.class));
+    }
+
+    @Test
+    @DisplayName("Have public internalBuild() method")
+    void publicInternalBuild() throws NoSuchMethodException {
+        Method method = AbstractValidatingBuilder.class.getMethod("internalBuild");
+        assertThat(Modifier.isPublic(method.getModifiers())).isTrue();
     }
 }

--- a/base/src/test/java/io/spine/validate/builders/StringValueVBuilder.java
+++ b/base/src/test/java/io/spine/validate/builders/StringValueVBuilder.java
@@ -43,4 +43,15 @@ public final class StringValueVBuilder
         getMessageBuilder().setValue(value);
         return this;
     }
+
+    /**
+     * Simply calls {@link #internalBuild()}.
+     *
+     * @apiNote This method is provided only to make sure that the {@link #internalBuild()} which
+     * is used by generated VBuilders is not accidentally made private.
+     */
+    @SuppressWarnings("unused")
+    public StringValue callInternalBuild() {
+        return internalBuild();
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,13 +47,14 @@ buildscript {
         }
     }
 
-    configurations.all({
+    configurations.all {
         resolutionStrategy {
             cacheChangingModulesFor(0, 'seconds')
             force deps.build.guava
             force deps.test.guavaTestlib
+            force deps.build.protobuf
         }
-    })
+    }
 }
 
 apply from: 'version.gradle'
@@ -120,12 +121,39 @@ subprojects {
             }
         }
 
-        configurations.all({
-            resolutionStrategy.cacheChangingModulesFor(0, 'seconds')
-        })
+        configurations.all {
+            resolutionStrategy {
+                cacheChangingModulesFor(0, 'seconds')
+
+                force deps.build.guava
+                force deps.test.guavaTestlib
+                force deps.build.protobuf
+            }
+        }
     }
 
     configurations {
+        all {
+            resolutionStrategy {
+
+                // Fail eagerly on version conflict (includes transitive dependencies)
+                // e.g. multiple different versions of the same dependency
+                // (where group and name are equal).
+                failOnVersionConflict()
+
+                force deps.build.errorProneAnnotations
+                force deps.build.jsr305Annotations
+                force deps.build.checkerAnnotations
+                force deps.build.guava
+                force deps.build.protobuf
+
+                force deps.test.guavaTestlib
+                force deps.test.truth
+                force deps.test.junit5Api
+                force deps.test.junit4
+            }
+        }
+
         // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
         runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
         testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"

--- a/build.gradle
+++ b/build.gradle
@@ -17,44 +17,21 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-buildscript {
+buildscript { final scriptHandler ->
 
     // As long as `buildscript` section is always evaluated first,
     // we need to apply explicitly here.
     apply from: "$rootDir/config/gradle/dependencies.gradle"
     apply from: "$rootDir/version.gradle"
 
-    repositories {
-        mavenLocal()
-        maven { url = repos.gradlePlugins }
-        jcenter()
-        
-        maven { url = repos.oldSpine }
-        maven { url = repos.oldSpineSnapshots }
-
-        maven { url = repos.spine }
-        maven { url = repos.spineSnapshots }
-    }
-
-    //noinspection GroovyAssignabilityCheck
+    defaultRepositories(scriptHandler)
     dependencies {
         classpath deps.build.guava
-        classpath (deps.build.gradlePlugins.protobuf) {
-            exclude group: 'com.google.guava'
-        }
-        classpath (deps.build.gradlePlugins.errorProne) {
-            exclude group: 'com.google.guava'
-        }
+        classpath deps.build.gradlePlugins.protobuf
+        classpath deps.build.gradlePlugins.errorProne
     }
 
-    configurations.all {
-        resolutionStrategy {
-            cacheChangingModulesFor(0, 'seconds')
-            force deps.build.guava
-            force deps.test.guavaTestlib
-            force deps.build.protobuf
-        }
-    }
+    forceConfiguration(scriptHandler)
 }
 
 apply from: 'version.gradle'
@@ -99,64 +76,17 @@ allprojects {
 }
 
 subprojects {
+    buildscript { final scriptHandler ->
 
-    buildscript {
         apply from: "$rootDir/version.gradle"
 
-        repositories {
-            mavenLocal()
-            maven { url = repos.gradlePlugins }
-            jcenter()
-
-            maven { url = repos.spine }
-            maven { url = repos.spineSnapshots }
-        }
-
-        //noinspection GroovyAssignabilityCheck
+        defaultRepositories(scriptHandler)
         dependencies {
             classpath deps.build.guava
-            classpath(deps.build.gradlePlugins.protobuf) {
-                // exclude an old Guava version
-                exclude group: 'com.google.guava'
-            }
+            classpath deps.build.gradlePlugins.protobuf
         }
 
-        configurations.all {
-            resolutionStrategy {
-                cacheChangingModulesFor(0, 'seconds')
-
-                force deps.build.guava
-                force deps.test.guavaTestlib
-                force deps.build.protobuf
-            }
-        }
-    }
-
-    configurations {
-        all {
-            resolutionStrategy {
-
-                // Fail eagerly on version conflict (includes transitive dependencies)
-                // e.g. multiple different versions of the same dependency
-                // (where group and name are equal).
-                failOnVersionConflict()
-
-                force deps.build.errorProneAnnotations
-                force deps.build.jsr305Annotations
-                force deps.build.checkerAnnotations
-                force deps.build.guava
-                force deps.build.protobuf
-
-                force deps.test.guavaTestlib
-                force deps.test.truth
-                force deps.test.junit5Api
-                force deps.test.junit4
-            }
-        }
-
-        // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
-        runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
-        testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+        forceConfiguration(scriptHandler)
     }
 
     project.ext {
@@ -193,14 +123,7 @@ subprojects {
     // # suppress inspection "UnusedProperty"
     // org.gradle.java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_51.jdk/Contents/Home/
 
-    repositories {
-        mavenLocal()
-        jcenter()
-
-        maven { url = repos.spine }
-        maven { url = repos.spineSnapshots }
-    }
-
+    defaultRepositories(project)
     dependencies {
         errorprone deps.build.errorProneCore
         errorproneJavac deps.build.errorProneJavac
@@ -220,6 +143,13 @@ subprojects {
         testImplementation deps.test.junit5Api
         testImplementation deps.test.junit5Runner
         testImplementation deps.test.junitPioneer
+    }
+
+    forceConfiguration(project)
+    configurations {
+        // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
+        runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+        testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
     }
 
     sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -247,17 +247,17 @@ subprojects {
     
     task sourceJar(type: Jar) {
         from sourceSets.main.allJava
-        classifier "sources"
+        archiveClassifier.set("sources")
     }
 
     task testOutputJar(type: Jar) {
         from sourceSets.test.output
-        classifier "test"
+        archiveClassifier.set("test")
     }
 
     task javadocJar(type: Jar, dependsOn: 'javadoc') {
         from "$projectDir/build/docs/javadoc"
-        classifier "javadoc"
+        archiveClassifier.set("javadoc")
     }
 
     // Apply the same IDEA module configuration for each of sub-projects.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -28,7 +28,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS=""
+DEFAULT_JVM_OPTS='"-Xmx64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -14,7 +14,7 @@ set APP_BASE_NAME=%~n0
 set APP_HOME=%DIRNAME%
 
 @rem Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-set DEFAULT_JVM_OPTS=
+set DEFAULT_JVM_OPTS="-Xmx64m"
 
 @rem Find java.exe
 if defined JAVA_HOME goto findJavaFromJavaHome

--- a/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
+++ b/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
@@ -34,7 +34,6 @@ import static io.spine.testing.Tests.assertTrue;
  *
  * @param <T> the type of the utility class under the test
  */
-@SuppressWarnings("UnstableApiUsage")
 public abstract class UtilityClassTest<T> {
 
     private final Class<T> utilityClass;

--- a/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
+++ b/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
@@ -38,11 +38,14 @@ public abstract class UtilityClassTest<T> {
 
     private final Class<T> utilityClass;
 
-    protected UtilityClassTest(Class<T> aClass) {
-        utilityClass = aClass;
+    protected UtilityClassTest(Class<T> cls) {
+        this.utilityClass = cls;
     }
 
-    protected Class<T> getUtilityClass() {
+    /**
+     * Obtains the class under the test.
+     */
+    protected final Class<T> getUtilityClass() {
         return utilityClass;
     }
 

--- a/tools/errorprone-checks/build.gradle
+++ b/tools/errorprone-checks/build.gradle
@@ -35,9 +35,18 @@ dependencies {
     implementation deps.build.errorProneCore
     implementation deps.build.errorProneAnnotations
 
-    compileOnly "com.google.auto.service:auto-service:$autoServiceVersion"
+    compileOnly ("com.google.auto.service:auto-service:$autoServiceVersion") {
 
-    testImplementation deps.build.errorProneTestHelpers
+        // Exclude com.google.auto:auto-common because of the version conflict:
+        // 0.8 is used by `auto-service` and 0.10 is used by `error_prone_core`.
+        exclude group: 'com.google.auto'
+    }
+
+    testImplementation (deps.build.errorProneTestHelpers) {
+        // Exclude com.google.auto:auto-common because of the version conflict:
+        // 0.9 is used by `error_prone_test_helpers` and 0.10 is used by `error_prone_core`.
+        exclude group: 'com.google.auto' 
+    }
 }
 
 def getResolvedArtifactFor(final dependency) {

--- a/tools/errorprone-checks/src/main/java/io/spine/tools/check/vbuilder/UseValidatingBuilder.java
+++ b/tools/errorprone-checks/src/main/java/io/spine/tools/check/vbuilder/UseValidatingBuilder.java
@@ -67,8 +67,6 @@ import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
  *
  * <p>Usage of the {@code Message.Builder} inside of the generated {@code Message messages} and
  * in the {@linkplain ValidatingBuilder validating builders} themselves is allowed.
- *
- * @author Dmytro Kuzmin
  */
 @AutoService(BugChecker.class)
 @BugPattern(

--- a/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
+++ b/tools/javadoc-filter/src/main/java/io/spine/tools/javadoc/ExcludeInternalPrinciple.java
@@ -33,10 +33,8 @@ import java.util.Collection;
  *
  * <p>Excludes all {@linkplain Internal}-annotated program elements, packages,
  * and their subpackages.
- *
- * @author Dmytro Grankin
  */
-class ExcludeInternalPrinciple implements ExcludePrinciple {
+final class ExcludeInternalPrinciple implements ExcludePrinciple {
 
     private final Collection<PackageDoc> exclusions;
     private final AnnotationAnalyst<Class<Internal>> internalAnalyst =


### PR DESCRIPTION
This PR:
  * Deprecates `Messagers.newInstance()` in favor of new method `defaultInstance()`
  * Improves build structure basing on reusable Gradle closures.
