### PR TITLE
Exclude Google `.proto`s from artifacts

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,3 +1,0 @@
----
-exclude_paths:
-  - "**/src/test/**/*.*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ sudo: required
 
 env:
   global:
-    # Encrypted `CODACY_PROJECT_TOKEN` variable according to:
-    # https://docs.travis-ci.com/user/environment-variables/#Encrypting-environment-variables
-    - secure: "Zf93nPFDF2sFnnVGZvs7BzCzwkdunL8lhFOG5xpe1WBmr2+zxl0oykkOi5ZUXcmWDWMKcCMui6gxjZuQsnX0bOyFWROtuq84py5NMmlbKx1sJE6KBvNnNWm4slBbrfBj1ngFmwuxI/SFddxNsgwLdvCkMrvPrA54Ws6jsMrraCnywWlP75EVM0ckzZ7ovxMrqFfkW4BTUpgDiOTw4ZFB6QUPI3XmrsB1sDJ8vj3SE5bzd6lL4cuXqZtOxCX/XWKXFjoG9Wch5cukErN0kOVD/wVKT1oFmZZyEAOzWdHSCgoa4+kvGAMcR5TEzkQcVZoim0RcACfXGoqf1qBeW/wm+yidHDoCpt9B3da0hm8g1TJpAXigT6pB3fE5JYticx0m5uZm7HnHNlRdDNIpoY1FhNxNkmwEbu/tssK1rG/WZDIJyKF+OmpDujeuQ1LalSmgNKn1nmwvJQiaWag8N6jO760v3KKBmZL+h4O8xgnSrr2/IB70ecXaxuP6zZgUhRWgY4sPQuHRAJ1C2ST7WfMPhUjZTUSp47VhMbePyTvMgNHNv6HDJlWhwNBq8X8dmxMrS057AwcSV7LQHk/NQGnaONidGzlefRjreli3pTKGQ+9G9oxIvUzVZMe/8a7z4AV5f9TKaXVeX/HzuQS/vpKTv1toftGH4DqecHtK5oQKLSM="
     # Encrypted `GCS_SECRET` variable.
     - secure: "i8MhONZu7QjyM2V887A1Tydr1WMqQP5jJZNjIJjc1Uae8F0/z8cJZIZ1hstodN7FpoR4VF92zyhUwbt6fz/dsdPEJFccsiMlEc9vlqecQCd267160wgRZneaB6Xe/y/EUmq9XsGdn/k1Ey+QZwX9au/8RU191v+fDsCtMRYXzyEa/BvbQuSwuYRgQDxTAxuJgTmG5Sxl9jWqKw1BfxUcEoErc/jqymU58w6z2TxKxVzIXT29Jy/Z12VuSiS8opigSrIP8e/1fctC84wI7S52mext2ZfhPYSTHFKS+xg1vQDYPb8m5aomL8E6Of7hVD5BTnEnyjj+/Gr63GAzHXtkHhWoxo+vB+xBFfDu8wxM5Aqna3H7LMDD5kGCxQEz8qmzHBHMAhLnhsRzjNVu2+tLCZdeMN88Ud2uemL2SCAcR8Juleg7DGMj3D0SAbPyUH3+9yYYWzSg6iaxgTdHBnJ+uXUJp0Nu+M2EK6Kl+pYAsCLVfZRPGaajFXVnJEPPeSr2PYzk7F4pIzgn/E8AtYEJ0gcEbjoTItS8EjliJKDXM4HdkluXBFLvzIH1O1nCtxKNv4UkUmPhFbfHrPXDcsYq2zsEe+NkvsJlxjAwYnOMkT4NLiEsec1a7K9bBC+iQA9e8rriMbu6/1w63JErQyx05avPjgO8XRDK8hxTf4rhBmY="
     - GRADLE_OPTS="-Xmx2G"
