### PR TITLE
Validating builders `mergeFrom` method formatting fix

### DIFF
--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderCode.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderCode.java
@@ -52,7 +52,7 @@ import static java.lang.String.format;
  */
 final class VBuilderCode implements Logging {
 
-    public static final Splitter DOT_SPLITTER = Splitter.on('.');
+    private static final Splitter DOT_SPLITTER = Splitter.on('.');
     private final File targetDir;
     private final Indent indent;
     private final MessageType type;

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderCode.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderCode.java
@@ -52,6 +52,7 @@ import static java.lang.String.format;
  */
 final class VBuilderCode implements Logging {
 
+    public static final Splitter DOT_SPLITTER = Splitter.on('.');
     private final File targetDir;
     private final Indent indent;
     private final MessageType type;
@@ -142,7 +143,7 @@ final class VBuilderCode implements Logging {
     private File resolve(String javaPackage, String className) {
         Path dir = targetDir.toPath();
         if (!javaPackage.isEmpty()) {
-            for (String packageDir :  Splitter.on('.').split(javaPackage)) {
+            for (String packageDir :  DOT_SPLITTER.split(javaPackage)) {
                 dir = dir.resolve(packageDir);
             }
         }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
@@ -107,7 +107,7 @@ final class VBuilderMethods {
                 .addAnnotation(CanIgnoreReturnValue.class)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(messageClass, MERGE_FROM_METHOD_PARAMETER_NAME)
-                .addStatement(checkAllFields())
+                .addCode(checkAllFields())
                 .addStatement(callSuper(methodName, MERGE_FROM_METHOD_PARAMETER_NAME))
                 .addStatement(returnThis())
                 .returns(className)
@@ -131,7 +131,7 @@ final class VBuilderMethods {
      *
      * @return a statement that checks whether all fields are present during a {@code mergeFrom()}
      */
-    private static String checkAllFields() {
+    private static CodeBlock checkAllFields() {
         String fieldsMap = "fieldsMap";
         String loopLocalVariable = "entry";
         CodeBlock codeBlock = CodeBlock
@@ -153,7 +153,7 @@ final class VBuilderMethods {
                 .addStatement("validateSetOnce($N.getKey())", loopLocalVariable)
                 .endControlFlow()
                 .build();
-        return codeBlock.toString();
+        return codeBlock;
     }
 
     private List<MethodSpec> fieldMethods() {


### PR DESCRIPTION
This PR closes https://github.com/SpineEventEngine/base/issues/292.

Before, all generated `mergeFrom` methods were malformed.

This PR fixes it, making the generated code look as expected.
It also extracts a `Splitter` creation from a loop to a `static final` field, since creating multiple `Splitters` is pointless.