### PR TITLE
Encode Spine Protoc Plugin custom parameters

### DIFF
--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.gradle.compiler;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.gradle.ExecutableLocator;
 import com.google.protobuf.gradle.GenerateProtoTask;
@@ -48,6 +49,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import java.util.Collection;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -246,8 +248,16 @@ public class ProtocConfigurationPlugin extends SpinePlugin {
                           options -> {
                               options.setOutputSubDir("java");
                               String option = spineProtocConfigPath.toString();
-                              options.option(option);
+                              String encodedOption = base64Encoded(option);
+                              options.option(encodedOption);
                           });
+    }
+
+    private static String base64Encoded(String value) {
+        Base64.Encoder encoder = Base64.getEncoder();
+        byte[] valueBytes = value.getBytes(Charsets.UTF_8);
+        String result = encoder.encodeToString(valueBytes);
+        return result;
     }
 
     /**

--- a/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/gradle/compiler/ProtocConfigurationPlugin.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.gradle.compiler;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.gradle.ExecutableLocator;
 import com.google.protobuf.gradle.GenerateProtoTask;
@@ -52,6 +51,7 @@ import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.Collection;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.code.java.DefaultJavaProject.at;
 import static io.spine.tools.gradle.ConfigurationName.FETCH;
@@ -255,7 +255,7 @@ public class ProtocConfigurationPlugin extends SpinePlugin {
 
     private static String base64Encoded(String value) {
         Base64.Encoder encoder = Base64.getEncoder();
-        byte[] valueBytes = value.getBytes(Charsets.UTF_8);
+        byte[] valueBytes = value.getBytes(UTF_8);
         String result = encoder.encodeToString(valueBytes);
         return result;
     }

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.protoc;
 
-import com.google.common.base.Charsets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
@@ -33,6 +32,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Base64;
 
+import static com.google.common.base.Charsets.UTF_8;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
 
@@ -95,7 +95,7 @@ public final class Plugin {
     private static String decodeBase64(String value) {
         Base64.Decoder decoder = Base64.getDecoder();
         byte[] decodedBytes = decoder.decode(value);
-        String result = new String(decodedBytes, Charsets.UTF_8);
+        String result = new String(decodedBytes, UTF_8);
         return result;
     }
 

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/Plugin.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.protoc;
 
+import com.google.common.base.Charsets;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest;
 import com.google.protobuf.compiler.PluginProtos.CodeGeneratorResponse;
@@ -30,6 +31,7 @@ import io.spine.tools.protoc.method.MethodGenerator;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.Base64;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static io.spine.util.Exceptions.newIllegalStateException;
@@ -76,7 +78,7 @@ public final class Plugin {
     }
 
     private static SpineProtocConfig readConfig(CodeGeneratorRequest request) {
-        String configFilePath = request.getParameter();
+        String configFilePath = decodeBase64(request.getParameter());
         try (FileInputStream fis = new FileInputStream(configFilePath)) {
             SpineProtocConfig config = SpineProtocConfig
                     .parseFrom(fis, OptionExtensionRegistry.instance());
@@ -88,6 +90,13 @@ public final class Plugin {
         } catch (IOException e) {
             throw newIllegalStateException(e, "Unable to read Spine Protoc Plugin config.");
         }
+    }
+
+    private static String decodeBase64(String value) {
+        Base64.Decoder decoder = Base64.getDecoder();
+        byte[] decodedBytes = decoder.decode(value);
+        String result = new String(decodedBytes, Charsets.UTF_8);
+        return result;
     }
 
     @SuppressWarnings("UseOfSystemOutOrSystemErr") // Required by the protoc API.

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/PluginTest.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/PluginTest.java
@@ -83,7 +83,7 @@ final class PluginTest {
                 .addProtoFile(TestGeneratorsProto.getDescriptor()
                                                  .toProto())
                 .addFileToGenerate(TEST_PROTO_FILE)
-                .setParameter(protocConfig(interfaces, methods, testPluginConfig).toString())
+                .setParameter(protocConfig(interfaces, methods, testPluginConfig))
                 .build();
 
         CodeGeneratorResponse response = runPlugin(request);
@@ -106,7 +106,7 @@ final class PluginTest {
                 .addProtoFile(TestMethodProtos.getDescriptor()
                                               .toProto())
                 .addFileToGenerate("spine/tools/protoc/method/test_protos.proto")
-                .setParameter(protocConfig(methods, testPluginConfig).toString())
+                .setParameter(protocConfig(methods, testPluginConfig))
                 .build();
         CodeGeneratorResponse response = runPlugin(request);
 
@@ -129,7 +129,7 @@ final class PluginTest {
                 .addProtoFile(TestGeneratorsProto.getDescriptor()
                                                  .toProto())
                 .addFileToGenerate(TEST_PROTO_FILE)
-                .setParameter(protocConfig(interfaces, methods, testPluginConfig).toString())
+                .setParameter(protocConfig(interfaces, methods, testPluginConfig))
                 .build();
 
         CodeGeneratorResponse response = runPlugin(request);
@@ -154,7 +154,7 @@ final class PluginTest {
                 .addProtoFile(TestGeneratorsProto.getDescriptor()
                                                  .toProto())
                 .addFileToGenerate(TEST_PROTO_FILE)
-                .setParameter(protocConfig(interfaces, methods, testPluginConfig).toString())
+                .setParameter(protocConfig(interfaces, methods, testPluginConfig))
                 .build();
 
         CodeGeneratorResponse response = runPlugin(request);

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/SpineProtoGeneratorTest.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/SpineProtoGeneratorTest.java
@@ -87,7 +87,7 @@ final class SpineProtoGeneratorTest {
                 .addProtoFile(TestGeneratorsProto.getDescriptor()
                                                  .toProto())
                 .addFileToGenerate(TEST_PROTO_FILE)
-                .setParameter(protocConfig(interfaces, methods, testPluginConfig).toString())
+                .setParameter(protocConfig(interfaces, methods, testPluginConfig))
                 .build();
         MessageType type = new MessageType(EnhancedWithCodeGeneration.getDescriptor());
         File firstFile = File

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/given/CodeGeneratorRequestGiven.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/given/CodeGeneratorRequestGiven.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.protoc.given;
 
-import com.google.common.base.Charsets;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
 import io.spine.option.OptionsProto;
@@ -33,6 +32,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Base64;
+
+import static com.google.common.base.Charsets.UTF_8;
 
 /**
  * A helper class for {@link com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
@@ -114,7 +115,7 @@ public final class CodeGeneratorRequestGiven {
     }
 
     private static String base64Encoded(String value) {
-        byte[] valueBytes = value.getBytes(Charsets.UTF_8);
+        byte[] valueBytes = value.getBytes(UTF_8);
         String result = Base64.getEncoder()
                               .encodeToString(valueBytes);
         return result;

--- a/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/given/CodeGeneratorRequestGiven.java
+++ b/tools/protoc-plugin/src/test/java/io/spine/tools/protoc/given/CodeGeneratorRequestGiven.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.protoc.given;
 
+import com.google.common.base.Charsets;
 import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.compiler.PluginProtos;
 import io.spine.option.OptionsProto;
@@ -31,6 +32,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Base64;
 
 /**
  * A helper class for {@link com.google.protobuf.compiler.PluginProtos.CodeGeneratorRequest
@@ -71,10 +73,10 @@ public final class CodeGeneratorRequestGiven {
      * Creates a {@link SpineProtocConfig} out of the supplied {@code GeneratedMethods} and
      * a default instance of {@code GeneratedInterfaces} and stores it in the supplied {@code path}.
      *
-     * @return configuration file absolute path
+     * @return base64 encoded path to the plugin configuration
      * @see #protocConfig(GeneratedInterfaces, GeneratedMethods, File)
      */
