### PR TITLE
`GeneratedMixin` annotation

### DIFF
--- a/base/src/main/java/io/spine/annotation/GeneratedMixin.java
+++ b/base/src/main/java/io/spine/annotation/GeneratedMixin.java
@@ -40,9 +40,9 @@ import java.lang.annotation.Target;
  *    <li>Add {@code default} methods. Presumably bodies of these methods would call accessor
  *    methods declared earlier.
  *    <li>Mark corresponding proto messages using the {@code (is).java_type} option (if for
- *    one message), or {@code (every_is).java_type} file if the interface is common for all the
- *    message declared in the file. This will instruct Spine Model Compiler to make the generated
- *    code implement this interface.
+ *    one message), or {@code (every_is).java_type} option for a file if the interface is common
+ *    for all the message declared in this file. These options instruct Spine Model Compiler to
+ *    make the generated code implement this interface.
  * </ol>
  *
  * <p>The annotation should <em>NOT</em> be used on interfaces that do not provide default methods,

--- a/base/src/main/java/io/spine/annotation/GeneratedMixin.java
+++ b/base/src/main/java/io/spine/annotation/GeneratedMixin.java
@@ -22,6 +22,7 @@ package io.spine.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -51,6 +52,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
+@Inherited
 @Documented
 public @interface GeneratedMixin {
 }

--- a/base/src/main/java/io/spine/annotation/GeneratedMixin.java
+++ b/base/src/main/java/io/spine/annotation/GeneratedMixin.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates an interface which is used for extending generated code using default methods
+ * declared in the interface.
+ *
+ * <p>In order to generate a class which implements a custom interface:
+ * <ol>
+ *    <li>Create the interface and annotate it using this annotation.
+ *    <li>Declare methods of interest following the Protobuf convention for the accessor methods.
+ *    For example, if a message has a property named {@code foo_bar}, the method to declare would
+ *    be {@code getFooBar()}.
+ *    <li>Add {@code default} methods. Presumably bodies of these methods would call accessor
+ *    methods declared earlier.
+ *    <li>Mark corresponding proto messages using the {@code (is).java_type} option (if for
+ *    one message), or {@code (every_is).java_type} file if the interface is common for all the
+ *    message declared in the file. This will instruct Spine Model Compiler to make the generated
+ *    code implement this interface.
+ * </ol>
+ *
+ * <p>The annotation should <em>NOT</em> be used on interfaces that do not provide default methods,
+ * as implementing classes would not be mixins.
+ *
+ * @see io.spine.option.IsOption
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+@Documented
+public @interface GeneratedMixin {
+}

--- a/base/src/main/java/io/spine/base/MessageContext.java
+++ b/base/src/main/java/io/spine/base/MessageContext.java
@@ -20,10 +20,11 @@
 
 package io.spine.base;
 
-import com.google.protobuf.Message;
+import com.google.errorprone.annotations.Immutable;
 
 /**
  * Base interface for message contexts.
  */
-public interface MessageContext extends Message {
+@Immutable
+public interface MessageContext extends SerializableMessage {
 }

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -748,8 +748,7 @@ message IsOption {
     // The reference to a Java interface.
     //
     // May be an fully-qualified or a simple name. In the latter case, the interface should belong
-    // to the same
-    // Java package as the message class which implements this interface.
+    // to the same Java package as the message class which implements this interface.
     //
     // The framework does not ensure the referenced type exists.
     // If the generation is disabled, the Java type is used as-is. Otherwise, a corresponding Java

--- a/base/src/test/java/io/spine/base/GeneratedMixinTest.java
+++ b/base/src/test/java/io/spine/base/GeneratedMixinTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base;
+
+import com.google.common.truth.IterableSubject;
+import io.spine.annotation.GeneratedMixin;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("GeneratedMixin annotation should")
+class GeneratedMixinTest {
+
+    @Test
+    @DisplayName("have `SOURCE` retention policy")
+    void retention() {
+       assertThat(annotation(Retention.class).value())
+               .isEqualTo(RetentionPolicy.SOURCE);
+    }
+
+    @Test
+    @DisplayName("have `TYPE` target")
+    void target() {
+        IterableSubject assertTargets = assertThat(annotation(Target.class).value()).asList();
+
+        assertTargets.hasSize(1);
+        assertTargets.contains(ElementType.TYPE);
+    }
+
+    @Test
+    @DisplayName("be `Documented`")
+    void documented() {
+        assertThat(annotation(Documented.class)).isNotNull();
+    }
+
+    private static <A extends Annotation> A annotation(Class<A> annotationClass) {
+        return GeneratedMixin.class.getAnnotation(annotationClass);
+    }
+}

--- a/base/src/test/java/io/spine/base/GeneratedMixinTest.java
+++ b/base/src/test/java/io/spine/base/GeneratedMixinTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -57,6 +58,12 @@ class GeneratedMixinTest {
     @DisplayName("be `Documented`")
     void documented() {
         assertThat(annotation(Documented.class)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("be `Inherited`")
+    void inherited() {
+        assertThat(annotation(Inherited.class)).isNotNull();
     }
 
     private static <A extends Annotation> A annotation(Class<A> annotationClass) {

--- a/base/src/test/java/io/spine/base/MessageContextTest.java
+++ b/base/src/test/java/io/spine/base/MessageContextTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.base;
 
+import com.google.errorprone.annotations.Immutable;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.CodedOutputStream;
 import com.google.protobuf.Descriptors;
@@ -50,7 +51,10 @@ class MessageContextTest {
      * Stub implementation of {@link MessageContext}.
      */
     @SuppressWarnings("ReturnOfNull")
+    @Immutable
     private static class StubMessageContext implements MessageContext {
+
+        private static final long serialVersionUID = 0L;
 
         @Override
         public void writeTo(CodedOutputStream output) throws IOException {

--- a/base/src/test/java/io/spine/base/MessageContextTest.java
+++ b/base/src/test/java/io/spine/base/MessageContextTest.java
@@ -30,7 +30,6 @@ import com.google.protobuf.UnknownFieldSet;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +56,7 @@ class MessageContextTest {
         private static final long serialVersionUID = 0L;
 
         @Override
-        public void writeTo(CodedOutputStream output) throws IOException {
+        public void writeTo(CodedOutputStream output) {
         }
 
         @Override
@@ -82,7 +81,7 @@ class MessageContextTest {
         }
 
         @Override
-        public void writeTo(OutputStream output) throws IOException {
+        public void writeTo(OutputStream output) {
         }
 
         @Override


### PR DESCRIPTION
This PR introduces `GeneratedMixin` annotation for annotating interfaces that extend generated code with `default` methods declared in the interfaces.
