### PR TITLE
Allow set same value if `(set_once) = true`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,10 +8,15 @@
 *.html text
 *.xml text
 *.css text
+*.scss text
 *.js text
 *.properties text
-*.bat text
 *.rtf text
+*.yaml text
+*.yml text
+*.md text
+
+LICENSE text
 
 # SQL scripts
 *.sql text
@@ -19,19 +24,11 @@
 # Java sources
 *.java text
 
-# Jsf sources
-*.jsf text
-*.xhtml text
-
-# Action script and Flex
-*.as text
-*.mxml text
-*.actionScriptProperties text
-*.flexLibProperties text
+# Python sources
+*.py text
 
 # Gradle build files
 *.gradle text
-gradlew.bat
 
 # Google protocol buffers
 *.proto text
@@ -40,7 +37,12 @@ gradlew.bat
 *.rb text
 
 # Declare files that will always have CRLF line endings on checkout.
-# *.sln text eol=crlf
+*.bat text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+*.sh text eol=lf
+gradlew text eol=lf
+pull text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary

--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -51,7 +51,6 @@
       <w>testutil</w>
       <w>threeten</w>
       <w>tuples</w>
-      <w>unmutes</w>
       <w>unregister</w>
       <w>unregistering</w>
       <w>unregisters</w>

--- a/base/src/main/java/io/spine/code/proto/FieldDeclaration.java
+++ b/base/src/main/java/io/spine/code/proto/FieldDeclaration.java
@@ -37,7 +37,6 @@ import io.spine.type.MessageType;
 import io.spine.type.TypeName;
 import io.spine.type.TypeUrl;
 import io.spine.type.UnknownTypeException;
-import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
 import java.util.List;
 import java.util.Optional;