-    public static Path protocConfig(GeneratedMethods methods, Path configPath) {
+    public static String protocConfig(GeneratedMethods methods, Path configPath) {
         return protocConfig(GeneratedInterfaces.withDefaults(), methods, configPath);
     }
 
@@ -82,10 +84,10 @@ public final class CodeGeneratorRequestGiven {
      * Creates a {@link SpineProtocConfig} out of the supplied {@code GeneratedInterfaces} and
      * a default instance of {@code GeneratedMethods} and stores it in the supplied {@code path}.
      *
-     * @return configuration file absolute path
+     * @return base64 encoded path to the plugin configuration
      * @see #protocConfig(GeneratedInterfaces, GeneratedMethods, File)
      */
-    public static Path protocConfig(GeneratedInterfaces interfaces, Path configPath) {
+    public static String protocConfig(GeneratedInterfaces interfaces, Path configPath) {
         return protocConfig(interfaces, GeneratedMethods.withDefaults(), configPath);
     }
 
@@ -93,9 +95,9 @@ public final class CodeGeneratorRequestGiven {
      * Creates a {@link SpineProtocConfig} out of the supplied {@code GeneratedInterfaces} and
      * {@code GeneratedMethods} and stores it in the supplied {@code path}.
      *
-     * @return configuration file absolute path
+     * @return base64 encoded path to the plugin configuration
      */
-    public static Path
+    public static String
     protocConfig(GeneratedInterfaces interfaces, GeneratedMethods methods, Path configPath) {
         SpineProtocConfig config = SpineProtocConfig
                 .newBuilder()
@@ -107,7 +109,15 @@ public final class CodeGeneratorRequestGiven {
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
-        return configPath.toAbsolutePath();
+        return base64Encoded(configPath.toAbsolutePath()
+                                       .toString());
+    }
+
+    private static String base64Encoded(String value) {
+        byte[] valueBytes = value.getBytes(Charsets.UTF_8);
+        String result = Base64.getEncoder()
+                              .encodeToString(valueBytes);
+        return result;
     }
 
     private static DescriptorProtos.FileDescriptorProto spineOptionsProto() {


### PR DESCRIPTION
This PR fixes #379.

Now Spine Protoc Plugin parameters are base64-encoded.