### PR TITLE
Fix OneofValidator

### DIFF
--- a/base/src/main/java/io/spine/validate/FieldValidator.java
+++ b/base/src/main/java/io/spine/validate/FieldValidator.java
@@ -170,8 +170,8 @@ abstract class FieldValidator<V> implements Logging {
                 fieldValidatingOptions.stream()
                                       .filter(option -> option.shouldValidate(descriptor()))
                                       .map(option -> option.constraintFor(value))
-                                      .flatMap(constraint -> constraint.check(value)
-                                                                       .stream())
+                                      .map(constraint -> constraint.check(value))
+                                      .flatMap(List::stream)
                                       .collect(toList());
         return violations;
     }

--- a/base/src/main/java/io/spine/validate/RequiredFieldConstraint.java
+++ b/base/src/main/java/io/spine/validate/RequiredFieldConstraint.java
@@ -39,14 +39,14 @@ final class RequiredFieldConstraint implements Constraint<MessageValue> {
     private static final Pattern WHITESPACE = Pattern.compile("\\s+");
 
     /**
-     * Splits field name (or field combination) options.
+     * Splits Protobuf field names separated with a logical disjunction (OR) literal {@literal |}.
      */
-    private static final Splitter optionSeparator = Splitter.on('|');
+    private static final Splitter orSplitter = Splitter.on('|');
 
     /**
-     * Splits fields combination within the option.
+     * Splits Protobuf field names separated with a logical conjunction (AND) literal {@literal &}.
      */
-    private static final Splitter fieldsCombinationSeparator = Splitter.on('&');
+    private static final Splitter andSplitter = Splitter.on('&');
 
     private final String optionValue;
 
@@ -95,17 +95,17 @@ final class RequiredFieldConstraint implements Constraint<MessageValue> {
             return new RequiredFieldAlternatives(fieldNames);
         }
 
-        private static RequiredFieldAlternatives ofCombination(CharSequence expression) {
-            Iterable<String> parts = fieldsCombinationSeparator.split(expression);
+        private static RequiredFieldAlternatives ofCombination(String expression) {
+            Iterable<String> parts = andSplitter.split(expression);
             return ofCombination(ImmutableList.copyOf(parts));
         }
     }
 
-    private static ImmutableList<RequiredFieldAlternatives> parse(CharSequence expression) {
+    private static ImmutableList<RequiredFieldAlternatives> parse(String expression) {
         ImmutableList.Builder<RequiredFieldAlternatives> alternatives = ImmutableList.builder();
         String whiteSpaceRemoved = WHITESPACE.matcher(expression)
                                              .replaceAll("");
-        Iterable<String> parts = optionSeparator.split(whiteSpaceRemoved);
+        Iterable<String> parts = orSplitter.split(whiteSpaceRemoved);
         for (String part : parts) {
             alternatives.add(RequiredFieldAlternatives.ofCombination(part));
         }

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -61,7 +61,16 @@ abstract class MessageValidatorTest {
         assertIsValid(false);
     }
 
+    void assertNotValid(Message msg, boolean checkFieldPath) {
+        validate(msg);
+        assertIsValid(false, checkFieldPath);
+    }
+
     void assertIsValid(boolean isValid) {
+        assertIsValid(isValid, true);
+    }
+
+    void assertIsValid(boolean isValid, boolean checkFieldPath) {
         if (isValid) {
             assertTrue(violations.isEmpty(), () -> violations.toString());
         } else {
@@ -76,9 +85,11 @@ abstract class MessageValidatorTest {
                 } else {
                     assertTrue(noParams);
                 }
-                assertFalse(violation.getFieldPath()
-                                     .getFieldNameList()
-                                     .isEmpty());
+                if (checkFieldPath) {
+                    assertFalse(violation.getFieldPath()
+                                         .getFieldNameList()
+                                         .isEmpty());
+                }
             }
         }
     }

--- a/base/src/test/java/io/spine/validate/MessageValidatorTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValidatorTest.java
@@ -74,24 +74,37 @@ abstract class MessageValidatorTest {
         if (isValid) {
             assertTrue(violations.isEmpty(), () -> violations.toString());
         } else {
-            assertFalse(violations.isEmpty());
-            for (ConstraintViolation violation : violations) {
-                String format = violation.getMsgFormat();
-                assertTrue(!format.isEmpty());
-                boolean noParams = violation.getParamList()
-                                            .isEmpty();
-                if (format.contains("%s")) {
-                    assertFalse(noParams);
-                } else {
-                    assertTrue(noParams);
-                }
-                if (checkFieldPath) {
-                    assertFalse(violation.getFieldPath()
-                                         .getFieldNameList()
-                                         .isEmpty());
-                }
+            assertViolations(violations, checkFieldPath);
+        }
+    }
+
+    private static void assertViolations(List<ConstraintViolation> violations,
+                                         boolean checkFieldPath) {
+        assertFalse(violations.isEmpty());
+        for (ConstraintViolation violation : violations) {
+            assertHasCorrectFormat(violation);
+            if (checkFieldPath) {
+                assertHasFieldPath(violation);
             }
         }
+    }
+
+    private static void assertHasCorrectFormat(ConstraintViolation violation) {
+        String format = violation.getMsgFormat();
+        assertTrue(!format.isEmpty());
+        boolean noParams = violation.getParamList()
+                                    .isEmpty();
+        if (format.contains("%s")) {
+            assertFalse(noParams);
+        } else {
+            assertTrue(noParams);
+        }
+    }
+
+    private static void assertHasFieldPath(ConstraintViolation violation) {
+        assertFalse(violation.getFieldPath()
+                             .getFieldNameList()
+                             .isEmpty());
     }
 
     void assertSingleViolation(Message message,

--- a/base/src/test/java/io/spine/validate/OneofTest.java
+++ b/base/src/test/java/io/spine/validate/OneofTest.java
@@ -20,54 +20,142 @@
 
 package io.spine.validate;
 
-import io.spine.test.validate.oneof.EveryOptional;
-import io.spine.test.validate.oneof.EveryRequired;
-import io.spine.test.validate.oneof.OneRequired;
+import io.spine.test.validate.oneof.OneofAndOtherAreRequired;
+import io.spine.test.validate.oneof.OneofWithOptionalFields;
+import io.spine.test.validate.oneof.OneofWithRequiredFields;
+import io.spine.test.validate.oneof.OneofWithValidation;
+import io.spine.test.validate.oneof.RequiredOneofWithValidation;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.validate.MessageValidatorTest.MESSAGE_VALIDATOR_SHOULD;
 
 @DisplayName(MESSAGE_VALIDATOR_SHOULD + "consider Oneof")
-class OneofTest extends MessageValidatorTest {
+final class OneofTest extends MessageValidatorTest {
 
-    @Test
-    @DisplayName("valid if a required field is set to a non-default value")
-    void validIfRequireFieldIsNotDefault() {
-        EveryRequired requiredIsNotDefault = EveryRequired
-                .newBuilder()
-                .setFirst(newUuid())
-                .build();
-        assertValid(requiredIsNotDefault);
+    @DisplayName("valid if")
+    @Nested
+    final class Valid {
+
+        @Test
+        @DisplayName("a required field is set to a non-default value")
+        void requiredFieldIsNotDefault() {
+            OneofWithRequiredFields requiredIsSet = OneofWithRequiredFields
+                    .newBuilder()
+                    .setFirst(newUuid())
+                    .build();
+            assertValid(requiredIsSet);
+        }
+
+        @Test
+        @DisplayName("all required fields are set")
+        void allRequiredFieldsAreNotDefault() {
+            OneofAndOtherAreRequired requiredAreSet = OneofAndOtherAreRequired
+                    .newBuilder()
+                    .setSecond(newUuid())
+                    .setThird(newUuid())
+                    .build();
+            assertValid(requiredAreSet);
+        }
+
+        @Test
+        @DisplayName("an optional field is set to the default value")
+        void optionalIsDefault() {
+            OneofWithOptionalFields optionalIsDefault = OneofWithOptionalFields
+                    .newBuilder()
+                    .setFirst("")
+                    .build();
+            assertValid(optionalIsDefault);
+            assertValid(OneofWithOptionalFields.getDefaultInstance());
+        }
+
+        @Test
+        @DisplayName("an optional field is properly validated")
+        void optionalIsValid() {
+            OneofWithValidation validFieldSet = OneofWithValidation
+                    .newBuilder()
+                    .setWithValidation("valid")
+                    .build();
+            assertValid(validFieldSet);
+        }
+
+        @Test
+        @DisplayName("an optional validated field is is default")
+        void optionalFieldWithValidationIsDefault() {
+            assertValid(OneofWithValidation.getDefaultInstance());
+        }
+
+        @Test
+        @DisplayName("an optional field without validation is set")
+        void optionalFieldWithoutValidationSet() {
+            OneofWithValidation fieldWithoutValidationSet = OneofWithValidation
+                    .newBuilder()
+                    .setNoValidation("does not require validation")
+                    .build();
+            assertValid(fieldWithoutValidationSet);
+        }
+
+        @Test
+        @DisplayName("a required field without validation is set")
+        void requiredNonValidatedFieldSet() {
+            RequiredOneofWithValidation requiredWithoutValidationSet = RequiredOneofWithValidation
+                    .newBuilder()
+                    .setRawValue(-1)
+                    .build();
+            assertValid(requiredWithoutValidationSet);
+        }
+
+        @Test
+        @DisplayName("a required field with validation is set")
+        void requiredValidatedFieldSet() {
+            RequiredOneofWithValidation requiredWithValidationSet = RequiredOneofWithValidation
+                    .newBuilder()
+                    .setValidValue(1)
+                    .build();
+            assertValid(requiredWithValidationSet);
+        }
     }
 
-    @Test
-    @DisplayName("invalid if a required field is set to the default value")
-    void invalidIfRequireFieldIsDefault() {
-        EveryRequired requiredIsDefault = EveryRequired
-                .newBuilder()
-                .setFirst("")
-                .build();
-        assertNotValid(requiredIsDefault);
-    }
+    @DisplayName("invalid if")
+    @Nested
+    final class Invalid {
 
-    @Test
-    @DisplayName("valid if a non-required field is set to the default value")
-    void validIfOptionalIsDefault() {
-        OneRequired optionalIsDefault = OneRequired
-                .newBuilder()
-                .setOptional("")
-                .build();
-        assertValid(optionalIsDefault);
-    }
+        @Test
+        @DisplayName("a required field is set to the default value")
+        void requiredFieldIsDefault() {
+            OneofWithRequiredFields requiredIsDefault = OneofWithRequiredFields
+                    .newBuilder()
+                    .setFirst("")
+                    .build();
+            assertNotValid(requiredIsDefault, false);
+        }
 
-    @Test
-    @DisplayName("invalid if all fields are optional, but none is set")
-    void invalidIfNoneIsSet() {
-        EveryOptional noneIsSet = EveryOptional
-                .newBuilder()
-                .build();
-        assertNotValid(noneIsSet);
+        @Test
+        @DisplayName("a field within oneof is not valid")
+        void fieldIsNotValid() {
+            OneofWithValidation validFieldSet = OneofWithValidation
+                    .newBuilder()
+                    .setWithValidation("   ")
+                    .build();
+            assertNotValid(validFieldSet);
+        }
+
+        @Test
+        @DisplayName("a required field is not set")
+        void requiredFieldNotSet() {
+            assertNotValid(OneofWithRequiredFields.getDefaultInstance(), false);
+        }
+
+        @Test
+        @DisplayName("a required field is not valid")
+        void requiredFieldIsNotValid() {
+            RequiredOneofWithValidation requiredWithValidationSet = RequiredOneofWithValidation
+                    .newBuilder()
+                    .setValidValue(0)
+                    .build();
+            assertNotValid(requiredWithValidationSet);
+        }
     }
 }

--- a/base/src/test/java/io/spine/validate/RequiredFieldTest.java
+++ b/base/src/test/java/io/spine/validate/RequiredFieldTest.java
@@ -81,7 +81,7 @@ final class RequiredFieldTest extends MessageValidatorTest {
             }
         }
 
-        @Disabled  // () syntax is currently not supported
+        @Disabled("See https://github.com/SpineEventEngine/base/issues/381")
         @DisplayName("oneof and other field are set")
         @Test
         void oneofAndOtherFieldsAreSet() {
@@ -105,7 +105,7 @@ final class RequiredFieldTest extends MessageValidatorTest {
             assertValid(message);
         }
 
-        @Disabled  // () syntax is currently not supported
+        @Disabled("See https://github.com/SpineEventEngine/base/issues/381")
         @DisplayName("a message qualifies for complex required field pattern")
         @ParameterizedTest
         @MethodSource("io.spine.validate.RequiredFieldTest#validComplexMessages")
@@ -184,7 +184,7 @@ final class RequiredFieldTest extends MessageValidatorTest {
             assertNotValid(withOtherFieldOnly, false);
         }
 
-        @Disabled // () syntax is currently not supported
+        @Disabled("See https://github.com/SpineEventEngine/base/issues/381")
         @DisplayName("a message does not qualifies for a complext required field pattern")
         @ParameterizedTest
         @MethodSource("io.spine.validate.RequiredFieldTest#invalidComplexMessages")

--- a/base/src/test/java/io/spine/validate/RequiredFieldTest.java
+++ b/base/src/test/java/io/spine/validate/RequiredFieldTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validate;
+
+import io.spine.test.validate.requiredfield.ComplexRequiredFields;
+import io.spine.test.validate.requiredfield.EveryFieldOptional;
+import io.spine.test.validate.requiredfield.EveryFieldRequired;
+import io.spine.test.validate.requiredfield.OneofFieldAndOtherFieldRequired;
+import io.spine.test.validate.requiredfield.OneofRequired;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static io.spine.validate.MessageValidatorTest.MESSAGE_VALIDATOR_SHOULD;
+
+@DisplayName(
+        MESSAGE_VALIDATOR_SHOULD + "analyze (required_field) message option and consider message")
+final class RequiredFieldTest extends MessageValidatorTest {
+
+    @DisplayName("valid if")
+    @Nested
+    final class Valid {
+
+        @DisplayName("all required fields are set")
+        @Test
+        void allRequiredFieldsAreSet() {
+            EveryFieldRequired message = EveryFieldRequired
+                    .newBuilder()
+                    .setFirst("first field set")
+                    .setSecond("second field set")
+                    .setThird("third field set")
+                    .build();
+            assertValid(message);
+        }
+
+        @DisplayName("oneof field")
+        @Nested
+        final class OneofField {
+
+            @DisplayName("'first' is set")
+            @Test
+            void first() {
+                OneofRequired withFirstField = OneofRequired
+                        .newBuilder()
+                        .setFirst("first field set")
+                        .build();
+                assertValid(withFirstField);
+            }
+
+            @DisplayName("'second' is set")
+            @Test
+            void second() {
+                OneofRequired withSecondField = OneofRequired
+                        .newBuilder()
+                        .setSecond("second field set")
+                        .build();
+                assertValid(withSecondField);
+            }
+        }
+
+        @DisplayName("oneof and other field are set")
+        @Test
+        void oneofAndOtherFieldsAreSet() {
+            OneofFieldAndOtherFieldRequired message = OneofFieldAndOtherFieldRequired
+                    .newBuilder()
+                    .setSecond("second field set")
+                    .setThird("third field set")
+                    .build();
+            assertValid(message);
+        }
+
+        @DisplayName("all fields are optional")
+        @Test
+        void optionalFieldsAreNotSet() {
+            assertValid(EveryFieldOptional.getDefaultInstance());
+            EveryFieldOptional message = EveryFieldOptional
+                    .newBuilder()
+                    .setFirst("first field set")
+                    .setThird("third field set")
+                    .build();
+            assertValid(message);
+        }
+
+        @DisplayName("a message qualifies for complex required field pattern")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.RequiredFieldTest#validComplexMessages")
+        void qualifiesForComplexRequiredFieldPattern(ComplexRequiredFields message) {
+            assertValid(message);
+        }
+
+    }
+
+    private static Stream<ComplexRequiredFields> validComplexMessages() {
+        ComplexRequiredFields message = ComplexRequiredFields
+                .newBuilder()
+                .addFirst("first field set")
+                .setFourth("fourth field set")
+                .setFifth(ComplexRequiredFields.FifthField
+                                  .newBuilder()
+                                  .setValue("fifthFieldValue"))
+                .build();
+        ComplexRequiredFields alternativeMessage = ComplexRequiredFields
+                .newBuilder()
+                .putSecond("key", "second field set")
+                .setThird("fourth field set")
+                .setFifth(ComplexRequiredFields.FifthField
+                                  .newBuilder()
+                                  .setValue("fifthFieldValue"))
+                .build();
+        return Stream.of(message, alternativeMessage);
+    }
+
+    @DisplayName("invalid if")
+    @Nested
+    final class Invalid {
+
+        @DisplayName("a required field is not set")
+        @Test
+        void requiredFieldIsNotSet() {
+            assertNotValid(EveryFieldRequired.getDefaultInstance(), false);
+            EveryFieldRequired onlyOneRequiredSet = EveryFieldRequired
+                    .newBuilder()
+                    .setFirst("only one set")
+                    .build();
+            assertNotValid(onlyOneRequiredSet, false);
+
+            EveryFieldRequired twoRequiredSet = EveryFieldRequired
+                    .newBuilder()
+                    .setFirst("first set")
+                    .setSecond("second set")
+                    .build();
+            assertNotValid(twoRequiredSet, false);
+        }
+
+        @DisplayName("a required oneof is not set")
+        @Test
+        void oneofNotSet() {
+            assertNotValid(OneofRequired.getDefaultInstance(), false);
+            OneofRequired withDefaultValue = OneofRequired
+                    .newBuilder()
+                    .setFirst("")
+                    .build();
+            assertNotValid(withDefaultValue, false);
+        }
+
+        @DisplayName("oneof or other field is not set")
+        @Test
+        void oneofOrOtherNotSet() {
+            assertNotValid(OneofFieldAndOtherFieldRequired.getDefaultInstance(), false);
+            OneofFieldAndOtherFieldRequired withOneofOnly = OneofFieldAndOtherFieldRequired
+                    .newBuilder()
+                    .setSecond("oneof set")
+                    .build();
+            assertNotValid(withOneofOnly, false);
+            OneofFieldAndOtherFieldRequired withOtherFieldOnly = OneofFieldAndOtherFieldRequired
+                    .newBuilder()
+                    .setThird("other field set")
+                    .build();
+            assertNotValid(withOtherFieldOnly, false);
+        }
+
+        @Disabled // () syntax is currently not supported
+        @DisplayName("a message does not qualifies for a complext required field pattern")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.RequiredFieldTest#invalidComplexMessages")
+        void notQualifiesForComplexPattern(ComplexRequiredFields message) {
+            assertNotValid(message, false);
+        }
+    }
+
+    private static Stream<ComplexRequiredFields> invalidComplexMessages() {
+        ComplexRequiredFields.FifthField.Builder fifthFieldValue =
+                ComplexRequiredFields.FifthField.newBuilder()
+                                                .setValue("fifthFieldValue");
+        ComplexRequiredFields withoutListOrMap = ComplexRequiredFields
+                .newBuilder()
+                .setFourth("fourth field set")
+                .setFifth(fifthFieldValue)
+                .build();
+
+        ComplexRequiredFields withoutOneof = ComplexRequiredFields
+                .newBuilder()
+                .putSecond("key", "second field set")
+                .setFifth(fifthFieldValue)
+                .build();
+
+        ComplexRequiredFields withoutMessage = ComplexRequiredFields
+                .newBuilder()
+                .putSecond("key", "second field set")
+                .setThird("fourth field set")
+                .build();
+        return Stream.of(ComplexRequiredFields.getDefaultInstance(),
+                         withoutListOrMap,
+                         withoutOneof,
+                         withoutMessage);
+    }
+}

--- a/base/src/test/java/io/spine/validate/RequiredFieldTest.java
+++ b/base/src/test/java/io/spine/validate/RequiredFieldTest.java
@@ -81,6 +81,7 @@ final class RequiredFieldTest extends MessageValidatorTest {
             }
         }
 
+        @Disabled  // () syntax is currently not supported
         @DisplayName("oneof and other field are set")
         @Test
         void oneofAndOtherFieldsAreSet() {
@@ -104,6 +105,7 @@ final class RequiredFieldTest extends MessageValidatorTest {
             assertValid(message);
         }
 
+        @Disabled  // () syntax is currently not supported
         @DisplayName("a message qualifies for complex required field pattern")
         @ParameterizedTest
         @MethodSource("io.spine.validate.RequiredFieldTest#validComplexMessages")

--- a/base/src/test/java/io/spine/validate/RequiredFieldTest.java
+++ b/base/src/test/java/io/spine/validate/RequiredFieldTest.java
@@ -112,7 +112,6 @@ final class RequiredFieldTest extends MessageValidatorTest {
         void qualifiesForComplexRequiredFieldPattern(ComplexRequiredFields message) {
             assertValid(message);
         }
-
     }
 
     private static Stream<ComplexRequiredFields> validComplexMessages() {

--- a/base/src/test/proto/spine/test/validate/oneof.proto
+++ b/base/src/test/proto/spine/test/validate/oneof.proto
@@ -28,26 +28,51 @@ option java_multiple_files = true;
 option java_outer_classname = "MessageValidatorTestOneofProto";
 option java_package = "io.spine.test.validate.oneof";
 
+// `oneof` declarations for `OneofTest`.
 
-// `oneof` declarations for `MessageValidatorTest`.
+message OneofWithRequiredFields {
 
-message EveryRequired {
+    option (required_field) = "first | second";
+
     oneof fields {
-        string first = 1 [(required) = true];
-        string second = 2 [(required) = true];
+        string first = 1;
+        string second = 2;
     }
 }
 
-message OneRequired {
+message OneofWithOptionalFields {
     oneof fields {
-        string required_val = 1 [(required) = true];
-        string optional = 2 [(required) = false];
+        string first = 1;
+        string second = 2;
     }
 }
 
-message EveryOptional {
+message OneofAndOtherAreRequired {
+
+    option (required_field) = "first | second";
+
     oneof fields {
-        string first = 1 [(required) = false];
-        string second = 2 [(required) = false];
+        string first = 1;
+        string second = 2;
+    }
+
+    string third = 3 [(required) = true];
+}
+
+message OneofWithValidation {
+
+    oneof fields {
+        string no_validation = 1;
+        string with_validation = 2 [(valid) = true, (pattern).regex = "^[A-Za-z0-9+]+$"];
+    }
+}
+
+message RequiredOneofWithValidation {
+
+    option (required_field) = "raw_value | valid_value";
+
+    oneof fields {
+        int32 raw_value = 1;
+        int32 valid_value = 2 [(valid) = true, (min).value = "1"];
     }
 }

--- a/base/src/test/proto/spine/test/validate/required_field_test.proto
+++ b/base/src/test/proto/spine/test/validate/required_field_test.proto
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.validate;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_multiple_files = true;
+option java_outer_classname = "RequiredFieldTestProto";
+option java_package = "io.spine.test.validate.requiredfield";
+
+// `oneof` declarations for `MessageValidatorTest`.
+
+message EveryFieldRequired {
+
+    option (required_field) = "first & second & third";
+
+    string first = 1;
+
+    string second = 2;
+
+    string third = 3;
+}
+
+message OneofRequired {
+
+    option (required_field) = "first | second";
+
+    oneof fields {
+        string first = 1;
+        string second = 2;
+    }
+}
+
+// Currently () syntax is not supported.
+// The message is here because the test that validates the behavior is disabled.
+message OneofFieldAndOtherFieldRequired {
+
+    option (required_field) = "(first | second) & third";
+
+    oneof fields {
+        string first = 1;
+        string second = 2;
+    }
+
+    string third = 3;
+}
+
+message EveryFieldOptional {
+    oneof fields {
+        string first = 1;
+        string second = 2;
+    }
+
+    string third = 3;
+}
+
+// Currently () syntax is not supported.
+// The message is here because the test that validates the behavior is disabled.
+message ComplexRequiredFields {
+
+    option (required_field) = "(first | second) & (third | fourth) & fifth";
+
+    repeated string first = 1;
+
+    map<string,string> second = 2;
+
+    oneof fields {
+        string third = 3;
+        string fourth = 4;
+    }
+
+    FifthField fifth = 5;
+
+    message FifthField {
+        string value = 1;
+    }
+}

--- a/base/src/test/proto/spine/test/validate/required_field_test.proto
+++ b/base/src/test/proto/spine/test/validate/required_field_test.proto
@@ -53,6 +53,7 @@ message OneofRequired {
 
 // Currently () syntax is not supported.
 // The message is here because the test that validates the behavior is disabled.
+// Remove the comment when the https://github.com/SpineEventEngine/base/issues/381 is resolved.
 message OneofFieldAndOtherFieldRequired {
 
     option (required_field) = "(first | second) & third";
@@ -76,6 +77,7 @@ message EveryFieldOptional {
 
 // Currently () syntax is not supported.
 // The message is here because the test that validates the behavior is disabled.
+// Remove the comment when the https://github.com/SpineEventEngine/base/issues/381 is resolved.
 message ComplexRequiredFields {
 
     option (required_field) = "(first | second) & (third | fourth) & fifth";


### PR DESCRIPTION
This PR partially addresses #378.

Now `oneof` fields are optional by default.

The configuration validation will be implemented in a separate PR.