### PR TITLE
Enable PMD static analysis during the build

### DIFF
--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -27,7 +27,6 @@ import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.annotation.Internal;
 import io.spine.protobuf.AnyPacker;
-import io.spine.protobuf.Messages;
 import io.spine.protobuf.TypeConverter;
 import io.spine.string.StringifierRegistry;
 import org.checkerframework.checker.nullness.qual.Nullable;

--- a/base/src/main/java/io/spine/base/UuidFactory.java
+++ b/base/src/main/java/io/spine/base/UuidFactory.java
@@ -22,7 +22,6 @@ package io.spine.base;
 
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
-import com.google.protobuf.Internal;
 import com.google.protobuf.Message;
 import io.spine.protobuf.Messages;
 

--- a/base/src/main/java/io/spine/logging/Logging.java
+++ b/base/src/main/java/io/spine/logging/Logging.java
@@ -63,7 +63,7 @@ import static org.slf4j.LoggerFactory.getLogger;
         "ClassWithTooManyMethods"
         /* We provide shortcut methods for calling Slf4J Logger API. */,
 
-        "NewMethodNamingConvention"
+        "NewMethodNamingConvention", "PMD.MethodNamingConventions"
         /* These methods are prefixed with underscore to highlight the fact that these methods
            are for logging, and to make them more visible in the real code. */
 })

--- a/base/src/main/java/io/spine/reflect/PackageGraph.java
+++ b/base/src/main/java/io/spine/reflect/PackageGraph.java
@@ -283,12 +283,8 @@ public final class PackageGraph implements Graph<PackageInfo> {
                 return true;
             }
 
-            if (exclusions.stream()
-                          .anyMatch(packageName::startsWith)) {
-                return false;
-            }
-
-            return true;
+            return exclusions.stream()
+                             .noneMatch(packageName::startsWith);
         }
     }
 }

--- a/base/src/main/java/io/spine/validate/ComparableNumber.java
+++ b/base/src/main/java/io/spine/validate/ComparableNumber.java
@@ -36,6 +36,7 @@ final class ComparableNumber extends Number implements Comparable<Number> {
 
     /** Creates a new instance from the specified number. */
     ComparableNumber(Number value) {
+        super();
         this.value = value;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
     }
 
     apply plugin: 'java-library'
+    apply plugin: 'pmd'
     apply plugin: 'com.google.protobuf'
     apply plugin: 'net.ltgt.errorprone'
 
@@ -215,6 +216,8 @@ subprojects {
     }
 
     clean.dependsOn cleanGenerated
+
+    apply from: deps.scripts.pmd
 }
 
 // IDEA project configuration.

