### PR TITLE
Generate marker interface for enrichments

### DIFF
--- a/base/src/main/java/io/spine/base/EnrichmentMessage.java
+++ b/base/src/main/java/io/spine/base/EnrichmentMessage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base;
+
+import com.google.errorprone.annotations.Immutable;
+
+/**
+ * A common interface for enrichment messages.
+ *
+ * <p>The messages to which {@code (enrichment_for)} option is applied are spotted
+ * by the Spine Model Compiler and marked with this interface automatically.
+ */
+@Immutable
+public interface EnrichmentMessage extends SerializableMessage {
+}

--- a/base/src/main/java/io/spine/base/EnrichmentMessageClassifier.java
+++ b/base/src/main/java/io/spine/base/EnrichmentMessageClassifier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base;
+
+import com.google.errorprone.annotations.Immutable;
+import io.spine.code.proto.MessageType;
+
+/**
+ * Checks if the given message definition is a {@link EnrichmentMessage}.
+ */
+@Immutable
+final class EnrichmentMessageClassifier implements MessageClassifier {
+
+    @Override
+    public boolean test(MessageType type) {
+        return type.isEnrichment();
+    }
+}

--- a/base/src/main/java/io/spine/base/MessageClassifiers.java
+++ b/base/src/main/java/io/spine/base/MessageClassifiers.java
@@ -36,7 +36,8 @@ public final class MessageClassifiers {
             CommandMessage.class, MessageType::isCommand,
             EventMessage.class, MessageType::isEvent,
             RejectionMessage.class, MessageType::isRejection,
-            UuidValue.class, new UuidValueClassifier()
+            UuidValue.class, new UuidValueClassifier(),
+            EnrichmentMessage.class, new EnrichmentMessageClassifier()
     );
 
     private MessageClassifiers() {

--- a/base/src/main/java/io/spine/code/proto/MessageType.java
+++ b/base/src/main/java/io/spine/code/proto/MessageType.java
@@ -43,6 +43,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.newLinkedList;
 import static io.spine.code.proto.FileDescriptors.sameFiles;
+import static io.spine.option.OptionsProto.enrichmentFor;
 
 /**
  * A message type as declared in a proto file.
@@ -197,10 +198,20 @@ public class MessageType extends Type<Descriptor, DescriptorProto> implements Lo
     }
 
     /**
+     * Tells if the message is an enrichment.
+     */
+    public boolean isEnrichment() {
+        DescriptorProtos.MessageOptions options = descriptor().getOptions();
+        boolean result = isTopLevel() && options.hasExtension(enrichmentFor);
+        return result;
+    }
+
+    /**
      * Obtains the name of a Validating Builder class for the type.
      *
-     * @throws java.lang.IllegalStateException if the message type does not have a corresponding
-     *  a Validating Builder class, for example, because it's a Google Protobuf message
+     * @throws java.lang.IllegalStateException
+     *         if the message type does not have a corresponding
+     *         a Validating Builder class, for example, because it's a Google Protobuf message
      */
     public SimpleClassName validatingBuilderClass() {
         checkState(isCustom(), "No validating builder class available for the type `%s`.", this);
@@ -295,7 +306,6 @@ public class MessageType extends Type<Descriptor, DescriptorProto> implements Lo
      * }</pre>
      *
      * @return the comments text or {@code Optional.empty()} if there are no comments
-     *
      * @see <a href="https://github.com/google/protobuf-gradle-plugin/blob/master/README.md#generate-descriptor-set-files">
      *         Protobuf plugin configuration</a>
      */

--- a/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
+++ b/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
@@ -30,7 +30,9 @@ import io.spine.net.Url;
 import io.spine.option.EntityOption;
 import io.spine.option.GoesOption;
 import io.spine.option.MinOption;
+import io.spine.test.code.proto.command.MttNotEnrichment;
 import io.spine.test.code.proto.command.MttStartProject;
+import io.spine.test.code.proto.command.MttStartProjectEnrichment;
 import io.spine.test.code.proto.event.MttProjectStarted;
 import io.spine.test.code.proto.rejections.TestRejections;
 import org.junit.jupiter.api.DisplayName;
@@ -48,8 +50,9 @@ class MessageTypeTest {
     /**
      * Negates the passed predicate.
      *
-     * @apiNote Provided for brevity of tests, avoiding avoiding using {@code Predicates.not()}
-     * from Guava, util similar method is provided by Java 11.
+     * @apiNote Provided for brevity of tests, avoiding avoiding using {@code
+     *         Predicates.not()}
+     *         from Guava, util similar method is provided by Java 11.
      */
     static <T> Predicate<T> not(Predicate<T> yes) {
         return yes.negate();
@@ -106,10 +109,19 @@ class MessageTypeTest {
             );
         }
 
+        @DisplayName("an enrichment")
+        @Test
+        void enrichment() {
+            assertQuality(MessageType::isEnrichment,
+                          MttStartProjectEnrichment.getDescriptor()
+            );
+        }
+
         @Nested
-        @DisplayName("not a")
+        @DisplayName("not")
         class NotA {
-            @DisplayName("rejection")
+
+            @DisplayName("a rejection")
             @Test
             void rejection() {
                 assertQuality(not(MessageType::isRejection),
@@ -117,7 +129,7 @@ class MessageTypeTest {
                 );
             }
 
-            @DisplayName("command")
+            @DisplayName("a command")
             @Test
             void command() {
                 assertQuality(not(MessageType::isCommand),
@@ -125,11 +137,19 @@ class MessageTypeTest {
                 );
             }
 
-            @DisplayName("event")
+            @DisplayName("an event")
             @Test
             void event() {
                 assertQuality(not(MessageType::isEvent),
                               MttProjectStarted.Details.getDescriptor()
+                );
+            }
+
+            @DisplayName("an enrichment")
+            @Test
+            void enrichment() {
+                assertQuality(not(MessageType::isEnrichment),
+                              MttNotEnrichment.getDescriptor()
                 );
             }
         }
@@ -190,7 +210,8 @@ class MessageTypeTest {
         @DisplayName("second-level message")
         void secondLevel() {
             IterableSubject assertPath = assertPath(Uri.Protocol.getDescriptor());
-            assertPath.contains(Uri.getDescriptor().getIndex());
+            assertPath.contains(Uri.getDescriptor()
+                                   .getIndex());
         }
     }
 }

--- a/base/src/test/proto/spine/test/code/proto/test_enrichments.proto
+++ b/base/src/test/proto/spine/test/code/proto/test_enrichments.proto
@@ -19,7 +19,7 @@
  */
 syntax = "proto3";
 
-package spine.test.code.proto.commands;
+package spine.test.code.proto.enrichments;
 
 import "spine/options.proto";
 
@@ -27,17 +27,18 @@ option (type_url_prefix) = "type.spine.io";
 option (SPI_all) = true;
 option java_package = "io.spine.test.code.proto.command";
 option java_multiple_files = true;
-option java_outer_classname = "MttCommandsProto";
+option java_outer_classname = "MttEnrichmentsProto";
 
 // This file defines test environment for `MessageTypeTest.java`.
 
-// A sample command to verify detecting that a message is a command from `MessageType`.
-message MttStartProject {
+// A sample enrichment to verify detecting that a message is an enrichment from `MessageType`.
+message MttStartProjectEnrichment {
 
-    Details details = 1;
+    option (enrichment_for) = "spine.test.code.proto.events.MttProjectStarted";
 
-    message Details {
+    string id = 1 [(by) = "details"];
+}
 
-        string description = 1;
-    }
+message MttNotEnrichment {
+    int32 id = 1;
 }

--- a/base/src/test/proto/spine/test/code/proto/test_events.proto
+++ b/base/src/test/proto/spine/test/code/proto/test_events.proto
@@ -19,7 +19,7 @@
  */
 syntax = "proto3";
 
-package spine.test.code.proto.rejections;
+package spine.test.code.proto.events;
 
 import "spine/options.proto";
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/EnrichmentInterfaceConfig.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/EnrichmentInterfaceConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.compiler;
+
+
+/**
+ * A {@link GeneratedInterfaceConfig} which configures messages with {@code (enrichment_for)} option.
+ */
+final class EnrichmentInterfaceConfig extends AbstractGeneratedInterfaceConfig {
+}

--- a/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/GeneratedInterfacesTest.java
+++ b/tools/model-compiler/src/test/java/io/spine/tools/gradle/compiler/GeneratedInterfacesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.tools.gradle.compiler;
+
+import io.spine.base.CommandMessage;
+import io.spine.base.EnrichmentMessage;
+import io.spine.base.EventMessage;
+import io.spine.base.RejectionMessage;
+import io.spine.base.UuidValue;
+import io.spine.code.java.ClassName;
+import io.spine.tools.protoc.GeneratedInterface;
+import io.spine.tools.protoc.SpineProtocConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+import static io.spine.base.MessageFile.COMMANDS;
+import static io.spine.base.MessageFile.EVENTS;
+import static io.spine.base.MessageFile.REJECTIONS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("GeneratedInterfaces should prepare default GeneratedInterfaceConfig for")
+class GeneratedInterfacesTest {
+
+    @DisplayName("EnrichmentMessage")
+    @Test
+    void enrichment() {
+        GeneratedInterfaces defaults = GeneratedInterfaces.withDefaults();
+        assertHasInterfaceName(EnrichmentMessage.class, defaults.enrichmentMessage());
+    }
+
+    @DisplayName("UuidValue")
+    @Test
+    void uuid() {
+        GeneratedInterfaces defaults = GeneratedInterfaces.withDefaults();
+        assertHasInterfaceName(UuidValue.class, defaults.uuidMessage());
+    }
+
+    @DisplayName("CommandMessage")
+    @Test
+    void command() {
+        SpineProtocConfig defaults = GeneratedInterfaces.withDefaults()
+                                                        .asProtocConfig();
+        assertHasInterfaceWithNameAndPostfix(CommandMessage.class, COMMANDS.suffix(), defaults);
+    }
+
+    @DisplayName("EventMessage")
+    @Test
+    void event() {
+        SpineProtocConfig defaults = GeneratedInterfaces.withDefaults()
+                                                        .asProtocConfig();
+        assertHasInterfaceWithNameAndPostfix(EventMessage.class, EVENTS.suffix(), defaults);
+    }
+
+    @DisplayName("RejectionMessage")
+    @Test
+    void rejection() {
+        SpineProtocConfig defaults = GeneratedInterfaces.withDefaults()
+                                                        .asProtocConfig();
+        assertHasInterfaceWithNameAndPostfix(RejectionMessage.class, REJECTIONS.suffix(), defaults);
+    }
+
+    void assertHasInterfaceWithNameAndPostfix(Class<?> interfaceClass,
+                                              String postfix,
+                                              SpineProtocConfig config) {
+        boolean hasInterface = false;
+        String expectedInterface = interfaceClass.getName();
+        for (GeneratedInterface generatedInterface : config.getGeneratedInterfaceList()) {
+            if (expectedInterface.equals(generatedInterface.getInterfaceName()) &&
+                    postfix.equals(generatedInterface.getFilePostfix())) {
+                hasInterface = true;
+                break;
+            }
+        }
+        assertTrue(hasInterface);
+    }
+
+    void assertHasInterfaceName(Class<?> interfaceClass, GeneratedInterfaceConfig config) {
+        assertThat(config)
+                .isInstanceOf(AbstractGeneratedInterfaceConfig.class);
+        Optional<ClassName> actual = ((AbstractGeneratedInterfaceConfig) config).interfaceName();
+        assertTrue(actual.isPresent());
+        assertEquals(ClassName.of(interfaceClass), actual.get());
+    }
+}

--- a/tools/protoc-api/src/main/proto/spine/tools/protoc/config.proto
+++ b/tools/protoc-api/src/main/proto/spine/tools/protoc/config.proto
@@ -29,6 +29,15 @@ message GeneratedInterface {
     string file_postfix = 2 [(required) = true];
 }
 
+// Interface to mark Enrichment messages.
+//
+// An empty value signifies that the messages should not be marked.
+//
+message EnrichmentInterface {
+
+    string interface_name = 1;
+}
+
 // Configuration of the Spine Protoc plugin.
 //
 // The configuration is passed to the plugin as the single option. The passed value is serialized
@@ -39,4 +48,6 @@ message SpineProtocConfig {
     UuidInterface uuid_interface = 1;
 
     repeated GeneratedInterface generated_interface = 2;
+
+    EnrichmentInterface enrichment_interface= 3;
 }

--- a/tools/protoc-plugin/README.md
+++ b/tools/protoc-plugin/README.md
@@ -84,7 +84,8 @@ convention:
    a name ending with `commands.proto`;
  - `io.spine.base.RejectionMessage` is applied to all top-level messages declared in a file which
    has a name ending with `rejections.proto`;
- - `io.spine.base.UuidValue` is applied to all messages with a single string field called `uuid`.
+ - `io.spine.base.UuidValue` is applied to all messages with a single string field called `uuid`;
+ - `io.spine.base.EnrichmentMessage` is applied to all message with an `(enrichment_for)` option.
 
 ## Usage
 

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/insert/PatternScanner.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/insert/PatternScanner.java
@@ -23,6 +23,7 @@ package io.spine.tools.protoc.insert;
 import io.spine.code.java.ClassName;
 import io.spine.code.proto.MessageType;
 import io.spine.tools.protoc.CompilerOutput;
+import io.spine.tools.protoc.EnrichmentInterface;
 import io.spine.tools.protoc.GeneratedInterface;
 import io.spine.tools.protoc.SpineProtocConfig;
 import io.spine.tools.protoc.UuidInterface;
@@ -49,14 +50,52 @@ final class PatternScanner {
      * Finds an interface to be generated for the given type.
      */
     Optional<CompilerOutput> scan(MessageType type) {
-        UuidInterface uuidInterface = patterns.getUuidInterface();
-        if (isNotDefault(uuidInterface) && uuidContainer().test(type)) {
-            return Optional.of(uuidInterface(type, uuidInterface));
-        } else if (type.isTopLevel()) {
-            return postfixBasedInterface(type);
-        } else {
-            return Optional.empty();
+        if (isUuidMessage(type)) {
+            return uuidInterface(type);
         }
+        if (type.isEnrichment()) {
+            return enrichmentInterface(type);
+        }
+        if (type.isTopLevel()) {
+            return postfixBasedInterface(type);
+        }
+        return Optional.empty();
+    }
+
+    private boolean isUuidMessage(MessageType type) {
+        if (!patterns.hasUuidInterface()) {
+            return false;
+        }
+        UuidInterface uuidInterface = patterns.getUuidInterface();
+        return isNotDefault(uuidInterface) && uuidContainer().test(type);
+    }
+
+    private Optional<CompilerOutput> uuidInterface(MessageType type) {
+        UuidInterface uuidInterface = patterns.getUuidInterface();
+        return Optional.of(uuidInterface(type, uuidInterface));
+    }
+
+    private static CompilerOutput uuidInterface(MessageType type, UuidInterface uuidInterface) {
+        ClassName interfaceName = ClassName.of(uuidInterface.getInterfaceName());
+        MessageInterfaceParameters parameters =
+                MessageInterfaceParameters.of(new IdentityParameter());
+        MessageInterface messageInterface = new PredefinedInterface(interfaceName, parameters);
+        CompilerOutput insertionPoint = implementInterface(type, messageInterface);
+        return insertionPoint;
+    }
+
+    private Optional<CompilerOutput> enrichmentInterface(MessageType type) {
+        EnrichmentInterface enrichmentInterface = patterns.getEnrichmentInterface();
+        return Optional.of(enrichmentInterface(type, enrichmentInterface));
+    }
+
+    private static CompilerOutput
+    enrichmentInterface(MessageType type, EnrichmentInterface enrichmentInterface) {
+        MessageInterface messageInterface = new PredefinedInterface(
+                ClassName.of(enrichmentInterface.getInterfaceName()),
+                MessageInterfaceParameters.empty()
+        );
+        return implementInterface(type, messageInterface);
     }
 
     private Optional<CompilerOutput> postfixBasedInterface(MessageType type) {
@@ -66,7 +105,8 @@ final class PatternScanner {
                                     .toString();
         return generatedInterfaces
                 .stream()
-                .filter(target -> !target.getInterfaceName().isEmpty())
+                .filter(target -> !target.getInterfaceName()
+                                         .isEmpty())
                 .filter(target -> sourceFilePath.contains(target.getFilePostfix()))
                 .map(target -> implementByTargetTarget(type, target))
                 .findFirst();
@@ -79,14 +119,5 @@ final class PatternScanner {
                 MessageInterfaceParameters.empty()
         );
         return implementInterface(type, messageInterface);
-    }
-
-    private static CompilerOutput uuidInterface(MessageType type, UuidInterface uuidInterface) {
-        ClassName interfaceName = ClassName.of(uuidInterface.getInterfaceName());
-        MessageInterfaceParameters parameters =
-                MessageInterfaceParameters.of(new IdentityParameter());
-        MessageInterface messageInterface = new PredefinedInterface(interfaceName, parameters);
-        CompilerOutput insertionPoint = implementInterface(type, messageInterface);
-        return insertionPoint;
     }
 }

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/insert/MessageInterfaceGeneratorTest.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/insert/MessageInterfaceGeneratorTest.java
@@ -27,6 +27,7 @@ import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse.File;
 import com.google.protobuf.compiler.PluginProtos.Version;
 import io.spine.base.CommandMessage;
+import io.spine.base.EnrichmentMessage;
 import io.spine.base.EventMessage;
 import io.spine.base.RejectionMessage;
 import io.spine.base.UuidValue;
@@ -210,10 +211,7 @@ class MessageInterfaceGeneratorTest {
         List<File> files = response.getFileList();
         assertEquals(2, files.size());
         for (File file : files) {
-            assertTrue(file.hasInsertionPoint());
-            assertTrue(file.hasName());
-
-            assertEquals(EventMessage.class.getName() + ',', file.getContent());
+            assertGeneratedInterface(EventMessage.class, file);
         }
     }
 
@@ -229,10 +227,7 @@ class MessageInterfaceGeneratorTest {
         List<File> files = response.getFileList();
         assertEquals(2, files.size());
         for (File file : files) {
-            assertTrue(file.hasInsertionPoint());
-            assertTrue(file.hasName());
-
-            assertEquals(CommandMessage.class.getName() + ',', file.getContent());
+            assertGeneratedInterface(CommandMessage.class, file);
         }
     }
 
@@ -248,10 +243,23 @@ class MessageInterfaceGeneratorTest {
         List<File> files = response.getFileList();
         assertEquals(1, files.size());
         for (File file : files) {
-            assertTrue(file.hasInsertionPoint());
-            assertTrue(file.hasName());
+            assertGeneratedInterface(RejectionMessage.class, file);
+        }
+    }
 
-            assertEquals(RejectionMessage.class.getName() + ',', file.getContent());
+    @Test
+    @DisplayName("generate EnrichmentMessage insertion points")
+    void generateEnrichmentMessageInsertionPoints() {
+        String filePath = "spine/tools/protoc/insert/test_enrichments.proto";
+
+        FileDescriptorProto descriptor = TestEnrichmentsProto.getDescriptor()
+                                                             .toProto();
+        CodeGeneratorResponse response = processCodeGenRequest(filePath, descriptor);
+        assertNotNull(response);
+        List<File> files = response.getFileList();
+        assertEquals(1, files.size());
+        for (File file : files) {
+            assertGeneratedInterface(EnrichmentMessage.class, file);
         }
     }
 
@@ -441,5 +449,12 @@ class MessageInterfaceGeneratorTest {
         Path generatedFilePath = Paths.get(generatedFile.getName());
         assertTrue(generatedFilePath.startsWith(PACKAGE_NAME.toDirectory()
                                                             .getPath()));
+    }
+
+    private static void assertGeneratedInterface(Class<?> interfaceClass, File file) {
+        assertTrue(file.hasInsertionPoint());
+        assertTrue(file.hasName());
+
+        assertEquals(interfaceClass.getName() + ',', file.getContent());
     }
 }

--- a/tools/protoc-plugin/src/test/proto/spine/tools/protoc/insert/test_enrichments.proto
+++ b/tools/protoc-plugin/src/test/proto/spine/tools/protoc/insert/test_enrichments.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package spine.tools.protoc.insert;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.tools.protoc.insert";
+option java_outer_classname = "TestEnrichmentsProto";
+option java_multiple_files = true;
+
+// This file contains test enrichment types.
+
+message ProjectNameEnrichment {
+    option (enrichment_for) = "spine.tools.protoc.insert.ProjectCreated";
+
+    string name = 1 [(by) = "id"];
+}
+
+message NonEnrichmentMessage {
+
+    string id = 1;
+}

--- a/tools/smoke-tests/model-compiler-tests/src/test/java/io/spine/tools/protoc/ProtocPluginTest.java
+++ b/tools/smoke-tests/model-compiler-tests/src/test/java/io/spine/tools/protoc/ProtocPluginTest.java
@@ -131,17 +131,18 @@ class ProtocPluginTest {
     @DisplayName("mark as rejection messages")
     void markRejectionMessages() {
         assertThat(Rejections.UserAlreadyExists.getDefaultInstance())
-                   .isInstanceOf(RejectionMessage.class);
+                .isInstanceOf(RejectionMessage.class);
         assertThat(Rejections.UserAlreadyExists.getDefaultInstance())
-                   .isInstanceOf(UserRejection.class);
+                .isInstanceOf(UserRejection.class);
     }
 
     @Test
     @DisplayName("mark messages with already existing interface types")
-    @SuppressWarnings("UnnecessaryLocalVariable") // Compile-time verification.
+    @SuppressWarnings("UnnecessaryLocalVariable")
+        // Compile-time verification.
     void implementHandcraftedInterfaces() {
         assertThat(Rejections.UserAlreadyExists.getDefaultInstance())
-                   .isInstanceOf(UserRejection.class);
+                .isInstanceOf(UserRejection.class);
         assertFalse(Message.class.isAssignableFrom(UserRejection.class));
         String id = Identifier.newUuid();
         Rejections.UserAlreadyExists message = Rejections.UserAlreadyExists
@@ -175,6 +176,18 @@ class ProtocPluginTest {
         assertThat(WeatherForecast.class).isAssignableTo(DocumentMessage.class);
         assertThat(WeatherForecast.Temperature.getDefaultInstance())
                 .isNotInstanceOf(DocumentMessage.class);
+    }
+
+    @Test
+    @DisplayName("mark message with (enrichment_for) option with a generated enrichment interface")
+    void markEnrichmentWithGeneratedInterface() {
+        assertThat(UserNicknameEnrichment.class).isAssignableTo(TestEnrichment.class);
+    }
+
+    @Test
+    @DisplayName("not mark message without (enrichment_for) option with a generated enrichment interface")
+    void notMarkEnrichmentWithGeneratedInterface() {
+        assertThat(NotEnrichment.getDefaultInstance()).isNotInstanceOf(TestEnrichment.class);
     }
 
     @CanIgnoreReturnValue

--- a/tools/smoke-tests/model-compiler-tests/src/test/java/io/spine/tools/protoc/TestEnrichment.java
+++ b/tools/smoke-tests/model-compiler-tests/src/test/java/io/spine/tools/protoc/TestEnrichment.java
@@ -18,12 +18,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-modelCompiler {
-    
-    generateInterfaces {
-        filePattern(endsWith("documents.proto")).markWith("io.spine.tools.protoc.DocumentMessage")
-        filePattern(endsWith("events.proto")).ignore()
-        uuidMessage().ignore()
-        enrichmentMessage().markWith("io.spine.tools.protoc.TestEnrichment")
-    }
+package io.spine.tools.protoc;
+
+import io.spine.base.SerializableMessage;
+
+public interface TestEnrichment extends SerializableMessage {
 }

--- a/tools/smoke-tests/model-compiler-tests/src/test/proto/spine/tools/protoc/test_enrichments.proto
+++ b/tools/smoke-tests/model-compiler-tests/src/test/proto/spine/tools/protoc/test_enrichments.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package spine.tools.protoc;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package = "io.spine.tools.protoc";
+option java_outer_classname = "TestEnrichmentsProto";
+option java_multiple_files = true;
+
+// This file contains test enrichment types.
+
+message UserNicknameEnrichment {
+    option (enrichment_for) = "spine.tools.protoc.UserCreated";
+
+    string nickname = 1 [(by) = "id"];
+}
+
+message NotEnrichment {
+    string id = 1;
+}


### PR DESCRIPTION
This PR is a part of the enrichments code generation improvements (#297).

From now all enrichment messages (messages that have `(enrichment_for)` option) will implement a common marked interface.
By default the `io.spine.base.EnrichmentMessage` interface is used.

The default value can be overridden in gradle `modelCompiler.generateInterfaces` configuration using `enrichmentMessage` option.

Here is how we can use `com.example.Enrichment` interface as an enrichment marker interface:

```groovy
modelCompiler {
    generateInterfaces {
        enrichmentMessage().markWith("com.example.Enrichment")
    }
}
```

It is also possible to disable generation of the enrichment message marker interface as follows:

```groovy
modelCompiler {
    generateInterfaces {
        enrichmentMessage().ignore()
    }
}
```