### PR TITLE
Set `protoc-api` publish group to `io.spine.tools`

### DIFF
--- a/tools/protoc-api/build.gradle
+++ b/tools/protoc-api/build.gradle
@@ -18,6 +18,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+group 'io.spine.tools'
+
 dependencies {
     compile project(':base')
 }


### PR DESCRIPTION
Previously, the `spine-protoc-api` artifact was published under auto-assigned `spine-base` group.

This caused problems with dependent repositories build.