@@ -55,9 +54,7 @@ import static java.util.stream.Collectors.toList;
 @SuppressWarnings("ClassWithTooManyMethods") // OK as isSomething() methods are mutually exclusive.
 public final class FieldDeclaration implements Logging {
 
-    /** If known the message which declares the field. */
-    private final @MonotonicNonNull MessageType message;
-
+    private final MessageType declaringMessage;
     private final FieldDescriptor field;
 
     /**
@@ -68,7 +65,7 @@ public final class FieldDeclaration implements Logging {
      */
     public FieldDeclaration(FieldDescriptor field) {
         this.field = checkNotNull(field);
-        this.message = null;
+        this.declaringMessage = new MessageType(field.getContainingType());
     }
 
     /**
@@ -76,7 +73,7 @@ public final class FieldDeclaration implements Logging {
      */
     public FieldDeclaration(FieldDescriptor field, MessageType message) {
         this.field = checkNotNull(field);
-        this.message = message;
+        this.declaringMessage = message;
     }
 
     /**
@@ -91,6 +88,13 @@ public final class FieldDeclaration implements Logging {
      */
     public FieldDescriptor descriptor() {
         return field;
+    }
+
+    /**
+     * Obtains the declaring message type if known.
+     */
+    public MessageType declaringType() {
+        return declaringMessage;
     }
 
     /**
@@ -287,7 +291,7 @@ public final class FieldDeclaration implements Logging {
      */
     public Optional<String> leadingComments() {
         LocationPath fieldPath = fieldPath();
-        return message.leadingComments(fieldPath);
+        return declaringMessage.leadingComments(fieldPath);
     }
 
     /**
@@ -299,7 +303,7 @@ public final class FieldDeclaration implements Logging {
      */
     private LocationPath fieldPath() {
         LocationPath locationPath = new LocationPath();
-        locationPath.addAll(message.path());
+        locationPath.addAll(declaringMessage.path());
         locationPath.add(DescriptorProto.FIELD_FIELD_NUMBER);
         int fieldIndex = fieldIndex();
         locationPath.add(fieldIndex);
@@ -308,9 +312,9 @@ public final class FieldDeclaration implements Logging {
 
     private int fieldIndex() {
         FieldDescriptorProto fproto = this.field.toProto();
-        return message.descriptor()
-                      .toProto()
-                      .getFieldList()
-                      .indexOf(fproto);
+        return declaringMessage.descriptor()
+                               .toProto()
+                               .getFieldList()
+                               .indexOf(fproto);
     }
 }

--- a/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
@@ -260,29 +260,31 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
      *         if the value of the  field that is {@code (set_once) = true} is being changed
      */
     @SuppressWarnings("unused") // Called by all actual validating builder subclasses.
-    protected final void validateSetOnce(FieldValue<?> newValue) throws ValidationException {
-        FieldDeclaration field = newValue.declaration();
-        boolean shouldValidate = setOnce(field);
+    protected final void validateSetOnce(FieldDescriptor field, Object newValue)
+            throws ValidationException {
+        checkNotNull(field);
+        checkNotNull(newValue);
+
+        FieldDeclaration declaration = new FieldDeclaration(field);
+        boolean shouldValidate = setOnce(declaration);
         if (shouldValidate) {
-            boolean setOnceInapplicable = field.isCollection();
+            boolean setOnceInapplicable = declaration.isCollection();
             if (setOnceInapplicable) {
-                onSetOnceMisuse(field);
+                onSetOnceMisuse(declaration);
             } else {
-                checkNotOverriding(newValue);
+                checkNotOverriding(declaration, newValue);
             }
         }
     }
 
-    private void checkNotOverriding(FieldValue<?> newValue) throws ValidationException {
-        FieldDeclaration field = newValue.declaration();
-
+    private void checkNotOverriding(FieldDeclaration field, Object newValue)
+            throws ValidationException {
         FieldDescriptor descriptor = field.descriptor();
         B builder = getMessageBuilder();
         boolean valueIsSet = !builder.hasField(descriptor);
         if (valueIsSet) {
-            Object actualNewValue = newValue.singleValue();
             Object currentValue = builder.getField(descriptor);
-            boolean anotherValueSet = !currentValue.equals(actualNewValue);
+            boolean anotherValueSet = !currentValue.equals(newValue);
             if (anotherValueSet) {
                 throw violatedSetOnce(field);
             }

--- a/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
@@ -281,7 +281,7 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
             throws ValidationException {
         FieldDescriptor descriptor = field.descriptor();
         B builder = getMessageBuilder();
-        boolean valueIsSet = !builder.hasField(descriptor);
+        boolean valueIsSet = builder.hasField(descriptor);
         if (valueIsSet) {
             Object currentValue = builder.getField(descriptor);
             boolean anotherValueSet = !currentValue.equals(newValue);

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/AbstractMethodGroup.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/AbstractMethodGroup.java
@@ -122,8 +122,14 @@ abstract class AbstractMethodGroup implements MethodGroup {
     }
 
     /** Creates a statement that calls the {@code validateSetOnce} method. */
-    static String validateSetOnce() {
-        CodeBlock codeBlock = CodeBlock.of("validateSetOnce($N)", FIELD_DESCRIPTOR_NAME);
+    static String validateSetOnce(String newValue) {
+        CodeBlock codeBlock = CodeBlock.of("validateSetOnce($N, $N)",
+                                           FIELD_DESCRIPTOR_NAME, newValue);
+        return codeBlock.toString();
+    }
+
+    static String ensureNotSetOnce() {
+        CodeBlock codeBlock = CodeBlock.of("checkNotSetOnce($N)", FIELD_DESCRIPTOR_NAME);
         return codeBlock.toString();
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethods.java
@@ -148,7 +148,6 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                 .addParameter(keyTypeName, KEY)
                 .addParameter(valueTypeName, VALUE)
                 .addStatement(descriptorDeclaration())
-                .addStatement(validateSetOnce())
                 .addStatement(mapToValidate, Map.class, keyTypeName,
                               valueTypeName, Collections.class)
                 .addStatement(validateStatement(MAP_TO_VALIDATE_PARAM_NAME, javaFieldName))
@@ -175,6 +174,7 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                 .addStatement(ConvertStatement.of(VALUE, valueTypeName)
                                               .value())
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(mapToValidate, Map.class, keyTypeName,
                               valueTypeName, Collections.class)
                 .addStatement(validateStatement(MAP_TO_VALIDATE_PARAM_NAME, javaFieldName))
@@ -195,6 +195,7 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                 .addParameter(fieldType.getTypeName(), MAP_PARAM_NAME)
                 .addException(ValidationException.class)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(MAP_PARAM_NAME, javaFieldName))
                 .addStatement(putAllStatement)
                 .addStatement(returnThis())
@@ -212,6 +213,7 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                 .addException(ValidationException.class)
                 .addException(ConversionException.class)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(createGetConvertedMapValue(),
                               Map.class, keyTypeName, valueTypeName,
                               keyTypeName, valueTypeName)
@@ -228,6 +230,8 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                                       getMessageBuilder(), methodName, KEY);
         MethodSpec result = newBuilderSetter(methodName)
                 .addParameter(keyTypeName, KEY)
+                .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(removeFromMap)
                 .addStatement(returnThis())
                 .build();
@@ -238,6 +242,8 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
         String methodName = clearer().format(javaFieldName);
         String clearMap = format("%s.%s()", getMessageBuilder(), methodName);
         MethodSpec result = newBuilderSetter(methodName)
+                .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(clearMap)
                 .addStatement(returnThis())
                 .build();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/MapFieldMethods.java
@@ -148,6 +148,7 @@ class MapFieldMethods extends AbstractMethodGroup implements Logging {
                 .addParameter(keyTypeName, KEY)
                 .addParameter(valueTypeName, VALUE)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(mapToValidate, Map.class, keyTypeName,
                               valueTypeName, Collections.class)
                 .addStatement(validateStatement(MAP_TO_VALIDATE_PARAM_NAME, javaFieldName))

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/RepeatedFieldMethods.java
@@ -170,6 +170,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                 .addStatement(ConvertStatement.of(VALUE, listElementClassName)
                                               .value())
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(CONVERTED_VALUE, javaFieldName))
                 .addStatement(addValueStatement)
                 .addStatement(returnThis())
@@ -199,6 +200,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                 .addStatement(ConvertStatement.of(VALUE, listElementClassName)
                                               .value())
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(CONVERTED_VALUE, javaFieldName))
                 .addStatement(modificationStatement)
                 .addStatement(returnThis())
@@ -220,6 +222,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                               listElementClassName,
                               listElementClassName)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(CONVERTED_VALUE, javaFieldName))
                 .addStatement(addAllValues)
                 .addStatement(returnThis())
@@ -236,6 +239,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                 .addParameter(parameter, VALUE)
                 .addException(ValidationException.class)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(VALUE, javaFieldName))
                 .addStatement(addAllValues)
                 .addStatement(returnThis())
@@ -258,7 +262,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                 .addParameter(listElementClassName, VALUE)
                 .addException(ValidationException.class)
                 .addStatement(descriptorDeclaration)
-                .addStatement(validateSetOnce())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(VALUE, javaFieldName))
                 .addStatement(addValue)
                 .addStatement(returnThis())
@@ -279,6 +283,8 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
         String addValue = format("%s.%s(%s)", getMessageBuilder(), methodName, INDEX);
         MethodSpec result = newBuilderSetter(methodName)
                 .addParameter(TypeName.INT, INDEX)
+                .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(addValue)
                 .addStatement(returnThis())
                 .build();
@@ -293,6 +299,7 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
                 .addParameter(listElementClassName, VALUE)
                 .addException(ValidationException.class)
                 .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(validateStatement(VALUE, javaFieldName))
                 .addStatement(modificationStatement)
                 .addStatement(returnThis())
@@ -304,6 +311,8 @@ final class RepeatedFieldMethods extends AbstractMethodGroup implements Logging 
         String methodName = clearer().format(javaFieldName);
         String clearField = format("%s.%s()", getMessageBuilder(), clearer().format(javaFieldName));
         MethodSpec result = newBuilderSetter(methodName)
+                .addStatement(descriptorDeclaration())
+                .addStatement(ensureNotSetOnce())
                 .addStatement(clearField)
                 .addStatement(returnThis())
                 .build();

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
@@ -22,6 +22,7 @@ package io.spine.tools.compiler.validation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto;
+import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
@@ -33,6 +34,7 @@ import io.spine.logging.Logging;
 import io.spine.tools.compiler.field.AccessorTemplates;
 import io.spine.tools.compiler.field.type.FieldType;
 import io.spine.validate.ValidationException;
+import io.spine.value.StringTypeValue;
 
 import java.util.Collection;
 
@@ -188,12 +190,26 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
         return result;
     }
 
+    /**
+     * Constructs an expression which obtains the default value of the field.
+     *
+     * <p>Example: {@code org.example.CompiledMessage.getDefaultInstance().getMyField()}.
+     */
     private String fieldDefaultValueExpression() {
-        return defaultInstanceExpression() + ".get" + javaFieldName.capitalize() + "()";
+        return format("%s.get%s()", defaultInstanceExpression(), javaFieldName.capitalize());
     }
 
+    /**
+     * Constructs an expression which obtains the default value of the built type.
+     *
+     * <p>Example: {@code org.example.CompiledMessage.getDefaultInstance()}.
+     */
     private String defaultInstanceExpression() {
-        return io.spine.code.java.ClassName.from(field.getContainingType()).toDotted().value() + ".getDefaultInstance()";
+        Descriptor containingType = field.getContainingType();
+        StringTypeValue messageClassName =
+                io.spine.code.java.ClassName.from(containingType)
+                                            .toDotted();
+        return messageClassName.value() + ".getDefaultInstance()";
     }
 
     /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/SingularFieldMethods.java
@@ -110,7 +110,7 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
                         .addParameter(parameter)
                         .addException(ValidationException.class)
                         .addStatement(descriptorDeclaration)
-                        .addStatement(validateSetOnce())
+                        .addStatement(validateSetOnce(javaFieldName.value()))
                         .addStatement(validateStatement)
                         .addStatement(setStatement)
                         .addStatement(returnThis())
@@ -139,7 +139,7 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
         MethodSpec methodSpec =
                 newBuilderSetter(methodName)
                         .addStatement(descriptorDeclaration())
-                        .addStatement(validateSetOnce())
+                        .addStatement(validateSetOnce(fieldDefaultValueExpression()))
                         .addStatement(methodBody)
                         .addStatement(returnThis())
                         .build();
@@ -169,6 +169,7 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
                           .addException(ConversionException.class)
                           .addStatement(descriptorDeclaration())
                           .addStatement(convertStatement.value())
+                          .addStatement(validateSetOnce(convertedVariableName))
                           .addStatement(validateStatement(convertedVariableName, javaFieldName))
                           .addStatement(setStatement)
                           .addStatement(returnThis())
@@ -185,6 +186,14 @@ class SingularFieldMethods extends AbstractMethodGroup implements Logging {
         ParameterSpec result = ParameterSpec.builder(methodParamType, paramName)
                                             .build();
         return result;
+    }
+
+    private String fieldDefaultValueExpression() {
+        return defaultInstanceExpression() + ".get" + javaFieldName.capitalize() + "()";
+    }
+
+    private String defaultInstanceExpression() {
+        return io.spine.code.java.ClassName.from(field.getContainingType()).toDotted().value() + ".getDefaultInstance()";
     }
 
     /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/validation/VBuilderMethods.java
@@ -108,7 +108,7 @@ final class VBuilderMethods {
                 .addAnnotation(CanIgnoreReturnValue.class)
                 .addModifiers(Modifier.PUBLIC)
                 .addParameter(messageClass, MERGE_FROM_METHOD_PARAMETER_NAME)
-                .addCode(checkAllFields())
+                .addCode(checkSetOnceOnAllFields())
                 .addStatement(callSuper(methodName, MERGE_FROM_METHOD_PARAMETER_NAME))
                 .addStatement(returnThis())
                 .returns(className)
@@ -125,14 +125,14 @@ final class VBuilderMethods {
      *          {@code
      *              Map<FieldDescriptor, Object> fieldsMap = message.getAllFields();
      *              for (Map.Entry<FieldDescriptor, Object> entry : message.entrySet() {
-     *                      validateSetOnce(entry.getKey());
+     *                      validateSetOnce(entry.getKey(), entry.getValue());
      *              }
      *          }
      *          </pre>
      *
      * @return a statement that checks whether all fields are present during a {@code mergeFrom()}
      */
-    private static CodeBlock checkAllFields() {
+    private static CodeBlock checkSetOnceOnAllFields() {
         String fieldsMap = "fieldsMap";
         String loopLocalVariable = "entry";
         CodeBlock codeBlock = CodeBlock
@@ -151,7 +151,8 @@ final class VBuilderMethods {
                         ClassName.get(Object.class),
                         loopLocalVariable,
                         fieldsMap)
-                .addStatement("validateSetOnce($N.getKey())", loopLocalVariable)
+                .addStatement("validateSetOnce($N.getKey(), $N.getValue())",
+                              loopLocalVariable, loopLocalVariable)
                 .endControlFlow()
                 .build();
         return codeBlock;

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
@@ -29,6 +29,7 @@ import io.spine.test.validate.msg.builder.ArtificialBlizzardVBuilder;
 import io.spine.test.validate.msg.builder.Attachment;
 import io.spine.test.validate.msg.builder.BlizzardVBuilder;
 import io.spine.test.validate.msg.builder.EditTaskStateVBuilder;
+import io.spine.test.validate.msg.builder.EssayVBuilder;
 import io.spine.test.validate.msg.builder.FrostyWeatherButInWholeNumberVBuilder;
 import io.spine.test.validate.msg.builder.FrostyWeatherVBuilder;
 import io.spine.test.validate.msg.builder.InconsistentBoundariesVBuilder;
@@ -73,7 +74,9 @@ import static io.spine.test.validate.msg.builder.TaskLabel.CRITICAL;
 import static io.spine.test.validate.msg.builder.TaskLabel.IMPORTANT;
 import static io.spine.test.validate.msg.builder.TaskLabel.OF_LITTLE_IMPORTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.slf4j.event.Level.ERROR;
 
 /**
  * A test suite covering the {@link ValidatingBuilder} behavior.
@@ -281,18 +284,20 @@ class ValidatingBuilderTest {
         @DisplayName("a repeated field")
         void testSetOnceRepeatedFieldsError() {
             essay.addLine("First line of the task");
-            assertFalse(loggedMessages.isEmpty());
-            assertEquals(loggedMessages.peek()
-                                       .getLevel(), Level.ERROR);
+            assertLoggedError();
         }
 
         @Test
         @DisplayName("a map field")
         void testSetOnceMapFieldError() {
             essay.putTableOfContents("Synopsis", 0);
+            assertLoggedError();
+        }
+
+        private void assertLoggedError() {
             assertFalse(loggedMessages.isEmpty());
-            assertEquals(loggedMessages.peek()
-                                       .getLevel(), Level.ERROR);
+            SubstituteLoggingEvent lastEvent = loggedMessages.peek();
+            assertEquals(lastEvent.getLevel(), ERROR);
         }
     }
 

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
@@ -29,18 +29,16 @@ import io.spine.test.validate.msg.builder.ArtificialBlizzardVBuilder;
 import io.spine.test.validate.msg.builder.Attachment;
 import io.spine.test.validate.msg.builder.BlizzardVBuilder;
 import io.spine.test.validate.msg.builder.EditTaskStateVBuilder;
-import io.spine.test.validate.msg.builder.EssayVBuilder;
 import io.spine.test.validate.msg.builder.FrostyWeatherButInWholeNumberVBuilder;
 import io.spine.test.validate.msg.builder.FrostyWeatherVBuilder;
 import io.spine.test.validate.msg.builder.InconsistentBoundariesVBuilder;
 import io.spine.test.validate.msg.builder.Member;
-import io.spine.test.validate.msg.builder.MinorCitizenVBuilder;
-import io.spine.test.validate.msg.builder.Menu;
 import io.spine.test.validate.msg.builder.MenuVBuilder;
+import io.spine.test.validate.msg.builder.MinorCitizenVBuilder;
 import io.spine.test.validate.msg.builder.ProjectVBuilder;
+import io.spine.test.validate.msg.builder.RequiredBooleanFieldVBuilder;
 import io.spine.test.validate.msg.builder.SafeBet;
 import io.spine.test.validate.msg.builder.SafeBetVBuilder;
-import io.spine.test.validate.msg.builder.RequiredBooleanFieldVBuilder;
 import io.spine.test.validate.msg.builder.Snowflake;
 import io.spine.test.validate.msg.builder.SpacedOutBoundariesVBuilder;
 import io.spine.test.validate.msg.builder.Task;
@@ -57,7 +55,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.slf4j.event.Level;
 import org.slf4j.event.SubstituteLoggingEvent;
 import org.slf4j.helpers.SubstituteLogger;
 
@@ -76,7 +73,6 @@ import static io.spine.test.validate.msg.builder.TaskLabel.CRITICAL;
 import static io.spine.test.validate.msg.builder.TaskLabel.IMPORTANT;
 import static io.spine.test.validate.msg.builder.TaskLabel.OF_LITTLE_IMPORTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -242,7 +238,8 @@ class ValidatingBuilderTest {
     private static void testSetOnce(Function<TaskVBuilder, TaskVBuilder> setup,
                                     Stream<Function<TaskVBuilder, ?>> mutateOperations) {
         mutateOperations.forEach(
-                operation -> testOption(TaskVBuilder.newBuilder(), setup, operation));
+                operation -> testOption(TaskVBuilder.newBuilder(), setup, operation)
+        );
     }
 
     /**
@@ -348,12 +345,13 @@ class ValidatingBuilderTest {
 
         @DisplayName("not produce warnings if it is not `required`")
         @Test
+        @SuppressWarnings("CheckReturnValue") // Builder used for the side effect.
         void testNoWarningOnBoolField() {
             int sizeBefore = loggedMessages.size();
             MenuVBuilder builder = MenuVBuilder.newBuilder();
-            Menu menu = builder.setName("Non-vegetarian menu.")
-                               .setMeatDish("Non-vegetarian dish.")
-                               .build();
+            builder.setName("Non-vegetarian menu.")
+                   .setMeatDish("Non-vegetarian dish.")
+                   .build();
             assertEquals(sizeBefore, loggedMessages.size());
         }
 
@@ -363,7 +361,7 @@ class ValidatingBuilderTest {
             int sizeBefore = loggedMessages.size();
             RequiredBooleanFieldVBuilder builder = RequiredBooleanFieldVBuilder.newBuilder();
             builder.setValue(true);
-           assertEquals(sizeBefore + 1, loggedMessages.size());
+            assertEquals(sizeBefore + 1, loggedMessages.size());
         }
     }
 


### PR DESCRIPTION
Currently, an enabled `(set_once)` option forbids the user to set any kind of value to the field. This is inconvenient since sometimes users may want to set the same value to the field. The `hasField(...)` checks are the only way to make sure that an error would not be produced in such a case.

This PR allows users to set the same value to the field.

Also, the `(set_once)` checks are being added to `setRaw...(...)` and `clear...()` methods.
`put...(...)` and `add...(...)` methods now have explicit checks that the collection field is not marked with `(set_once)`.