@@ -33,8 +30,6 @@ script:
 after_success:
   # See: https://github.com/codecov/example-java/blob/master/.travis.yml
   - bash <(curl -s https://codecov.io/bash)
-  - chmod +x ./config/scripts/report-coverage.sh
-  - ./config/scripts/report-coverage.sh
 
 after_script:
   - chmod +x ./config/scripts/upload-artifacts.sh

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -20,23 +20,14 @@
 
 group = 'io.spine'
 
-configurations {
-    // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
-    runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
-    testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
-}
-
 apply plugin: 'java'
-apply plugin: 'com.google.protobuf'
+
+apply from: "$projectDir/script/protobuf.gradle"
 
 apply from: deps.scripts.testArtifacts
 apply from: deps.scripts.runBuild
 
 dependencies {
-    // Re-generate standard Proto types, so they are included in `known_types.desc`.
-    //noinspection GroovyAssignabilityCheck
-    protobuf deps.build.protobuf
-
     // Since we use `@CanIgnoreReturnValue` when annotating Validating Builders
     // ErrorProne Annotations is part of our API. 
     api deps.build.errorProneAnnotations
@@ -44,22 +35,6 @@ dependencies {
     implementation deps.gen.javaPoet
 
     testImplementation project(path: ":testlib")
-}
-
-protobuf {
-    generatedFilesBaseDir = "$projectDir/generated"
-    protoc {
-        artifact = deps.build.protoc
-    }
-    generateProtoTasks {
-        all().each { final task ->
-            final def scope = task.sourceSet.name
-            task.generateDescriptorSet = true
-            task.descriptorSetOptions.path = "$buildDir/descriptors/$scope/known_types_${scope}.desc"
-            task.descriptorSetOptions.includeImports = true
-            task.descriptorSetOptions.includeSourceInfo = true
-        }
-    }
 }
 
 sourceSets {
@@ -76,10 +51,6 @@ sourceSets {
 jar {
     // See `base-validating-builders/README.md`.
     from "$rootDir/base-validating-builders/builders"
-    exclude { final FileTreeElement file ->
-        final String[] pathSegments = file.relativePath.segments
-        return pathSegments.length >= 1 && pathSegments[0].equals("google")
-    }
 }
 
 build.doLast {

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     api deps.build.errorProneAnnotations
 
     implementation deps.gen.javaPoet
-    
+
     testImplementation project(path: ":testlib")
 }
 
@@ -76,6 +76,10 @@ sourceSets {
 jar {
     // See `base-validating-builders/README.md`.
     from "$rootDir/base-validating-builders/builders"
+    exclude { final FileTreeElement file ->
+        final String[] pathSegments = file.relativePath.segments
+        return pathSegments.length >= 1 && pathSegments[0].equals("google")
+    }
 }
 
 build.doLast {

--- a/base/script/protobuf.gradle
+++ b/base/script/protobuf.gradle
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+apply plugin: 'com.google.protobuf'
+
+configurations {
+    // Avoid collisions of Java classes defined both in `protobuf-lite` and `protobuf-java`
+    runtime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+    testRuntime.exclude group: "com.google.protobuf", module: "protobuf-lite"
+}
+
+dependencies {
+    // Re-generate standard Proto types, so they are included in `known_types.desc`.
+    protobuf deps.build.protobuf
+}
+
+protobuf {
+    generatedFilesBaseDir = "$projectDir/generated"
+    protoc {
+        artifact = deps.build.protoc
+    }
+    generateProtoTasks {
+        all().each { final task ->
+            final def scope = task.sourceSet.name
+            task.generateDescriptorSet = true
+            task.descriptorSetOptions.path = "$buildDir/descriptors/$scope/known_types_${scope}.desc"
+            task.descriptorSetOptions.includeImports = true
+            task.descriptorSetOptions.includeSourceInfo = true
+        }
+    }
+}
+
+/**
+ * Checks if the given file belongs to the Google `.proto` sources.
+ */
+static boolean isGoogleProtoSource(final FileTreeElement file) {
+    final String[] pathSegments = file.relativePath.segments
+    return pathSegments.length >= 1 && pathSegments[0].equals('google')
+}
+
+/**
+ * Checks if the given directory hosts files generated from the Google `.proto` sources.
+ * 
+ * <p>The directory should be called `com` and should have a single child directory called `google`.
+ */
+static boolean isCompiledGoogleProtoDir(final FileTreeElement file) {
+    if (!file.directory) {
+        return false
+    }
+    if (!file.name.equals('com')) {
+        return false
+    }
+    final File directory = file.file
+    final String[] children = directory.list()
+    return children.length == 1 && children[0].equals('google')
+}
+
+/**
+ * From all artifacts, exclude Google `.proto` sources and files generated from those sources.
+ */
+tasks.withType(Jar) {
+    it.exclude { final FileTreeElement file ->
+        isGoogleProtoSource(file) || isCompiledGoogleProtoDir(file)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -134,9 +134,9 @@ subprojects {
         //  https://github.com/epeee/junit-jupiter-extension-testing/blob/57b7ba75ab64ed8c229d2a5b14a954d6ae359189/gradle/errorprone.gradle
         
         api deps.build.protobuf
+        api deps.build.slf4j
 
         implementation deps.build.guava
-        api deps.build.slf4j
         implementation deps.build.checkerAnnotations
         implementation deps.build.errorProneAnnotations
         implementation deps.build.jsr305Annotations


### PR DESCRIPTION
This PR configures Gradle to exclude Google `.proto` sources and files generated from those sources from all the Spine archives (such as the default JAR, the source code JAR, and the Javadoc JAR).

Fixes #199.

Also, in this PR we delete the script and configuration files of Codacy.