### PR TITLE
Delete generated Google `.proto`s

### DIFF
--- a/base/script/protobuf.gradle
+++ b/base/script/protobuf.gradle
@@ -78,27 +78,8 @@ static boolean isGoogleProtoSource(final FileTreeElement file) {
 }
 
 /**
- * Checks if the given directory hosts files generated from the Google `.proto` sources.
- * 
- * <p>The directory should be called `com` and should have a single child directory called `google`.
- */
-static boolean isCompiledGoogleProtoDir(final FileTreeElement file) {
-    if (!file.directory) {
-        return false
-    }
-    if (!file.name.equals('com')) {
-        return false
-    }
-    final File directory = file.file
-    final String[] children = directory.list()
-    return children.length == 1 && children[0].equals('google')
-}
-
-/**
- * From all artifacts, exclude Google `.proto` sources and files generated from those sources.
+ * From all artifacts, exclude Google `.proto` sources.
  */
 tasks.withType(Jar) {
-    it.exclude { final FileTreeElement file ->
-        isGoogleProtoSource(file) || isCompiledGoogleProtoDir(file)
-    }
+    it.exclude { final FileTreeElement file -> isGoogleProtoSource(file) }
 }

--- a/base/script/protobuf.gradle
+++ b/base/script/protobuf.gradle
@@ -31,8 +31,24 @@ dependencies {
     protobuf deps.build.protobuf
 }
 
+ext {
+    compiledProtoRoot = "$projectDir/generated"
+    mainCompiledProto = "$compiledProtoRoot/main/java"
+    testCompiledProto = "$compiledProtoRoot/test/java"
+}
+
+final def mainPruneTask = task pruneGoogleProtos(type: Delete) {
+    delete "$mainCompiledProto/com"
+    compileJava.dependsOn it
+}
+
+final def testPruneTask = task pruneTestGoogleProtos(type: Delete) {
+    delete "$testCompiledProto/com"
+    compileTestJava.dependsOn it
+}
+
 protobuf {
-    generatedFilesBaseDir = "$projectDir/generated"
+    generatedFilesBaseDir = compiledProtoRoot
     protoc {
         artifact = deps.build.protoc
     }
@@ -43,6 +59,12 @@ protobuf {
             task.descriptorSetOptions.path = "$buildDir/descriptors/$scope/known_types_${scope}.desc"
             task.descriptorSetOptions.includeImports = true
             task.descriptorSetOptions.includeSourceInfo = true
+
+            if (task.sourceSet.name.contains('test')) {
+                testPruneTask.dependsOn task
+            } else {
+                mainPruneTask.dependsOn task
+            }
         }
     }
 }

--- a/base/script/protobuf.gradle
+++ b/base/script/protobuf.gradle
@@ -35,15 +35,16 @@ ext {
     compiledProtoRoot = "$projectDir/generated"
     mainCompiledProto = "$compiledProtoRoot/main/java"
     testCompiledProto = "$compiledProtoRoot/test/java"
+    googlePackagePrefix = 'com/google'
 }
 
 final def mainPruneTask = task pruneGoogleProtos(type: Delete) {
-    delete "$mainCompiledProto/com"
+    delete "$mainCompiledProto/$googlePackagePrefix"
     compileJava.dependsOn it
 }
 
 final def testPruneTask = task pruneTestGoogleProtos(type: Delete) {
-    delete "$testCompiledProto/com"
+    delete "$testCompiledProto/$googlePackagePrefix"
     compileTestJava.dependsOn it
 }
 

--- a/base/src/main/java/io/spine/validate/MessageFieldValidatingOption.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidatingOption.java
@@ -44,7 +44,7 @@ abstract class MessageFieldValidatingOption<T, M extends Message>
     @Override
     boolean shouldValidate(FieldDescriptor value) {
         FieldDeclaration declaration = new FieldDeclaration(value);
-        Valid<M> validOption = new Valid<>();
+        Valid validOption = new Valid();
         Boolean valid = validOption.valueFrom(value)
                                    .orElse(false);
         boolean shouldValidateCollection = declaration.isNotCollection() || valid;

--- a/base/src/main/java/io/spine/validate/MessageFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidator.java
@@ -63,7 +63,7 @@ final class MessageFieldValidator<V extends Message> extends FieldValidator<V> {
 
     private boolean shouldValidateFields() {
         boolean fieldValueSet = !fieldValueNotSet();
-        Valid<V> validOption = new Valid<>();
+        Valid validOption = new Valid();
         boolean valid = validOption.valueFrom(descriptor())
                                    .orElse(false);
         return valid && fieldValueSet;

--- a/base/src/main/java/io/spine/validate/MessageFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/MessageFieldValidator.java
@@ -64,7 +64,7 @@ final class MessageFieldValidator<V extends Message> extends FieldValidator<V> {
     private boolean shouldValidateFields() {
         boolean fieldValueSet = !fieldValueNotSet();
         Valid<V> validOption = new Valid<>();
-        Boolean valid = validOption.valueFrom(descriptor())
+        boolean valid = validOption.valueFrom(descriptor())
                                    .orElse(false);
         return valid && fieldValueSet;
     }

--- a/base/src/main/java/io/spine/validate/Valid.java
+++ b/base/src/main/java/io/spine/validate/Valid.java
@@ -26,7 +26,7 @@ import io.spine.option.OptionsProto;
 /**
  * An option that indicates that the fields internal field should be included into the validation.
  */
-class Valid<T> extends FieldOption<Boolean> {
+final class Valid extends FieldOption<Boolean> {
 
     /** Creates a new instance of this option. */
     Valid() {


### PR DESCRIPTION
In this PR we prune the code generated from the Google `.proto` files as soon as it is generated.

We still need to feed `protoc` with the Google `.proto` files in order to receive correct descriptor files.

Fixes #246.

Also, in this PR we clean up the signature of `Valid` option accessor class.