### PR TITLE
Update the reference to `config` to grab the forced Gradle Protobuf plugin version

### DIFF
--- a/base/src/main/java/io/spine/reflect/PackageGraph.java
+++ b/base/src/main/java/io/spine/reflect/PackageGraph.java
@@ -226,6 +226,11 @@ public final class PackageGraph implements Graph<PackageInfo> {
         return impl.hasEdgeConnecting(nodeU, nodeV);
     }
 
+    @Override
+    public boolean hasEdgeConnecting(EndpointPair<PackageInfo> endpoints) {
+        return impl.hasEdgeConnecting(endpoints);
+    }
+
     private static void checkNotNullOrEmpty(String packagePrefix) {
         checkNotNull(packagePrefix);
         checkArgument(!packagePrefix.isEmpty(), "Package prefix cannot be empty");


### PR DESCRIPTION
This PR updates the `config` submodule reference to the latest one — in order to grab all the latest dependency updates.

Also, it updates the `PackageGraph` to the latest Guava API.