### PR TITLE
Make a copy of "live" view on Gradle tasks in Protoc plugin before iterating through them

### DIFF
--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
@@ -43,12 +43,12 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.tasks.TaskCollection;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Base64;
+import java.util.Collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.code.java.DefaultJavaProject.at;
@@ -247,7 +247,7 @@ public class ProtocConfigurationPlugin extends SpinePlugin {
     private void configureProtocTasks(GenerateProtoTaskCollection tasks,
                                       GradleTask dependency) {
         // This is a `live` view of the current Gradle tasks.
-        TaskCollection<GenerateProtoTask> tasksProxy = tasks.all();
+        Collection<GenerateProtoTask> tasksProxy = tasks.all();
 
         /*
          *  Creating a hard-copy of `live` view of matching Gradle tasks.

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
@@ -246,14 +246,14 @@ public class ProtocConfigurationPlugin extends SpinePlugin {
 
     private void configureProtocTasks(GenerateProtoTaskCollection tasks,
                                       GradleTask dependency) {
-        // This is a `live` view of the current Gradle tasks.
+        // This is a "live" view of the current Gradle tasks.
         Collection<GenerateProtoTask> tasksProxy = tasks.all();
 
         /*
-         *  Creating a hard-copy of `live` view of matching Gradle tasks.
+         *  Creating a hard-copy of "live" view of matching Gradle tasks.
          *
          *  Otherwise a `ConcurrentModificationException` is thrown upon an attempt to
-         *  insert a task into the Gradle task list.
+         *  insert a task into the Gradle lifecycle.
          */
         ImmutableList<GenerateProtoTask> allTasks = ImmutableList.copyOf(tasksProxy);
         for (GenerateProtoTask task : allTasks) {


### PR DESCRIPTION
Currently the version updates of Spine dependencies aren't possible. With the updated versions of Gradle plugins something will change. In particular, the way Protoc plugin attempts to modify a list of Gradle tasks while iterating through the same list. 

So basically instead of inserting an element into a collection being traversed, this PR changes the way we treat a collection. And before iterating through tasks, we create a copy of the Gradle task collection and use it for iteration.