### PR TITLE
Document task names

### DIFF
--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
@@ -129,10 +129,26 @@ public enum TaskName {
      */
     generateJsonParsers,
 
+    /**
+     * Downloads the Protobuf compiler plugin executable JAR and distributes it into the required
+     * paths in the project.
+     */
     copyPluginJar,
 
+    /**
+     * Creates the {@code desc.ref} file containing the reference to the descriptor file(-s) with
+     * the known types.
+     *
+     * <p>Works only with the {@code main} scope descriptors.
+     */
     writeDescriptorReference,
 
+    /**
+     * Creates the {@code desc.ref} file containing the reference to the descriptor file(-s) with
+     * the known types.
+     *
+     * <p>Works only with the {@code test} scope descriptors.
+     */
     writeTestDescriptorReference;
 
     /**

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
@@ -135,7 +135,7 @@ public enum TaskName {
     copyPluginJar,
 
     /**
-     * Creates the {@code desc.ref} file containing the reference to the descriptor file(-s) with
+     * Creates the {@code desc.ref} file containing the reference to the descriptor file(s) with
      * the known types.
      *
      * <p>Works only with the {@code main} scope descriptors.
@@ -143,7 +143,7 @@ public enum TaskName {
     writeDescriptorReference,
 
     /**
-     * Creates the {@code desc.ref} file containing the reference to the descriptor file(-s) with
+     * Creates the {@code desc.ref} file containing the reference to the descriptor file(s) with
      * the known types.
      *
      * <p>Works only with the {@code test} scope descriptors.

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/TaskName.java
@@ -130,8 +130,7 @@ public enum TaskName {
     generateJsonParsers,
 
     /**
-     * Downloads the Protobuf compiler plugin executable JAR and distributes it into the required
-     * paths in the project.
+     * Downloads the Protobuf compiler plugin executable JAR into the required paths in the project.
      */
     copyPluginJar,
 


### PR DESCRIPTION
Some of the elements of `TaskName` enum were not documented. In this PR we add the required doc.

Fixes #352.