### PR TITLE
Improve naming

### DIFF
--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -51,7 +51,7 @@ public final class Identifier<I> {
     public static final String NULL_ID = "NULL";
 
     /** An empty ID string representation. */
-    public static final String EMPTY_ID = "EMPTY";
+    static final String EMPTY_ID = "EMPTY";
 
     private final Type type;
     private final I value;
@@ -81,17 +81,17 @@ public final class Identifier<I> {
     /**
      * Obtains a default value for an identifier of the passed class.
      */
-    public static <I> I getDefaultValue(Class<I> idClass) {
+    public static <I> I defaultValue(Class<I> idClass) {
         checkNotNull(idClass);
-        Type type = getType(idClass);
-        I result = type.getDefaultValue(idClass);
+        Type type = toType(idClass);
+        I result = type.defaultValue(idClass);
         return result;
     }
 
     /**
-     * Obtains the type of identifiers of the passed class.
+     * Converts the class of identifiers to {@code Identifier.Type}.
      */
-    public static <I> Type getType(Class<I> idClass) {
+    public static <I> Type toType(Class<I> idClass) {
         for (Type type : Type.values()) {
             if (type.matchClass(idClass)) {
                 return type;
@@ -100,12 +100,42 @@ public final class Identifier<I> {
         throw unsupportedClass(idClass);
     }
 
+    /**
+     * Verifies if the passed value of the identifier is empty.
+     *
+     * <p>Always returns {@code false} for long and integer values.
+     *
+     * <p>For string and message identifiers, the method verifies the values.
+     *
+     * <p>A string identifier is empty, if it contains an empty string.
+     *
+     * <p>A message identifier is empty if
+     *
+     * @param value
+     *         the value to check
+     * @param <I>
+     *         the type of the identifier
+     * @return {@code true} if the identifier is empty;
+     *         {@code false} otherwise
+     */
+    public static <I> boolean isEmpty(I value) {
+        checkNotNull(value);
+        Identifier<I> id = from(value);
+        if (id.type == Type.INTEGER || id.type == Type.LONG) {
+            return false;
+        }
+
+        String str = id.toString();
+        boolean result = str.equals(EMPTY_ID);
+        return result;
+    }
+
     private static <I> IllegalArgumentException unsupported(I id) {
-        return newIllegalArgumentException("ID of unsupported type encountered: %s", id);
+        return newIllegalArgumentException("ID of unsupported type encountered: %s.", id);
     }
 
     private static <I> IllegalArgumentException unsupportedClass(Class<I> idClass) {
-        return newIllegalArgumentException("Unsupported ID class encountered: %s",
+        return newIllegalArgumentException("Unsupported ID class encountered: `%s`.",
                                            idClass.getName());
     }
 
@@ -142,7 +172,7 @@ public final class Identifier<I> {
         checkNotNull(idClass);
         // Even through `getType()` can never return null, we use its return value here
         // instead of allowing ignoring just because of this one usage.
-        checkNotNull(getType(idClass));
+        checkNotNull(toType(idClass));
     }
 
     /**
@@ -365,7 +395,7 @@ public final class Identifier<I> {
             }
 
             @Override
-            <I> I getDefaultValue(Class<I> idClass) {
+            <I> I defaultValue(Class<I> idClass) {
                 return (I) "";
             }
         },
@@ -392,7 +422,7 @@ public final class Identifier<I> {
             }
 
             @Override
-            <I> I getDefaultValue(Class<I> idClass) {
+            <I> I defaultValue(Class<I> idClass) {
                 return (I) Integer.valueOf(0);
             }
         },
@@ -419,7 +449,7 @@ public final class Identifier<I> {
             }
 
             @Override
-            <I> I getDefaultValue(Class<I> idClass) {
+            <I> I defaultValue(Class<I> idClass) {
                 return (I) Long.valueOf(0);
             }
         },
@@ -460,7 +490,7 @@ public final class Identifier<I> {
             }
 
             @Override
-            <I> I getDefaultValue(Class<I> idClass) {
+            <I> I defaultValue(Class<I> idClass) {
                 Class<? extends Message> msgClass = (Class<? extends Message>) idClass;
                 Message result = defaultInstance(msgClass);
                 return (I) result;
@@ -489,7 +519,7 @@ public final class Identifier<I> {
 
         abstract Object fromMessage(Message message);
 
-        abstract <I> I getDefaultValue(Class<I> idClass);
+        abstract <I> I defaultValue(Class<I> idClass);
 
         <I> Any pack(I id) {
             Message msg = toMessage(id);

--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -109,8 +109,6 @@ public final class Identifier<I> {
      *
      * <p>A string identifier is empty, if it contains an empty string.
      *
-     * <p>A message identifier is empty if
-     *
      * @param value
      *         the value to check
      * @param <I>

--- a/base/src/main/java/io/spine/base/MessageIdToString.java
+++ b/base/src/main/java/io/spine/base/MessageIdToString.java
@@ -47,7 +47,7 @@ final class MessageIdToString {
     static String toString(Message message) {
         checkNotNull(message);
         String result;
-        StringifierRegistry registry = StringifierRegistry.getInstance();
+        StringifierRegistry registry = StringifierRegistry.instance();
         Class<? extends Message> msgClass = message.getClass();
         TypeToken<? extends Message> msgToken = TypeToken.of(msgClass);
         java.lang.reflect.Type msgType = msgToken.getType();

--- a/base/src/main/java/io/spine/base/ThrowableMessage.java
+++ b/base/src/main/java/io/spine/base/ThrowableMessage.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
 /**
@@ -38,9 +38,6 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *
  * <p>Typically used to signalize about a command rejection, occurred in a system. In which case
  * the {@code message} thrown is a detailed description of the rejection reason.
- *
- * @author Alex Tymchenko
- * @author Alexander Yevsyukov
  */
 public abstract class ThrowableMessage extends Throwable {
 
@@ -57,17 +54,20 @@ public abstract class ThrowableMessage extends Throwable {
     protected ThrowableMessage(RejectionMessage message) {
         super();
         this.message = checkNotNull(message);
-        this.timestamp = getCurrentTime();
+        this.timestamp = currentTime();
     }
 
-    public RejectionMessage getMessageThrown() {
+    /**
+     * Obtains the thrown rejection message.
+     */
+    public RejectionMessage messageThrown() {
         return message;
     }
 
     /**
-     * Returns timestamp of the rejection message creation.
+     * Obtains the time when the rejection message was created.
      */
-    public Timestamp getTimestamp() {
+    public Timestamp timestamp() {
         return timestamp;
     }
 

--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -44,26 +44,27 @@ public final class Time {
     }
 
     /**
-     * Obtains current time.
+     * Obtains current time via the current {@link Time.Provider}.
      *
      * @return current time
+     * @see #setProvider(Provider)
      */
-    public static Timestamp getCurrentTime() {
+    public static Timestamp currentTime() {
         Timestamp result = timeProvider.get()
-                                       .getCurrentTime();
+                                       .currentTime();
         return result;
     }
 
     /**
      * Obtains system time.
      *
-     * <p>Unlike {@link #getCurrentTime()} this method <strong>always</strong> uses
+     * <p>Unlike {@link #currentTime()} this method <strong>always</strong> uses
      * system time millis.
      *
      * @return current system time
      */
     public static Timestamp systemTime() {
-        return SystemTimeProvider.INSTANCE.getCurrentTime();
+        return SystemTimeProvider.INSTANCE.currentTime();
     }
 
     /**
@@ -91,11 +92,11 @@ public final class Time {
      * The provider of the current time.
      *
      * <p>Implement this interface and pass the resulting class to {@link #setProvider(Provider)}
-     * in order to change the {@link #getCurrentTime()} results.
+     * in order to change the {@link Time#currentTime()} results.
      */
     @Internal
     public interface Provider {
-        Timestamp getCurrentTime();
+        Timestamp currentTime();
     }
 
     /**
@@ -112,7 +113,7 @@ public final class Time {
         }
 
         @Override
-        public Timestamp getCurrentTime() {
+        public Timestamp currentTime() {
             Instant now = Instant.now();
             Timestamp result = Timestamp.newBuilder()
                                         .setSeconds(now.getEpochSecond())

--- a/base/src/main/java/io/spine/base/UuidValue.java
+++ b/base/src/main/java/io/spine/base/UuidValue.java
@@ -52,8 +52,8 @@ import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
 public interface UuidValue<I extends Message> extends SerializableMessage {
 
     /**
-     * Obtains a {@code MessageClassifier} for types which define a single string {@code uuid}
-     * field.
+     * Obtains a {@code MessageClassifier} for types which define a single
+     * string field named {@code uuid}.
      */
     static MessageClassifier classifier() {
         return new UuidValueClassifier();

--- a/base/src/main/java/io/spine/logging/LoggerClassValue.java
+++ b/base/src/main/java/io/spine/logging/LoggerClassValue.java
@@ -62,7 +62,7 @@ class LoggerClassValue extends ClassValue<Logger> {
         this.muted = false;
     }
 
-    static Logger getFor(Class<?> cls) {
+    static Logger loggerOf(Class<?> cls) {
         return INSTANCE.get(cls);
     }
 

--- a/base/src/main/java/io/spine/logging/Logging.java
+++ b/base/src/main/java/io/spine/logging/Logging.java
@@ -32,6 +32,7 @@ import java.util.Queue;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.logging.LogMessages.logThrowable;
+import static io.spine.logging.LoggerClassValue.loggerOf;
 import static java.lang.String.format;
 
 /**
@@ -69,14 +70,14 @@ public interface Logging {
      * @apiNote The primary purpose of this method is to provide logging in static methods.
      */
     static Logger get(Class<?> cls) {
-        return LoggerClassValue.getFor(cls);
+        return loggerOf(cls);
     }
 
     /**
      * Obtains logger associated with the class of this instance.
      */
     default Logger log() {
-        return LoggerClassValue.getFor(getClass());
+        return loggerOf(getClass());
     }
 
     /**

--- a/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
+++ b/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
@@ -21,7 +21,6 @@
 package io.spine.reflect;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.reflect.Types.getArgument;
 
 /**
  * Base interface for enumerations on generic parameters of types.
@@ -76,8 +75,8 @@ public interface GenericTypeIndex<C> {
         // `GenericTypeIndex`.
         // The type cast is ensured by the declaration of the `GenericTypeIndex` interface.
         @SuppressWarnings("unchecked") Class<C> superclassOfPassed =
-                (Class<C>) getArgument(indexClass, GenericTypeIndex.class, 0);
-        Class<?> result = getArgument(cls, superclassOfPassed, getIndex());
+                (Class<C>) Types.argumentIn(indexClass, GenericTypeIndex.class, 0);
+        Class<?> result = Types.argumentIn(cls, superclassOfPassed, getIndex());
         return result;
     }
 }

--- a/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
+++ b/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
@@ -29,7 +29,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * <pre>
  * {@code
  * public abstract class Tuple<K, V> {
- *      ...
+ *     ...
  *     public enum GenericParameter extends GenericTypeIndex<Tuple> {
  *
  *         // <K> param has index 0
@@ -43,12 +43,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *         GenericParameter(int index) { this.index = index; }
  *
  *         {@literal @}Override
- *         public int getIndex() { return index; }
- *
- *         {@literal @}Override
- *         public Class<?> getArgumentIn(Class<? extends Tuple> derivedClass) {
- *             return Default.getArgument(this, derivedClass);
- *         }
+ *         public int index() { return index; }
  *     }
  * }
  * }
@@ -60,23 +55,25 @@ public interface GenericTypeIndex<C> {
     /**
      * Obtains a zero-based index of a generic parameter of a type.
      */
-    int getIndex();
+    int index();
 
     /**
      * Obtains the class of the generic type argument.
      *
-     * @param cls the class to inspect
+     * @param cls
+     *         the class to inspect
      * @return the argument class
+     * @implNote Obtain the super class of the passed one by inspecting the class which
+     *         implements {@code GenericTypeIndex}.
      */
     default Class<?> argumentIn(Class<? extends C> cls) {
         checkNotNull(cls);
         Class<? extends GenericTypeIndex> indexClass = getClass();
-        // Obtain the super class of the passed one by inspecting the class which implements
-        // `GenericTypeIndex`.
-        // The type cast is ensured by the declaration of the `GenericTypeIndex` interface.
-        @SuppressWarnings("unchecked") Class<C> superclassOfPassed =
-                (Class<C>) Types.argumentIn(indexClass, GenericTypeIndex.class, 0);
-        Class<?> result = Types.argumentIn(cls, superclassOfPassed, getIndex());
+        @SuppressWarnings("unchecked") /* The type cast is ensured by the declaration of
+            the `GenericTypeIndex` interface. */
+        Class<C> superclassOfPassed = (Class<C>)
+                Types.argumentIn(indexClass, GenericTypeIndex.class, 0);
+        Class<?> result = Types.argumentIn(cls, superclassOfPassed, index());
         return result;
     }
 }

--- a/base/src/main/java/io/spine/reflect/Types.java
+++ b/base/src/main/java/io/spine/reflect/Types.java
@@ -36,7 +36,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 /**
  * Utility class for working with {@code Type}s.
  */
-@SuppressWarnings("UnstableApiUsage") // Guava's Reflection tools will probably be OK.
 public final class Types {
 
     /** Prevents instantiation of this utility class. */
@@ -129,9 +128,8 @@ public final class Types {
      *         the type of superclass
      * @return the class of the generic type argument
      */
-    static <T> Class<?> getArgument(Class<? extends T> cls,
-                                    Class<T> genericSuperclass,
-                                    int argNumber) {
+    static
+    <T> Class<?> argumentIn(Class<? extends T> cls, Class<T> genericSuperclass, int argNumber) {
         checkNotNull(cls);
         checkNotNull(genericSuperclass);
         TypeToken<?> supertypeToken =

--- a/base/src/main/java/io/spine/string/Registrar.java
+++ b/base/src/main/java/io/spine/string/Registrar.java
@@ -50,7 +50,7 @@ public final class Registrar {
      * Registers stringifiers.
      */
     public void register() {
-        StringifierRegistry registry = StringifierRegistry.getInstance();
+        StringifierRegistry registry = StringifierRegistry.instance();
         stringifiers.forEach((stringifier) -> {
             Class<?> dataClass = getDataClass(stringifier.getClass());
             registry.register(stringifier, dataClass);

--- a/base/src/main/java/io/spine/string/StringifierRegistry.java
+++ b/base/src/main/java/io/spine/string/StringifierRegistry.java
@@ -66,13 +66,16 @@ public final class StringifierRegistry {
     private StringifierRegistry() {
     }
 
-    public static StringifierRegistry getInstance() {
+    /**
+     * Obtains the instance of the singleton registry.
+     */
+    public static StringifierRegistry instance() {
         return INSTANCE;
     }
 
     static <T> Stringifier<T> getStringifier(Type typeOfT) {
         checkNotNull(typeOfT);
-        Optional<Stringifier<T>> optional = getInstance().get(typeOfT);
+        Optional<Stringifier<T>> optional = instance().get(typeOfT);
 
         if (optional.isPresent()) {
             Stringifier<T> stringifier = optional.get();

--- a/base/src/main/java/io/spine/util/NamedProperty.java
+++ b/base/src/main/java/io/spine/util/NamedProperty.java
@@ -87,7 +87,7 @@ public abstract class NamedProperty<T, H> {
         }
 
         @Override
-        public int getIndex() {
+        public int index() {
             return this.index;
         }
     }

--- a/base/src/main/java/io/spine/util/SerializableConverter.java
+++ b/base/src/main/java/io/spine/util/SerializableConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.base.Converter;
+
+import java.io.Serializable;
+
+/**
+ * Abstract base for serializable converters.
+ *
+ * @see SerializableFunction
+ */
+public abstract class SerializableConverter<A, B>
+        extends Converter<A, B>
+        implements Serializable {
+
+    private static final long serialVersionUID = 0L;
+}

--- a/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/AbstractValidatingBuilder.java
@@ -384,7 +384,7 @@ public abstract class AbstractValidatingBuilder<T extends Message, B extends Mes
         }
 
         @Override
-        public int getIndex() {
+        public int index() {
             return this.index;
         }
     }

--- a/base/src/main/java/io/spine/validate/DigitsConstraint.java
+++ b/base/src/main/java/io/spine/validate/DigitsConstraint.java
@@ -26,7 +26,7 @@ import io.spine.base.FieldPath;
 import io.spine.option.DigitsOption;
 
 import static io.spine.protobuf.TypeConverter.toAny;
-import static io.spine.validate.FieldValidator.getErrorMsgFormat;
+import static io.spine.validate.FieldValidator.errorMsgFormat;
 
 /**
  * A numerical field constraint that limits the number of whole and decimal digits.
@@ -45,8 +45,9 @@ final class DigitsConstraint<V extends Number & Comparable>
 
     @Override
     boolean satisfies(FieldValue<V> value) {
-        int wholeDigitsMax = optionValue().getIntegerMax();
-        int fractionDigitsMax = optionValue().getFractionMax();
+        DigitsOption option = optionValue();
+        int wholeDigitsMax = option.getIntegerMax();
+        int fractionDigitsMax = option.getFractionMax();
         if (wholeDigitsMax < 1 || fractionDigitsMax < 1) {
             return true;
         }
@@ -76,9 +77,10 @@ final class DigitsConstraint<V extends Number & Comparable>
 
     @Override
     ImmutableList<ConstraintViolation> constraintViolated(FieldValue<V> value) {
-        String msg = getErrorMsgFormat(optionValue(), optionValue().getMsgFormat());
-        String intMax = String.valueOf(optionValue().getIntegerMax());
-        String fractionMax = String.valueOf(optionValue().getFractionMax());
+        DigitsOption option = optionValue();
+        String msg = errorMsgFormat(option, option.getMsgFormat());
+        String intMax = String.valueOf(option.getIntegerMax());
+        String fractionMax = String.valueOf(option.getFractionMax());
         FieldPath fieldPath = value.context()
                                    .fieldPath();
 

--- a/base/src/main/java/io/spine/validate/FieldValidator.java
+++ b/base/src/main/java/io/spine/validate/FieldValidator.java
@@ -218,7 +218,7 @@ abstract class FieldValidator<V> implements Logging {
 
     /** Returns an immutable list of the field values. */
     @SuppressWarnings("ReturnOfCollectionOrArrayField") // is immutable list
-    protected ImmutableList<V> getValues() {
+    protected ImmutableList<V> values() {
         return values;
     }
 
@@ -233,7 +233,7 @@ abstract class FieldValidator<V> implements Logging {
     }
 
     private ConstraintViolation newViolation(IfMissingOption option) {
-        String msg = getErrorMsgFormat(option, option.getMsgFormat());
+        String msg = errorMsgFormat(option, option.getMsgFormat());
         ConstraintViolation violation = ConstraintViolation
                 .newBuilder()
                 .setMsgFormat(msg)
@@ -243,14 +243,17 @@ abstract class FieldValidator<V> implements Logging {
     }
 
     /**
-     * Returns a validation error message (a custom one (if present) or the default one).
+     * Returns a validation error message, which may have formatting placeholders
+     *
+     * <p>A custom message is returned if it is present in the option. Otherwise,
+     * default message is returned.
      *
      * @param option
      *         a validation option used to get the default message
      * @param customMsg
      *         a user-defined error message
      */
-    static String getErrorMsgFormat(Message option, String customMsg) {
+    static String errorMsgFormat(Message option, String customMsg) {
         String defaultMsg = option.getDescriptorForType()
                                   .getOptions()
                                   .getExtension(OptionsProto.defaultMessage);

--- a/base/src/main/java/io/spine/validate/MessageFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidator.java
@@ -77,7 +77,7 @@ final class MessageFieldValidator<V extends Message> extends FieldValidator<V> {
 
     @SuppressWarnings("MethodOnlyUsedFromInnerClass") // Proper encapsulation here.
     private boolean isOfType(Class<? extends Message> type) {
-        ImmutableList<V> values = getValues();
+        ImmutableList<V> values = values();
         Message value = values.isEmpty()
                         ? null
                         : values.get(0);
@@ -86,13 +86,13 @@ final class MessageFieldValidator<V extends Message> extends FieldValidator<V> {
     }
 
     private void validateFields() {
-        for (Message value : getValues()) {
+        for (Message value : values()) {
             validateSingle(value);
         }
     }
 
     private void validateAny() {
-        for (Message value : getValues()) {
+        for (Message value : values()) {
             Any any = (Any) value;
             Message unpacked = AnyPacker.unpack(any);
             validateSingle(unpacked);
@@ -110,7 +110,7 @@ final class MessageFieldValidator<V extends Message> extends FieldValidator<V> {
     private ConstraintViolation newValidViolation(Message fieldValue,
                                                   Iterable<ConstraintViolation> violations) {
         IfInvalidOption ifInvalid = ifInvalid();
-        String msg = getErrorMsgFormat(ifInvalid, ifInvalid.getMsgFormat());
+        String msg = errorMsgFormat(ifInvalid, ifInvalid.getMsgFormat());
         ConstraintViolation violation = ConstraintViolation
                 .newBuilder()
                 .setMsgFormat(msg)

--- a/base/src/main/java/io/spine/validate/MessageValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageValidator.java
@@ -36,6 +36,7 @@ import java.util.List;
 public class MessageValidator {
 
     private final MessageValue message;
+    private final ImmutableList.Builder<ConstraintViolation> result = ImmutableList.builder();
 
     private MessageValidator(MessageValue message) {
         this.message = message;
@@ -67,14 +68,13 @@ public class MessageValidator {
      * violations found.
      */
     public List<ConstraintViolation> validate() {
-        ImmutableList.Builder<ConstraintViolation> result = ImmutableList.builder();
-        validateAlternativeFields(result);
-        validateOneofFields(result);
-        validateFields(result);
+        validateAlternativeFields();
+        validateOneofFields();
+        validateFields();
         return result.build();
     }
 
-    private void validateAlternativeFields(ImmutableList.Builder<ConstraintViolation> result) {
+    private void validateAlternativeFields() {
         AlternativeFieldValidator altFieldValidator = new AlternativeFieldValidator(message);
         result.addAll(altFieldValidator.validate());
     }
@@ -82,13 +82,11 @@ public class MessageValidator {
     /**
      * Validates fields except fields from {@code Oneof} declarations.
      *
-     * <p>{@code Oneof} fields are validated {@linkplain #validateOneofFields(ImmutableList.Builder)
+     * <p>{@code Oneof} fields are validated {@linkplain #validateOneofFields()
      * separately}.
      *
-     * @param result
-     *         the builder of the message violations
      */
-    private void validateFields(ImmutableList.Builder<ConstraintViolation> result) {
+    private void validateFields() {
         for (FieldValue value : message.fieldsExceptOneofs()) {
             FieldValidator<?> fieldValidator = value.createValidator();
             List<ConstraintViolation> violations = fieldValidator.validate();
@@ -99,10 +97,8 @@ public class MessageValidator {
     /**
      * Validates every {@code Oneof} declaration in the message.
      *
-     * @param result
-     *         the builder of the message violations
      */
-    private void validateOneofFields(ImmutableList.Builder<ConstraintViolation> result) {
+    private void validateOneofFields() {
         List<OneofDescriptor> oneofDescriptors = message.oneofDescriptors();
         for (OneofDescriptor oneof : oneofDescriptors) {
             OneofValidator validator = new OneofValidator(oneof, message);

--- a/base/src/main/java/io/spine/validate/MessageValue.java
+++ b/base/src/main/java/io/spine/validate/MessageValue.java
@@ -28,7 +28,6 @@ import com.google.protobuf.Message;
 import io.spine.code.proto.FieldContext;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -50,7 +49,7 @@ final class MessageValue {
         this.context = checkNotNull(context);
     }
 
-    final Descriptor descriptor(){
+    Descriptor descriptor(){
         return descriptor;
     }
 
@@ -121,13 +120,6 @@ final class MessageValue {
         checkArgument(oneofDescriptors().contains(oneof));
         FieldDescriptor field = message.getOneofFieldDescriptor(oneof);
         return valueOfNullable(field);
-    }
-
-    /** Returns options of the message. */
-    Map<FieldDescriptor, Object> options() {
-        Map<FieldDescriptor, Object> options = descriptor.getOptions()
-                                                         .getAllFields();
-        return options;
     }
 
     /** Returns descriptors of {@code Oneof} declarations in the message. */

--- a/base/src/main/java/io/spine/validate/PatternConstraint.java
+++ b/base/src/main/java/io/spine/validate/PatternConstraint.java
@@ -25,7 +25,7 @@ import io.spine.base.FieldPath;
 import io.spine.option.PatternOption;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static io.spine.validate.FieldValidator.getErrorMsgFormat;
+import static io.spine.validate.FieldValidator.errorMsgFormat;
 
 /**
  * A constraint that, when applied to a string field, checks whether that field matches the
@@ -50,7 +50,7 @@ final class PatternConstraint extends FieldValueConstraint<String, PatternOption
     }
 
     private ConstraintViolation newViolation(FieldValue<String> fieldValue) {
-        String msg = getErrorMsgFormat(optionValue(), optionValue().getMsgFormat());
+        String msg = errorMsgFormat(optionValue(), optionValue().getMsgFormat());
         FieldPath fieldPath = fieldValue.context()
                                         .fieldPath();
         String regex = optionValue().getRegex();

--- a/base/src/main/java/io/spine/validate/RequiredFieldConstraint.java
+++ b/base/src/main/java/io/spine/validate/RequiredFieldConstraint.java
@@ -57,7 +57,7 @@ final class RequiredFieldConstraint implements Constraint<MessageValue> {
         ImmutableList<RequiredFieldAlternatives> alternatives = parse(this.optionValue);
         if (!alternativeFound(alternatives, messageField)) {
             String msgFormat =
-                    "None of the fields match the `required_field` definition: %s";
+                    "None of the fields match the `required_field` definition: `%s`.";
             ConstraintViolation requiredFieldNotFound = ConstraintViolation
                     .newBuilder()
                     .setMsgFormat(msgFormat)

--- a/base/src/main/java/io/spine/validate/WhenConstraint.java
+++ b/base/src/main/java/io/spine/validate/WhenConstraint.java
@@ -27,12 +27,12 @@ import io.spine.base.FieldPath;
 import io.spine.option.Time;
 import io.spine.option.TimeOption;
 
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static io.spine.option.Time.FUTURE;
 import static io.spine.option.Time.TIME_UNDEFINED;
 import static io.spine.protobuf.AnyPacker.pack;
 import static io.spine.protobuf.Timestamps2.isLaterThan;
-import static io.spine.validate.FieldValidator.getErrorMsgFormat;
+import static io.spine.validate.FieldValidator.errorMsgFormat;
 
 /**
  * A constraint that, when applied to a {@link Timestamp} field value, checks for whether the
@@ -49,7 +49,7 @@ final class WhenConstraint extends FieldValueConstraint<Timestamp, TimeOption> {
         if (when == TIME_UNDEFINED) {
             return ImmutableList.of();
         }
-        Timestamp now = getCurrentTime();
+        Timestamp now = currentTime();
         for (Message value : fieldValue.asList()) {
             Timestamp time = (Timestamp) value;
             if (isTimeInvalid(time, when, now)) {
@@ -81,7 +81,7 @@ final class WhenConstraint extends FieldValueConstraint<Timestamp, TimeOption> {
 
     private ConstraintViolation newTimeViolation(FieldValue<Timestamp> fieldValue,
                                                  Timestamp value) {
-        String msg = getErrorMsgFormat(optionValue(), optionValue().getMsgFormat());
+        String msg = errorMsgFormat(optionValue(), optionValue().getMsgFormat());
         String when = optionValue().getIn()
                                       .toString()
                                       .toLowerCase();

--- a/base/src/test/java/io/spine/base/FieldPathsTest.java
+++ b/base/src/test/java/io/spine/base/FieldPathsTest.java
@@ -91,7 +91,7 @@ class FieldPathsTest extends UtilityClassTest<FieldPaths> {
     @Test
     @DisplayName("obtain value at a complex path")
     void obtainComplex() {
-        Any value = pack(Time.getCurrentTime());
+        Any value = pack(Time.currentTime());
         AnyHolder anyHolder = AnyHolder
                 .newBuilder()
                 .setVal(value)

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -149,28 +149,29 @@ class IdentifierTest {
         @Test
         @DisplayName("Integer")
         void ofInteger() {
-            assertEquals(0, Identifier.defaultValue(Integer.class)
-                                      .intValue());
+            assertThat(Identifier.defaultValue(Integer.class))
+                    .isEqualTo(0);
         }
 
         @Test
         @DisplayName("Long")
         void ofLong() {
-            assertEquals(0L, Identifier.defaultValue(Long.class)
-                                       .longValue());
+            assertThat(Identifier.defaultValue(Long.class))
+                    .isEqualTo(0L);
         }
 
         @Test
         @DisplayName("String")
         void ofString() {
-            assertEquals("", Identifier.defaultValue(String.class));
+            assertThat(Identifier.defaultValue(String.class))
+                    .isEmpty();
         }
 
         @Test
         @DisplayName("Message")
         void ofMessage() {
-            assertEquals(Timestamp.getDefaultInstance(),
-                         Identifier.defaultValue(Timestamp.class));
+            assertThat(Identifier.defaultValue(Timestamp.class))
+                    .isEqualTo(Timestamp.getDefaultInstance());
         }
     }
 
@@ -181,22 +182,26 @@ class IdentifierTest {
         @Test
         @DisplayName("empty string")
         void emptyString() {
-            assertEquals(EMPTY_ID, Identifier.toString(""));
+            assertEmpty("");
         }
 
         @Test
         @DisplayName("a Message with the default value")
         void defaultInstance() {
-            assertEquals(EMPTY_ID, Identifier.toString(StringValue.getDefaultInstance()));
+            assertEmpty(StringValue.getDefaultInstance());
         }
 
         @Test
         @DisplayName("a Message with a field of Message type, which has the default value")
         void defaultNestedMessage() {
-            assertEquals(EMPTY_ID, Identifier.toString(TimestampFieldId.getDefaultInstance()));
+            assertEmpty(TimestampFieldId.getDefaultInstance());
+        }
+
+        private void assertEmpty(Object id) {
+            String str = Identifier.toString(id);
+            assertThat(str).isEqualTo(EMPTY_ID);
         }
     }
-
 
     @Nested
     @DisplayName("verify if ID is empty")

--- a/base/src/test/java/io/spine/base/ThrowableMessageTest.java
+++ b/base/src/test/java/io/spine/base/ThrowableMessageTest.java
@@ -57,13 +57,13 @@ class ThrowableMessageTest {
     @Test
     @DisplayName("return the thrown message")
     void return_message_thrown() {
-        assertEquals(message, throwableMessage.getMessageThrown());
+        assertEquals(message, throwableMessage.messageThrown());
     }
 
     @Test
     @DisplayName("have timestamp")
     void have_timestamp() {
-        assertTrue(Timestamps.isValid(throwableMessage.getTimestamp()));
+        assertTrue(Timestamps.isValid(throwableMessage.timestamp()));
     }
 
     @Test

--- a/base/src/test/java/io/spine/base/TimeTest.java
+++ b/base/src/test/java/io/spine/base/TimeTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.protobuf.util.Timestamps.subtract;
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static io.spine.base.Time.resetProvider;
 import static io.spine.base.Time.setProvider;
 import static io.spine.base.Time.systemTime;
@@ -53,7 +53,7 @@ class TimeTest {
     @Test
     @DisplayName("accept TimeProvider")
     void acceptProvider() {
-        Timestamp fiveMinutesAgo = subtract(getCurrentTime(), DURATION_5_MINUTES);
+        Timestamp fiveMinutesAgo = subtract(currentTime(), DURATION_5_MINUTES);
 
         setProvider(new ConstantTimeProvider(fiveMinutesAgo));
 
@@ -61,7 +61,7 @@ class TimeTest {
     }
 
     private static Subject<DefaultSubject, Object> assertCurrentTime() {
-        return assertThat(getCurrentTime());
+        return assertThat(currentTime());
     }
 
     @Test

--- a/base/src/test/java/io/spine/base/given/ConstantTimeProvider.java
+++ b/base/src/test/java/io/spine/base/given/ConstantTimeProvider.java
@@ -37,7 +37,7 @@ public class ConstantTimeProvider implements Time.Provider {
     }
 
     @Override
-    public Timestamp getCurrentTime() {
+    public Timestamp currentTime() {
         return timestamp;
     }
 }

--- a/base/src/test/java/io/spine/net/string/NetStringifiersTest.java
+++ b/base/src/test/java/io/spine/net/string/NetStringifiersTest.java
@@ -53,7 +53,7 @@ class NetStringifiersTest extends UtilityClassTest<NetStringifiers> {
     }
 
     private static <T> void assertRegistered(Stringifier<T> stringifier, Class<T> cls) {
-        Optional<Stringifier<T>> optional = StringifierRegistry.getInstance()
+        Optional<Stringifier<T>> optional = StringifierRegistry.instance()
                                                                .get(cls);
         Truth8.assertThat(optional).hasValue(stringifier);
     }
@@ -81,7 +81,7 @@ class NetStringifiersTest extends UtilityClassTest<NetStringifiers> {
         }
 
         <T> void assertStringifier(Class<T> cls, String value) {
-            Optional<Stringifier<T>> optional = StringifierRegistry.getInstance()
+            Optional<Stringifier<T>> optional = StringifierRegistry.instance()
                                                                    .get(cls);
             Truth8.assertThat(optional).isPresent();
 

--- a/base/src/test/java/io/spine/protobuf/AttributeTest.java
+++ b/base/src/test/java/io/spine/protobuf/AttributeTest.java
@@ -54,7 +54,7 @@ class AttributeTest {
 
         boolAttr.setValue(builder, Boolean.TRUE);
         longAttr.setValue(builder, LONG_VAL);
-        timestampAttr.setValue(builder, Time.getCurrentTime());
+        timestampAttr.setValue(builder, Time.currentTime());
 
         msg = builder.build();
     }

--- a/base/src/test/java/io/spine/protobuf/MessageFieldExceptionTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldExceptionTest.java
@@ -58,7 +58,7 @@ class MessageFieldExceptionTest {
     @Test
     @DisplayName("contain an instance without text")
     void contains_instance_without_text() {
-        Timestamp protobufMessage = Time.getCurrentTime();
+        Timestamp protobufMessage = Time.currentTime();
         MessageFieldException exception = new MessageFieldException(protobufMessage);
 
         assertEquals(protobufMessage, exception.getProtobufMessage());

--- a/base/src/test/java/io/spine/protobuf/MessagesTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessagesTest.java
@@ -58,7 +58,7 @@ class MessagesTest extends UtilityClassTest<Messages> {
     @Test
     @DisplayName("pack to Any")
     void packToAny() {
-        Timestamp timestamp = Time.getCurrentTime();
+        Timestamp timestamp = Time.currentTime();
         assertEquals(timestamp, unpack(AnyPacker.pack(timestamp)));
     }
 

--- a/base/src/test/java/io/spine/protobuf/Timestamps2Test.java
+++ b/base/src/test/java/io/spine/protobuf/Timestamps2Test.java
@@ -35,7 +35,7 @@ import java.time.Instant;
 import static com.google.protobuf.util.Durations.fromSeconds;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static io.spine.protobuf.Timestamps2.fromInstant;
 import static io.spine.protobuf.Timestamps2.isLaterThan;
 import static io.spine.protobuf.Timestamps2.toInstant;
@@ -54,7 +54,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
 
     @Override
     protected void configure(NullPointerTester nullTester) {
-        nullTester.setDefault(Timestamp.class, Time.getCurrentTime())
+        nullTester.setDefault(Timestamp.class, Time.currentTime())
                   .setDefault(Instant.class, Instant.now());
     }
 
@@ -65,7 +65,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
         @Test
         @DisplayName("between two others")
         void isBetween() {
-            Timestamp start = getCurrentTime();
+            Timestamp start = currentTime();
             Timestamp timeBetween = add(start, TEN_SECONDS);
             Timestamp finish = add(timeBetween, TEN_SECONDS);
 
@@ -77,7 +77,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
         @Test
         @DisplayName("not between two others")
         void isNotBetween() {
-            Timestamp start = getCurrentTime();
+            Timestamp start = currentTime();
             Timestamp finish = add(start, TEN_SECONDS);
             Timestamp timeNotBetween = add(finish, TEN_SECONDS);
 
@@ -94,7 +94,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
         @Test
         @DisplayName("later than another")
         void isLater() {
-            Timestamp fromPoint = getCurrentTime();
+            Timestamp fromPoint = currentTime();
             Timestamp timeToCheck = add(fromPoint, TEN_SECONDS);
 
             boolean isAfter = isLaterThan(timeToCheck, fromPoint);
@@ -105,7 +105,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
         @Test
         @DisplayName("not later than another")
         void isNotLater() {
-            Timestamp fromPoint = getCurrentTime();
+            Timestamp fromPoint = currentTime();
             Timestamp timeToCheck = subtract(fromPoint, TEN_SECONDS);
 
             boolean isAfter = isLaterThan(timeToCheck, fromPoint);
@@ -122,7 +122,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
     @Test
     @DisplayName("convert Timestamp to Instant")
     void convertToInstant() {
-        Timestamp timestamp = Time.getCurrentTime();
+        Timestamp timestamp = Time.currentTime();
         Instant instant = toInstant(timestamp);
 
         assertEqual(timestamp, instant);
@@ -140,7 +140,7 @@ class Timestamps2Test extends UtilityClassTest<Timestamps2> {
     @Test
     @DisplayName("provide converter to Instant")
     void converterToInstant() {
-        Timestamp timestamp = Time.getCurrentTime();
+        Timestamp timestamp = Time.currentTime();
         Converter<Timestamp, Instant> converter = Timestamps2.converter()
                                                              .reverse();
         Instant instant = converter.convert(timestamp);

--- a/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
+++ b/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
@@ -32,15 +32,15 @@ class GenericTypeIndexTest {
     @DisplayName("obtain generic argument assuming generic superclass")
     void obtain_generic_argument_assuming_generic_superclass() {
         Parametrized<Long, String> val = new Parametrized<Long, String>() {};
-        assertEquals(Long.class, Types.getArgument(val.getClass(), Base.class, 0));
-        assertEquals(String.class, Types.getArgument(val.getClass(), Base.class, 1));
+        assertEquals(Long.class, Types.argumentIn(val.getClass(), Base.class, 0));
+        assertEquals(String.class, Types.argumentIn(val.getClass(), Base.class, 1));
     }
 
     @Test
     @DisplayName("obtain generic argument via superclass")
     void obtain_generic_argument_via_superclass() {
-        assertEquals(String.class, Types.getArgument(Leaf.class, Base.class, 0));
-        assertEquals(Float.class, Types.getArgument(Leaf.class, Base.class, 1));
+        assertEquals(String.class, Types.argumentIn(Leaf.class, Base.class, 0));
+        assertEquals(Float.class, Types.argumentIn(Leaf.class, Base.class, 1));
     }
 
     @SuppressWarnings({"EmptyClass", "unused"})

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -36,14 +36,14 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.reflect.Types.getArgument;
+import static io.spine.reflect.Types.argumentIn;
 import static io.spine.reflect.Types.listTypeOf;
 import static io.spine.reflect.Types.mapTypeOf;
 import static io.spine.reflect.Types.resolveArguments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings({"SerializableNonStaticInnerClassWithoutSerialVersionUID",
-        "SerializableInnerClassWithNonSerializableOuterClass"}) // It is OK for test methods.
+        "SerializableInnerClassWithNonSerializableOuterClass"}) // OK when using TypeToken.
 @DisplayName("Types utility class should")
 class TypesTest extends UtilityClassTest<Types> {
 
@@ -86,7 +86,7 @@ class TypesTest extends UtilityClassTest<Types> {
     @Test
     @DisplayName("obtain type argument value from the inheritance chain")
     void getTypeArgument() {
-        Class<?> argument = getArgument(ListOfMessages.class, Iterable.class, 0);
+        Class<?> argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
         assertEquals(argument, Message.class);
     }
 
@@ -96,6 +96,9 @@ class TypesTest extends UtilityClassTest<Types> {
         tester.testStaticMethods(Types.class, NullPointerTester.Visibility.PACKAGE);
     }
 
+    /**
+     * Stub class for testing obtaining generic argument.
+     */
     @SuppressWarnings({"serial", "ClassExtendsConcreteCollection"})
     private static class ListOfMessages extends ArrayList<Message> {
     }

--- a/base/src/test/java/io/spine/string/AbstractStringifierTest.java
+++ b/base/src/test/java/io/spine/string/AbstractStringifierTest.java
@@ -92,7 +92,7 @@ abstract class AbstractStringifierTest<T> {
     @Test
     @DisplayName("be registered")
     void isRegistered() {
-        assertTrue(StringifierRegistry.getInstance()
+        assertTrue(StringifierRegistry.instance()
                                       .get(dataClass)
                                       .isPresent());
     }

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -89,7 +89,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         private ImmutableList<Timestamp> createList() {
             ImmutableList.Builder<Timestamp> builder = ImmutableList.builder();
             for (int i = 0; i < SIZE; i++) {
-                builder.add(Time.getCurrentTime());
+                builder.add(Time.currentTime());
             }
             return builder.build();
         }
@@ -97,7 +97,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         private ImmutableMap<Long, Timestamp> createMap() {
             ImmutableMap.Builder<Long, Timestamp> builder = ImmutableMap.builder();
             for (int i = 0; i < SIZE; i++) {
-                Timestamp t = Time.getCurrentTime();
+                Timestamp t = Time.currentTime();
                 builder.put((long) i, t);
             }
             return builder.build();

--- a/base/src/test/java/io/spine/string/TimestampStringifierTest.java
+++ b/base/src/test/java/io/spine/string/TimestampStringifierTest.java
@@ -24,7 +24,7 @@ import com.google.protobuf.Timestamp;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @DisplayName("TimestampStringifier should")
@@ -36,14 +36,14 @@ class TimestampStringifierTest extends AbstractStringifierTest<Timestamp> {
 
     @Override
     protected Timestamp createObject() {
-        return getCurrentTime();
+        return currentTime();
     }
 
     @Test
     @DisplayName("Throw IllegalArgumentException when parsing unsupported format")
     void parsingError() {
         // This uses TextFormat printing, for the output which won't be parsable.
-        String time = getCurrentTime().toString();
+        String time = currentTime().toString();
         assertThrows(
                 IllegalArgumentException.class,
                 () -> Stringifiers.fromString(time, Timestamp.class)

--- a/base/src/test/java/io/spine/util/SerializableConverterTest.java
+++ b/base/src/test/java/io/spine/util/SerializableConverterTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.testing.SerializableTester;
+import com.google.protobuf.Timestamp;
+import com.google.protobuf.util.Timestamps;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+
+@DisplayName("SerializableConverter should")
+class SerializableConverterTest {
+
+    @Test
+    @DisplayName("serialize")
+    void serialize() {
+        SerializableTester.reserialize(new StubSerializer());
+    }
+
+    private static class StubSerializer extends SerializableConverter<Timestamp, String> {
+
+        private static final long serialVersionUID = 0L;
+
+        @Override
+        protected String doForward(Timestamp timestamp) {
+            return Timestamps.toString(timestamp);
+        }
+
+        @Override
+        protected Timestamp doBackward(String s) {
+            try {
+                return Timestamps.parse(s);
+            } catch (ParseException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+    }
+}

--- a/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
+++ b/base/src/test/java/io/spine/validate/AbstractValidatingBuilderTest.java
@@ -171,7 +171,7 @@ class AbstractValidatingBuilderTest {
             @Test
             @DisplayName("of messages")
             void toMessageList() {
-                Timestamp now = Time.getCurrentTime();
+                Timestamp now = Time.currentTime();
                 Timestamp soon = Timestamps.add(now, Durations2.minutes(5));
                 ImmutableList<Timestamp> times = ImmutableList.of(now, soon);
                 String str = createInput(times);

--- a/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
+++ b/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
@@ -33,7 +33,6 @@ import io.spine.validate.ConstraintViolation;
 import static com.google.protobuf.util.Timestamps.add;
 import static com.google.protobuf.util.Timestamps.subtract;
 import static io.spine.base.Identifier.newUuid;
-import static io.spine.base.Time.getCurrentTime;
 import static io.spine.base.Time.setProvider;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -69,7 +68,7 @@ public class MessageValidatorTestEnv {
     }
 
     public static Timestamp currentTimeWithNanos(int nanos) {
-        Timestamp result = timeWithNanos(getCurrentTime(), nanos);
+        Timestamp result = timeWithNanos(Time.currentTime(), nanos);
         return result;
     }
 
@@ -93,7 +92,7 @@ public class MessageValidatorTestEnv {
      * Freezes time for current thread by setting the time provider to a 
      * {@link ConstantTimeProvider}.
      *
-     * @param time time to be returned upon {@link Time#getCurrentTime()} call. 
+     * @param time time to be returned upon {@link Time#currentTime()} call.
      */
     public static void freezeTime(Timestamp time) {
         Time.Provider frozenTimeProvider = new ConstantTimeProvider(time);
@@ -108,12 +107,12 @@ public class MessageValidatorTestEnv {
     }
 
     public static Timestamp getFuture() {
-        Timestamp future = add(getCurrentTime(), newDuration(SECONDS_IN_5_MINUTES));
+        Timestamp future = add(Time.currentTime(), newDuration(SECONDS_IN_5_MINUTES));
         return future;
     }
 
     public static Timestamp getPast() {
-        Timestamp past = subtract(getCurrentTime(), newDuration(SECONDS_IN_5_MINUTES));
+        Timestamp past = subtract(Time.currentTime(), newDuration(SECONDS_IN_5_MINUTES));
         return past;
     }
 
@@ -137,7 +136,7 @@ public class MessageValidatorTestEnv {
         }
 
         @Override
-        public Timestamp getCurrentTime() {
+        public Timestamp currentTime() {
             return timestamp;
         }
     }

--- a/testlib/src/main/java/io/spine/testing/TestValues.java
+++ b/testlib/src/main/java/io/spine/testing/TestValues.java
@@ -44,9 +44,6 @@ public final class TestValues {
 
     /**
      * Generates a {@code StringValue} with generated UUID.
-     *
-     * <p>Use this method when you need to generate a test {@code Message} value
-     * but do not want to resort to {@code Timestamp} via {@code Timestamps#getCurrentTime()}.
      */
     public static StringValue newUuidValue() {
         String id = randomString();
@@ -67,6 +64,14 @@ public final class TestValues {
      */
     public static int random(int min, int max) {
         int randomNum = ThreadLocalRandom.current().nextInt(min, max);
+        return randomNum;
+    }
+
+    /**
+     * Generates a random long value in the range [min, max).
+     */
+    public static long longRandom(long min, long max) {
+        long randomNum = ThreadLocalRandom.current().nextLong(min, max);
         return randomNum;
     }
 }

--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/rejection/RejectionWriter.java
@@ -50,7 +50,7 @@ import static javax.lang.model.element.Modifier.STATIC;
  */
 public class RejectionWriter implements Logging {
 
-    private static final NoArgMethod getMessageThrown = new NoArgMethod("getMessageThrown");
+    private static final NoArgMethod messageThrown = new NoArgMethod("messageThrown");
 
     private final RejectionType declaration;
     private final ClassName messageClass;
@@ -97,7 +97,7 @@ public class RejectionWriter implements Logging {
                             .superclass(ThrowableMessage.class)
                             .addField(serialVersionUID())
                             .addMethod(constructor())
-                            .addMethod(getMessageThrown())
+                            .addMethod(messageThrown())
                             .addMethod(builder.newBuilder())
                             .addType(builder.typeDeclaration())
                             .build();
@@ -129,11 +129,11 @@ public class RejectionWriter implements Logging {
                 .build();
     }
 
-    private MethodSpec getMessageThrown() {
-        String methodSignature = getMessageThrown.signature();
+    private MethodSpec messageThrown() {
+        String methodSignature = messageThrown.signature();
         _debug("Constructing method {}", methodSignature);
         ClassName returnType = messageClass;
-        return MethodSpec.methodBuilder(getMessageThrown.name())
+        return MethodSpec.methodBuilder(messageThrown.name())
                          .addAnnotation(Override.class)
                          .addModifiers(PUBLIC)
                          .returns(returnType)

--- a/tools/smoke-tests/rejection-tests/src/test/java/io/spine/tools/gradle/compiler/RejectionPluginTest.java
+++ b/tools/smoke-tests/rejection-tests/src/test/java/io/spine/tools/gradle/compiler/RejectionPluginTest.java
@@ -37,10 +37,11 @@ class RejectionPluginTest {
     @DisplayName("generate a rejection, which extends ThrowableMessage")
     void generate() {
         String username = Identifier.newUuid();
-        CannotUpdateUsername rejection = CannotUpdateUsername.newBuilder()
-                                                             .setUsername(username)
-                                                             .build();
-        Rejections.CannotUpdateUsername rejectionMessage = rejection.getMessageThrown();
+        CannotUpdateUsername rejection = CannotUpdateUsername
+                .newBuilder()
+                .setUsername(username)
+                .build();
+        Rejections.CannotUpdateUsername rejectionMessage = rejection.messageThrown();
         assertEquals(username, rejectionMessage.getUsername());
     }
 

--- a/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
+++ b/tools/smoke-tests/validation-tests/src/test/java/io/spine/test/validate/ValidatingBuilderTest.java
@@ -69,7 +69,7 @@ import static com.google.protobuf.ByteString.copyFrom;
 import static com.google.protobuf.util.Durations.fromSeconds;
 import static com.google.protobuf.util.Timestamps.add;
 import static io.spine.base.Identifier.newUuid;
-import static io.spine.base.Time.getCurrentTime;
+import static io.spine.base.Time.currentTime;
 import static io.spine.test.validate.msg.builder.TaskLabel.CRITICAL;
 import static io.spine.test.validate.msg.builder.TaskLabel.IMPORTANT;
 import static io.spine.test.validate.msg.builder.TaskLabel.OF_LITTLE_IMPORTANCE;
@@ -500,11 +500,11 @@ class ValidatingBuilderTest {
     }
 
     private static Timestamp timeInPast() {
-        return add(getCurrentTime(), fromSeconds(-1000L));
+        return add(currentTime(), fromSeconds(-1000L));
     }
 
     private static Timestamp timeInFuture() {
-        return add(getCurrentTime(), fromSeconds(1000L));
+        return add(currentTime(), fromSeconds(1000L));
     }
 
     private static double safeOdds() {


### PR DESCRIPTION
This PR improves method names, eliminating `get` prefix in non-generated API.

Also `SerializableConverter` abstract class is introduced.