--- a/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
+++ b/testlib/src/main/java/io/spine/testing/UtilityClassTest.java
@@ -57,7 +57,7 @@ public abstract class UtilityClassTest<T> {
 
     @Test
     @DisplayName("not accept nulls in public static methods if the arg is non-Nullable")
-    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssertRule")
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         /* This test does assert via `NullPointerTester. */
     void nullCheckPublicStaticMethods() {
         NullPointerTester tester = new NullPointerTester();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ApiOption.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ApiOption.java
@@ -213,7 +213,7 @@ public final class ApiOption {
         EXPERIMENTAL(new ApiOption(experimentalAll, experimentalType, null, experimental)),
         INTERNAL(new ApiOption(internalAll, internalType, null, internal));
 
-        @SuppressWarnings("NonSerializableFieldInSerializableClass")
+        @SuppressWarnings({"NonSerializableFieldInSerializableClass", "PMD.SingularField"})
             // This private enum should not be serialized.
         private final ApiOption option;
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ModuleAnnotator.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/annotation/ModuleAnnotator.java
@@ -243,7 +243,7 @@ public final class ModuleAnnotator {
          * @see #setInternalAnnotation
          */
         public Builder setInternalPatterns(ImmutableSet<@Regex String> patterns) {
-            this.internalPatterns = checkNotNull(patterns);;
+            this.internalPatterns = checkNotNull(patterns);
             return this;
         }
 
@@ -255,7 +255,7 @@ public final class ModuleAnnotator {
          * @see #setInternalAnnotation
          */
         public Builder setInternalMethodNames(ImmutableSet<String> methodNames) {
-            this.internalMethodNames = checkNotNull(methodNames);;
+            this.internalMethodNames = checkNotNull(methodNames);
             return this;
         }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/Extension.java
@@ -48,7 +48,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
 @SuppressWarnings({
         "PublicField", "WeakerAccess" /* Expose fields as a Gradle extension */,
         "ClassWithTooManyMethods" /* The methods are needed for handing default values. */,
-        "ClassWithTooManyFields" /* OK for a Gradle extension to have a flat structure. */})
+        "ClassWithTooManyFields", "PMD.TooManyFields" /* Gradle extensions are flat like this. */})
 public class Extension extends GradleExtension {
 
     /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/GeneratedInterfaces.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/GeneratedInterfaces.java
@@ -263,6 +263,7 @@ public final class GeneratedInterfaces {
         private final String postfix;
 
         private PostfixPattern(String postfix) {
+            super();
             this.postfix = postfix;
         }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/PostfixInterfaceConfig.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/PostfixInterfaceConfig.java
@@ -35,6 +35,7 @@ final class PostfixInterfaceConfig extends PatternInterfaceConfig {
     private final String postfix;
 
     PostfixInterfaceConfig(@Regex String postfix) {
+        super();
         this.postfix = postfix;
     }
 

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
@@ -257,6 +257,7 @@ public class ProtocConfigurationPlugin extends SpinePlugin {
         GRPC("grpc"),
         SPINE("spineProtoc");
 
+        @SuppressWarnings("PMD.SingularField") /* Accessed from the outer class. */
         private final String name;
 
         ProtocPlugin(String name) {

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/GradleTask.java
@@ -43,6 +43,7 @@ import static com.google.common.collect.Lists.newLinkedList;
  * <p>Instantiated via {@link Builder}, forces the new task to be added to
  * the Gradle build lifecycle.
  */
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") /* Instantiated via Builder. */
 public final class GradleTask {
 
     private final Task task;

--- a/tools/plugin-base/src/main/java/io/spine/tools/type/MergedDescriptorSet.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/type/MergedDescriptorSet.java
@@ -37,7 +37,7 @@ public final class MergedDescriptorSet {
     private final FileSet fileSet;
 
     MergedDescriptorSet(FileDescriptorSet descriptorSet) {
-        this.descriptors = ImmutableSet.copyOf(descriptorSet.getFileList());;
+        this.descriptors = ImmutableSet.copyOf(descriptorSet.getFileList());
         this.fileSet = FileSet.ofFiles(descriptors);
     }
 

--- a/tools/proto-js-plugin/src/main/java/io/spine/js/generate/field/parser/FieldParser.java
+++ b/tools/proto-js-plugin/src/main/java/io/spine/js/generate/field/parser/FieldParser.java
@@ -20,7 +20,6 @@
 
 package io.spine.js.generate.field.parser;
 
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.js.generate.output.CodeLines;
@@ -64,7 +63,6 @@ public interface FieldParser {
         checkNotNull(jsOutput);
         FieldDeclaration fdecl = new FieldDeclaration(field);
         if (fdecl.isMessage()) {
-            Descriptors.Descriptor message = field.getMessageType();
             return MessageFieldParser.createFor(field, jsOutput);
         }
         if (fdecl.isEnum()) {


### PR DESCRIPTION
This PR enables the PMD code analysis for `base` modules.

Some warnings were suppressed and some violations were addressed.

Checkstyle rules aren't enabled with this PR due to the https://github.com/checkstyle/checkstyle/issues/3238, which causes Checkstyle to crash on `LogMessages` with `@Nullable ... params`.