### PR TITLE
Fix `(range)` option boundaries

### DIFF
--- a/base/src/main/java/io/spine/validate/ComparableNumber.java
+++ b/base/src/main/java/io/spine/validate/ComparableNumber.java
@@ -48,6 +48,11 @@ public final class ComparableNumber extends Number implements Comparable<Number>
         return new NumberText(value);
     }
 
+    /** Returns the actual wrapped number. */
+    public Number value() {
+        return value;
+    }
+
     @Override
     public int compareTo(Number anotherNumber) {
         long thisLong = longValue();

--- a/base/src/main/java/io/spine/validate/NumberFieldValidator.java
+++ b/base/src/main/java/io/spine/validate/NumberFieldValidator.java
@@ -30,7 +30,7 @@ import static io.spine.protobuf.TypeConverter.toAny;
  * @param <V>
  *         the type of the field value
  */
-abstract class NumberFieldValidator<V extends Number & Comparable> extends FieldValidator<V> {
+abstract class NumberFieldValidator<V extends Number & Comparable<V>> extends FieldValidator<V> {
 
     /**
      * Creates a new validator instance.

--- a/base/src/main/java/io/spine/validate/NumberText.java
+++ b/base/src/main/java/io/spine/validate/NumberText.java
@@ -73,12 +73,12 @@ public final class NumberText {
      *
      * <p>Example:
      * <pre>
-     * {@code
-     *   NumberText zeroWithDecimal = new NumberText("0.0");
-     *   NumberText plainZero = new NumberText("0");
+     *     {@code
+     *      NumberText zeroWithDecimal = new NumberText("0.0");
+     *      NumberText plainZero = new NumberText("0");
      *
-     *   zeroWithDecimal.isOfSameType(plainZero); // false
-     * }
+     *      zeroWithDecimal.isOfSameType(plainZero); // false
+     *      }
      *  </pre>
      * the above code is false, since {@code zeroWithDecimal} describes a number that has a decimal
      * part, be it a {@code Double} or a {@code Float}, while {@code plainZero} describes an

--- a/base/src/main/java/io/spine/validate/NumberText.java
+++ b/base/src/main/java/io/spine/validate/NumberText.java
@@ -22,10 +22,11 @@ package io.spine.validate;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
+import io.spine.annotation.Internal;
 
 import java.util.Collection;
+import java.util.List;
 
 import static io.spine.util.Exceptions.newIllegalStateException;
 import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
@@ -34,6 +35,7 @@ import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
  * A number that is described with a {@code String} of characters.
  */
 @Immutable
+@Internal
 public final class NumberText {
 
     private static final String DECIMAL_DELIMITER = ".";
@@ -88,10 +90,9 @@ public final class NumberText {
     }
 
     private static Number parseNumber(String text) {
-        ImmutableList<String> wholeAndDecimal =
-                ImmutableList.copyOf(DECIMAL_SPLIT.split(text));
+        List<String> wholeAndDecimal = DECIMAL_SPLIT.splitToList(text);
         hasOnlyWholeAndDecimal(wholeAndDecimal);
-        if (hasDecimalPart(text)) {
+        if (hasDecimalPart(wholeAndDecimal)) {
             return Double.parseDouble(text);
         }
         if (fitsIntoInteger(text)) {
@@ -101,9 +102,7 @@ public final class NumberText {
         }
     }
 
-    private static boolean hasDecimalPart(String text) {
-        ImmutableList<String> wholeAndDecimal =
-                ImmutableList.copyOf(DECIMAL_SPLIT.split(text));
+    private static boolean hasDecimalPart(List<String> wholeAndDecimal) {
         boolean hasOnlyWhole = wholeAndDecimal.size() <= 1;
         return !hasOnlyWhole && !wholeAndDecimal.get(1)
                                                 .isEmpty();

--- a/base/src/main/java/io/spine/validate/option/Max.java
+++ b/base/src/main/java/io/spine/validate/option/Max.java
@@ -33,7 +33,7 @@ import io.spine.validate.FieldValue;
  *         numeric value type that this option is applied to
  */
 @Immutable
-final class Max<@ImmutableTypeParameter V extends Number & Comparable>
+final class Max<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends FieldValidatingOption<MaxOption, V> {
 
     private Max() {
@@ -41,7 +41,7 @@ final class Max<@ImmutableTypeParameter V extends Number & Comparable>
     }
 
     /** Returns a new instance of this option. */
-    static <@ImmutableTypeParameter V extends Number & Comparable> Max<V> create() {
+    static <@ImmutableTypeParameter V extends Number & Comparable<V>> Max<V> create() {
         return new Max<>();
     }
 

--- a/base/src/main/java/io/spine/validate/option/MaxConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MaxConstraint.java
@@ -31,7 +31,7 @@ import io.spine.validate.NumberText;
  * A constraint, which checks whether a numeric field value exceeds a max value, when applied.
  */
 @Immutable
-final class MaxConstraint<@ImmutableTypeParameter V extends Number & Comparable>
+final class MaxConstraint<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends RangedConstraint<V, MaxOption> {
 
     MaxConstraint(MaxOption optionValue) {

--- a/base/src/main/java/io/spine/validate/option/Min.java
+++ b/base/src/main/java/io/spine/validate/option/Min.java
@@ -33,7 +33,7 @@ import io.spine.validate.FieldValue;
  *         numeric value type that this option is applied to
  */
 @Immutable
-final class Min<@ImmutableTypeParameter V extends Number & Comparable>
+final class Min<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends FieldValidatingOption<MinOption, V> {
 
     private Min() {
@@ -41,7 +41,7 @@ final class Min<@ImmutableTypeParameter V extends Number & Comparable>
     }
 
     /** Creates a new instance of this option. */
-    static <@ImmutableTypeParameter V extends Number & Comparable> Min<V> create() {
+    static <@ImmutableTypeParameter V extends Number & Comparable<V>> Min<V> create() {
         return new Min<>();
     }
 

--- a/base/src/main/java/io/spine/validate/option/MinConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MinConstraint.java
@@ -32,7 +32,7 @@ import io.spine.validate.NumberText;
  * greater than (or equal to, if specified by the value of the respective option) a min value.
  */
 @Immutable
-final class MinConstraint<@ImmutableTypeParameter V extends Number & Comparable>
+final class MinConstraint<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends RangedConstraint<V, MinOption> {
 
     MinConstraint(MinOption optionValue) {

--- a/base/src/main/java/io/spine/validate/option/NumberConversionChecker.java
+++ b/base/src/main/java/io/spine/validate/option/NumberConversionChecker.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validate.option;
+
+import com.google.common.collect.ImmutableList;
+import io.spine.validate.ComparableNumber;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Allows to determine safe variants of a number conversions without loosing precision.
+ *
+ * <p>Mimics the actual automatic conversions that are applied to primitive number types.
+ */
+final class NumberConversionChecker {
+
+    private static final ImmutableList<ConversionChecker<?>> CASTERS = ImmutableList.of(
+            new ByteChecker(), new ShortChecker(), new IntegerChecker(), new LongChecker(),
+            new FloatChecker(), new DoubleChecker()
+    );
+
+    /** Prevents direct instantiation. */
+    private NumberConversionChecker() {
+    }
+
+    /**
+     * Determines if the supplied {@code number} can be safely converted to the {@code
+     * anotherNumber}.
+     */
+    static boolean canConvert(Number number, Number anotherNumber) {
+        checkNotNull(number);
+        checkNotNull(anotherNumber);
+        Number unwrappedNumber = unwrap(number);
+        Number unwrappedAnotherNumber = unwrap(anotherNumber);
+        for (ConversionChecker<?> caster : CASTERS) {
+            if (caster.supports(unwrappedNumber)) {
+                return caster.canCast(unwrappedAnotherNumber);
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Unwraps the actual {@code value} from the {@link ComparableNumber}.
+     */
+    private static Number unwrap(Number number) {
+        if (number instanceof ComparableNumber) {
+            return ((ComparableNumber) number).value();
+        }
+        return number;
+    }
+
+    /**
+     * Allows to determine which types a number of {@code <T>} type can be converted to.
+     *
+     * @param <T>
+     *         type of a number for which conversions should be checked
+     */
+    private interface ConversionChecker<T extends Number> {
+
+        /**
+         * Determines if the supplied {@code number} can be safely converted to the type of
+         * the caster.
+         */
+        default boolean canCast(Number number) {
+            Class<? extends Number> numberClass = number.getClass();
+            for (Class<? extends Number> type : convertibleTypes()) {
+                if (type.equals(numberClass)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /**
+         * Determines if the supplied {@code number} is supported by the caster.
+         */
+        default boolean supports(Number number) {
+            return casterType().isInstance(number);
+        }
+
+        /**
+         * Returns {@code T} type class instance.
+         */
+        Class<T> casterType();
+
+        /**
+         * Returns a list of types to witch {@code T} type can be safely converted.
+         */
+        ImmutableList<Class<? extends Number>> convertibleTypes();
+    }
+
+    private static class ByteChecker implements ConversionChecker<Byte> {
+
+        @Override
+        public Class<Byte> casterType() {
+            return Byte.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Byte.class);
+        }
+    }
+
+    private static class ShortChecker implements ConversionChecker<Short> {
+
+        @Override
+        public Class<Short> casterType() {
+            return Short.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Byte.class, Short.class);
+        }
+    }
+
+    private static class IntegerChecker implements ConversionChecker<Integer> {
+
+        @Override
+        public Class<Integer> casterType() {
+            return Integer.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Byte.class, Short.class, Integer.class);
+        }
+    }
+
+    private static class LongChecker implements ConversionChecker<Long> {
+
+        @Override
+        public Class<Long> casterType() {
+            return Long.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Byte.class, Short.class, Integer.class, Long.class);
+        }
+    }
+
+    private static class FloatChecker implements ConversionChecker<Float> {
+
+        @Override
+        public Class<Float> casterType() {
+            return Float.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Float.class);
+        }
+    }
+
+    private static class DoubleChecker implements ConversionChecker<Double> {
+
+        @Override
+        public Class<Double> casterType() {
+            return Double.class;
+        }
+
+        @Override
+        public ImmutableList<Class<? extends Number>> convertibleTypes() {
+            return ImmutableList.of(Float.class, Double.class);
+        }
+    }
+}

--- a/base/src/main/java/io/spine/validate/option/NumberConversionChecker.java
+++ b/base/src/main/java/io/spine/validate/option/NumberConversionChecker.java
@@ -32,7 +32,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 final class NumberConversionChecker {
 
-    private static final ImmutableList<ConversionChecker<?>> CASTERS = ImmutableList.of(
+    private static final ImmutableList<ConversionChecker<?>> CHECKERS = ImmutableList.of(
             new ByteChecker(), new ShortChecker(), new IntegerChecker(), new LongChecker(),
             new FloatChecker(), new DoubleChecker()
     );
@@ -45,14 +45,14 @@ final class NumberConversionChecker {
      * Determines if the supplied {@code number} can be safely converted to the {@code
      * anotherNumber}.
      */
-    static boolean canConvert(Number number, Number anotherNumber) {
+    static boolean check(Number number, Number anotherNumber) {
         checkNotNull(number);
         checkNotNull(anotherNumber);
         Number unwrappedNumber = unwrap(number);
         Number unwrappedAnotherNumber = unwrap(anotherNumber);
-        for (ConversionChecker<?> caster : CASTERS) {
+        for (ConversionChecker<?> caster : CHECKERS) {
             if (caster.supports(unwrappedNumber)) {
-                return caster.canCast(unwrappedAnotherNumber);
+                return caster.isConvertible(unwrappedAnotherNumber);
             }
         }
         return false;
@@ -80,7 +80,7 @@ final class NumberConversionChecker {
          * Determines if the supplied {@code number} can be safely converted to the type of
          * the caster.
          */
-        default boolean canCast(Number number) {
+        default boolean isConvertible(Number number) {
             Class<? extends Number> numberClass = number.getClass();
             for (Class<? extends Number> type : convertibleTypes()) {
                 if (type.equals(numberClass)) {
@@ -103,7 +103,7 @@ final class NumberConversionChecker {
         Class<T> casterType();
 
         /**
-         * Returns a list of types to witch {@code T} type can be safely converted.
+         * Returns types which {@code T} type can be safely converted to.
          */
         ImmutableList<Class<? extends Number>> convertibleTypes();
     }

--- a/base/src/main/java/io/spine/validate/option/Range.java
+++ b/base/src/main/java/io/spine/validate/option/Range.java
@@ -32,7 +32,7 @@ import io.spine.validate.FieldValue;
  *         a value that this option is applied to
  */
 @Immutable
-final class Range<@ImmutableTypeParameter V extends Number & Comparable>
+final class Range<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends FieldValidatingOption<String, V> {
 
     private Range() {
@@ -40,7 +40,7 @@ final class Range<@ImmutableTypeParameter V extends Number & Comparable>
     }
 
     /** Creates a new instance of this option. */
-    static <@ImmutableTypeParameter V extends Number & Comparable> Range<V> create() {
+    static <@ImmutableTypeParameter V extends Number & Comparable<V>> Range<V> create() {
         return new Range<>();
     }
 

--- a/base/src/main/java/io/spine/validate/option/RangeConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/RangeConstraint.java
@@ -40,7 +40,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  *         numeric value that this constraint is applied to
  */
 @Immutable
-final class RangeConstraint<@ImmutableTypeParameter V extends Number & Comparable>
+final class RangeConstraint<@ImmutableTypeParameter V extends Number & Comparable<V>>
         extends RangedConstraint<V, String> {
 
     private static final Splitter RANGE_SPLITTER = Splitter.on("..");

--- a/base/src/main/java/io/spine/validate/option/RangedConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/RangedConstraint.java
@@ -86,12 +86,13 @@ abstract class RangedConstraint<@ImmutableTypeParameter V extends Number & Compa
     }
 
     private void checkBoundaryAndValue(NumberText boundary, FieldValue<V> value) {
-        NumberText valueToCheck = new NumberText(value.singleValue());
-        if (!boundary.isOfSameType(valueToCheck)) {
+        ComparableNumber boundaryNumber = boundary.toNumber();
+        V valueNumber = value.singleValue();
+        if (!NumberConversionChecker.canConvert(boundaryNumber, valueNumber)) {
             String errorMessage =
                     "Boundary values must have types consistent with values they bind: " +
                             "boundary %s, value %s";
-            throw newIllegalStateException(errorMessage, boundary, valueToCheck);
+            throw newIllegalStateException(errorMessage, boundary, valueNumber);
         }
     }
 
@@ -175,4 +176,5 @@ abstract class RangedConstraint<@ImmutableTypeParameter V extends Number & Compa
                ? OR_EQUAL_TO + " %s"
                : "%s";
     }
+
 }

--- a/base/src/main/java/io/spine/validate/option/RangedConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/RangedConstraint.java
@@ -49,7 +49,7 @@ import static java.lang.String.format;
  *         value of the option
  */
 @Immutable
-abstract class RangedConstraint<@ImmutableTypeParameter V extends Number & Comparable,
+abstract class RangedConstraint<@ImmutableTypeParameter V extends Number & Comparable<V>,
                                 @ImmutableTypeParameter T>
         extends NumericFieldConstraint<V, T> {
 
@@ -88,7 +88,7 @@ abstract class RangedConstraint<@ImmutableTypeParameter V extends Number & Compa
     private void checkBoundaryAndValue(NumberText boundary, FieldValue<V> value) {
         ComparableNumber boundaryNumber = boundary.toNumber();
         V valueNumber = value.singleValue();
-        if (!NumberConversionChecker.canConvert(boundaryNumber, valueNumber)) {
+        if (!NumberConversionChecker.check(boundaryNumber, valueNumber)) {
             String errorMessage =
                     "Boundary values must have types consistent with values they bind: " +
                             "boundary %s, value %s";

--- a/base/src/test/java/io/spine/validate/ComparableNumberTest.java
+++ b/base/src/test/java/io/spine/validate/ComparableNumberTest.java
@@ -38,7 +38,7 @@ class ComparableNumberTest {
             String longMaxValue = String.valueOf(Long.MAX_VALUE);
             String doubleMinValue = String.valueOf(Double.MIN_VALUE);
             new EqualsTester()
-                    .addEqualityGroup(new NumberText(1).toNumber(), new NumberText("1").toNumber())
+                    .addEqualityGroup(new NumberText(1L).toNumber(), new NumberText("1").toNumber())
                     .addEqualityGroup(new NumberText(longMaxValue).toNumber(),
                                       new NumberText(Long.MAX_VALUE).toNumber())
                     .addEqualityGroup(new NumberText(doubleMinValue).toNumber(),

--- a/base/src/test/java/io/spine/validate/NumberTextTest.java
+++ b/base/src/test/java/io/spine/validate/NumberTextTest.java
@@ -103,7 +103,9 @@ class NumberTextTest {
                 Arguments.of(0, "0"),
                 Arguments.of(-1.0d, "-1.0"),
                 Arguments.of(-1, "-1"),
-                Arguments.of(-1.23456789d, "-1.23456789")
+                Arguments.of(-1.23456789d, "-1.23456789"),
+                Arguments.of(-3L, "-3"),
+                Arguments.of(-2.23456f, "-2.23456")
         );
     }
 

--- a/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
+++ b/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
@@ -22,6 +22,7 @@ package io.spine.validate.option;
 
 import io.spine.validate.ComparableNumber;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -35,17 +36,96 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @DisplayName("NumberConversionChecker should tell that")
 final class NumberConversionCheckerTest {
 
-    @DisplayName("it is possible to convert byte to byte")
-    @Test
-    void byteToByte() {
-        assertTrue(NumberConversionChecker.canConvert(Byte.valueOf("1"), Byte.valueOf("2")));
+    @DisplayName("it is possible to convert")
+    @Nested
+    final class PossibleToConvert {
+
+        @DisplayName("to byte")
+        @Test
+        void toByte() {
+            assertTrue(NumberConversionChecker.canConvert(Byte.valueOf("1"), Byte.valueOf("2")));
+        }
+
+        @DisplayName("to short")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#shorts")
+        void toShort(Number shortNumber) {
+            assertTrue(NumberConversionChecker.canConvert(Short.valueOf("1"), shortNumber));
+        }
+
+        @DisplayName("to integer")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#integers")
+        void toInteger(Number integerNumber) {
+            assertTrue(NumberConversionChecker.canConvert(1, integerNumber));
+        }
+
+        @DisplayName("to long")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#longs")
+        void toLong(Number longNumber) {
+            assertTrue(NumberConversionChecker.canConvert(1L, longNumber));
+        }
+
+        @DisplayName("to float")
+        @Test
+        void toFloat() {
+            assertTrue(NumberConversionChecker.canConvert(1.0f, 3.14f));
+        }
+
+        @DisplayName("to double")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#doubles")
+        void toDouble(Number doubleNumber) {
+            assertTrue(NumberConversionChecker.canConvert(1.0d, doubleNumber));
+        }
     }
 
-    @DisplayName("it is not possible to convert non-byte to byte")
-    @ParameterizedTest
-    @MethodSource("nonBytes")
-    void byteToOthers(Number nonByte) {
-        assertFalse(NumberConversionChecker.canConvert(Byte.valueOf("1"), nonByte));
+    @DisplayName("it is not possible to convert")
+    @Nested
+    final class NotPossibleToConvert {
+
+        @DisplayName("it is not possible to convert non-byte to byte")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonBytes")
+        void byteToOthers(Number nonByte) {
+            assertFalse(NumberConversionChecker.canConvert(Byte.valueOf("1"), nonByte));
+        }
+
+        @DisplayName("it is not possible to convert non-short to short")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonShorts")
+        void shortToOthers(Number nonShort) {
+            assertFalse(NumberConversionChecker.canConvert(Short.valueOf("1"), nonShort));
+        }
+
+        @DisplayName("it is not possible to convert non-integer to integer")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonIntegers")
+        void integerToOthers(Number nonInteger) {
+            assertFalse(NumberConversionChecker.canConvert(1, nonInteger));
+        }
+
+        @DisplayName("it is not possible to convert non-long to long")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonLongs")
+        void longToOthers(Number nonLong) {
+            assertFalse(NumberConversionChecker.canConvert(1L, nonLong));
+        }
+
+        @DisplayName("it is not possible to convert non-float to float")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonFloats")
+        void floatToOthers(Number nonFloat) {
+            assertFalse(NumberConversionChecker.canConvert(1.0f, nonFloat));
+        }
+
+        @DisplayName("it is not possible to convert non-double to double")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonDoubles")
+        void doubleToOthers(Number nonDouble) {
+            assertFalse(NumberConversionChecker.canConvert(1.0d, nonDouble));
+        }
     }
 
     @DisplayName("ComparableNumber instances are automatically unwrapped")
@@ -61,9 +141,43 @@ final class NumberConversionCheckerTest {
         assertFalse(NumberConversionChecker.canConvert(BigDecimal.valueOf(1), 1L));
     }
 
-    //TODO:2019-06-11:ysergiichuk: Add tests for Short, Integer, Long, Float and Double conversions
-
     private static Stream<Number> nonBytes() {
-        return Stream.of(Short.valueOf("1"), 2, 3L, 4.0, 5.1f);
+        return Stream.concat(Stream.of(Short.valueOf("1")), nonShorts());
+    }
+
+    private static Stream<Number> nonShorts() {
+        return Stream.concat(Stream.of(2), nonIntegers());
+    }
+
+    private static Stream<Number> nonIntegers() {
+        return Stream.concat(Stream.of(3L), nonLongs());
+    }
+
+    private static Stream<Number> nonLongs() {
+        return Stream.of(4.0, 5.1f);
+    }
+
+    private static Stream<Number> nonFloats() {
+        return Stream.concat(nonDoubles(), Stream.of(4.0));
+    }
+
+    private static Stream<Number> nonDoubles() {
+        return Stream.of(Byte.valueOf("1"), Short.valueOf("1"), 2, 3L);
+    }
+
+    private static Stream<Number> shorts() {
+        return Stream.of(Byte.valueOf("1"), Short.valueOf("2"));
+    }
+
+    private static Stream<Number> integers() {
+        return Stream.concat(shorts(), Stream.of(2));
+    }
+
+    private static Stream<Number> longs() {
+        return Stream.concat(integers(), Stream.of(3L));
+    }
+
+    private static Stream<Number> doubles() {
+        return Stream.of(3.14f, 8.19d);
     }
 }

--- a/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
+++ b/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.validate.option;
 
+import io.spine.testing.UtilityClassTest;
 import io.spine.validate.ComparableNumber;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -33,55 +34,59 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("NumberConversionChecker should tell that")
-final class NumberConversionCheckerTest {
+@DisplayName("NumberConversionChecker should")
+final class NumberConversionCheckerTest extends UtilityClassTest<NumberConversionChecker> {
 
-    @DisplayName("it is possible to convert")
+    NumberConversionCheckerTest() {
+        super(NumberConversionChecker.class);
+    }
+
+    @DisplayName("tell that it is possible to convert")
     @Nested
     final class PossibleToConvert {
 
         @DisplayName("to byte")
         @Test
         void toByte() {
-            assertTrue(NumberConversionChecker.canConvert(Byte.valueOf("1"), Byte.valueOf("2")));
+            assertTrue(NumberConversionChecker.check(Byte.valueOf("1"), Byte.valueOf("2")));
         }
 
         @DisplayName("to short")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#shorts")
         void toShort(Number shortNumber) {
-            assertTrue(NumberConversionChecker.canConvert(Short.valueOf("1"), shortNumber));
+            assertTrue(NumberConversionChecker.check(Short.valueOf("1"), shortNumber));
         }
 
         @DisplayName("to integer")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#integers")
         void toInteger(Number integerNumber) {
-            assertTrue(NumberConversionChecker.canConvert(1, integerNumber));
+            assertTrue(NumberConversionChecker.check(1, integerNumber));
         }
 
         @DisplayName("to long")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#longs")
         void toLong(Number longNumber) {
-            assertTrue(NumberConversionChecker.canConvert(1L, longNumber));
+            assertTrue(NumberConversionChecker.check(1L, longNumber));
         }
 
         @DisplayName("to float")
         @Test
         void toFloat() {
-            assertTrue(NumberConversionChecker.canConvert(1.0f, 3.14f));
+            assertTrue(NumberConversionChecker.check(1.0f, 3.14f));
         }
 
         @DisplayName("to double")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#doubles")
         void toDouble(Number doubleNumber) {
-            assertTrue(NumberConversionChecker.canConvert(1.0d, doubleNumber));
+            assertTrue(NumberConversionChecker.check(1.0d, doubleNumber));
         }
     }
 
-    @DisplayName("it is not possible to convert")
+    @DisplayName("tell that it is not possible to convert")
     @Nested
     final class NotPossibleToConvert {
 
@@ -89,56 +94,56 @@ final class NumberConversionCheckerTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonBytes")
         void byteToOthers(Number nonByte) {
-            assertFalse(NumberConversionChecker.canConvert(Byte.valueOf("1"), nonByte));
+            assertFalse(NumberConversionChecker.check(Byte.valueOf("1"), nonByte));
         }
 
         @DisplayName("it is not possible to convert non-short to short")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonShorts")
         void shortToOthers(Number nonShort) {
-            assertFalse(NumberConversionChecker.canConvert(Short.valueOf("1"), nonShort));
+            assertFalse(NumberConversionChecker.check(Short.valueOf("1"), nonShort));
         }
 
         @DisplayName("it is not possible to convert non-integer to integer")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonIntegers")
         void integerToOthers(Number nonInteger) {
-            assertFalse(NumberConversionChecker.canConvert(1, nonInteger));
+            assertFalse(NumberConversionChecker.check(1, nonInteger));
         }
 
         @DisplayName("it is not possible to convert non-long to long")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonLongs")
         void longToOthers(Number nonLong) {
-            assertFalse(NumberConversionChecker.canConvert(1L, nonLong));
+            assertFalse(NumberConversionChecker.check(1L, nonLong));
         }
 
         @DisplayName("it is not possible to convert non-float to float")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonFloats")
         void floatToOthers(Number nonFloat) {
-            assertFalse(NumberConversionChecker.canConvert(1.0f, nonFloat));
+            assertFalse(NumberConversionChecker.check(1.0f, nonFloat));
         }
 
         @DisplayName("it is not possible to convert non-double to double")
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.NumberConversionCheckerTest#nonDoubles")
         void doubleToOthers(Number nonDouble) {
-            assertFalse(NumberConversionChecker.canConvert(1.0d, nonDouble));
+            assertFalse(NumberConversionChecker.check(1.0d, nonDouble));
         }
     }
 
-    @DisplayName("ComparableNumber instances are automatically unwrapped")
+    @DisplayName("tell that ComparableNumber instances are automatically unwrapped")
     @Test
     void comparableNumbersAreUnwrapped() {
         ComparableNumber number = new ComparableNumber(3);
-        assertTrue(NumberConversionChecker.canConvert(number, number));
+        assertTrue(NumberConversionChecker.check(number, number));
     }
 
-    @DisplayName("BigDecimals are not supported")
+    @DisplayName("tell that BigDecimals are not supported")
     @Test
     void bigDecimalsAreNotSupported() {
-        assertFalse(NumberConversionChecker.canConvert(BigDecimal.valueOf(1), 1L));
+        assertFalse(NumberConversionChecker.check(BigDecimal.valueOf(1), 1L));
     }
 
     private static Stream<Number> nonBytes() {

--- a/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
+++ b/base/src/test/java/io/spine/validate/option/NumberConversionCheckerTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.validate.option;
+
+import io.spine.validate.ComparableNumber;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("NumberConversionChecker should tell that")
+final class NumberConversionCheckerTest {
+
+    @DisplayName("it is possible to convert byte to byte")
+    @Test
+    void byteToByte() {
+        assertTrue(NumberConversionChecker.canConvert(Byte.valueOf("1"), Byte.valueOf("2")));
+    }
+
+    @DisplayName("it is not possible to convert non-byte to byte")
+    @ParameterizedTest
+    @MethodSource("nonBytes")
+    void byteToOthers(Number nonByte) {
+        assertFalse(NumberConversionChecker.canConvert(Byte.valueOf("1"), nonByte));
+    }
+
+    @DisplayName("ComparableNumber instances are automatically unwrapped")
+    @Test
+    void comparableNumbersAreUnwrapped() {
+        ComparableNumber number = new ComparableNumber(3);
+        assertTrue(NumberConversionChecker.canConvert(number, number));
+    }
+
+    @DisplayName("BigDecimals are not supported")
+    @Test
+    void bigDecimalsAreNotSupported() {
+        assertFalse(NumberConversionChecker.canConvert(BigDecimal.valueOf(1), 1L));
+    }
+
+    //TODO:2019-06-11:ysergiichuk: Add tests for Short, Integer, Long, Float and Double conversions
+
+    private static Stream<Number> nonBytes() {
+        return Stream.of(Short.valueOf("1"), 2, 3L, 4.0, 5.1f);
+    }
+}

--- a/base/src/test/java/io/spine/validate/option/RangeTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeTest.java
@@ -23,58 +23,102 @@ package io.spine.validate.option;
 import io.spine.test.validate.NumRanges;
 import io.spine.test.validate.RangesHolder;
 import io.spine.validate.MessageValidatorTest;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import static io.spine.validate.MessageValidatorTest.MESSAGE_VALIDATOR_SHOULD;
 
-@Disabled("See https://github.com/SpineEventEngine/base/issues/436")
-@DisplayName(MESSAGE_VALIDATOR_SHOULD + "analyze (range) option and")
+@DisplayName(MESSAGE_VALIDATOR_SHOULD + "analyze (range) option and find out that")
 final class RangeTest extends MessageValidatorTest {
 
-    @DisplayName("find out that hours fit into the defined range")
-    @ParameterizedTest
-    @MethodSource("validHours")
-    void findOutThatHoursFitIntoRange(int hour) {
-        NumRanges msg = validRange()
-                .setHour(hour)
-                .build();
-        assertValid(msg);
+    @Nested
+    @DisplayName("integers")
+    final class Integers {
+
+        @DisplayName("fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validHours")
+        void fitIntoRange(int hour) {
+            NumRanges msg = hourRange(hour);
+            assertValid(msg);
+        }
+
+        @DisplayName("fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validHalfDayHours")
+        void fitIntoExternalConstraintRange(int hour) {
+            NumRanges msg = hourRange(hour);
+            assertValid(holderOf(msg));
+        }
+
+        @DisplayName("do not fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidHours")
+        void doNotFitIntoRange(int hour) {
+            NumRanges msg = hourRange(hour);
+            assertNotValid(msg);
+        }
+
+        @DisplayName("do not fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidHalfDayHours")
+        void doNotFitIntoExternalConstraintRange(int hour) {
+            NumRanges msg = hourRange(hour);
+            assertNotValid(holderOf(msg));
+        }
+
+        private NumRanges hourRange(int hour) {
+            return validRange().setHour(hour)
+                               .build();
+        }
     }
 
-    @DisplayName("find out that hours fit into the defined external constraint range")
-    @ParameterizedTest
-    @MethodSource("validHalfDayHours")
-    void findOutThatHoursFitIntoExternalConstraintRange(int hour) {
-        NumRanges msg = validRange()
-                .setHour(hour)
-                .build();
-        assertValid(holderOf(msg));
-    }
+    @Nested
+    @DisplayName("longs")
+    final class Longs {
 
-    @DisplayName("find out that hours do not fit into the defined range")
-    @ParameterizedTest
-    @MethodSource("invalidHours")
-    void findOutThatHoursDoNotFitIntoRange(int hour) {
-        NumRanges msg = validRange()
-                .setHour(hour)
-                .build();
-        assertNotValid(msg);
-    }
+        @DisplayName("fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validMinutes")
+        void fitIntoRange(long minute) {
+            NumRanges msg = minuteRange(minute);
+            assertValid(msg);
+        }
 
-    @DisplayName("find out that hours do not fit into the defined external constraint range")
-    @ParameterizedTest
-    @MethodSource("invalidHalfDayHours")
-    void findOutThatHoursDoNotFitIntoExternalConstraintRange(int hour) {
-        NumRanges msg = validRange()
-                .setHour(hour)
-                .build();
-        assertNotValid(holderOf(msg));
+        @DisplayName("fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validHalfHourMinutes")
+        void fitIntoExternalConstraintRange(long minute) {
+            NumRanges msg = minuteRange(minute);
+            assertValid(holderOf(msg));
+        }
+
+        @DisplayName("do not fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidMinutes")
+        void doNotFitIntoRange(long minute) {
+            NumRanges msg = minuteRange(minute);
+            assertNotValid(msg);
+        }
+
+        @DisplayName("do not fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidHalfHourMinutes")
+        void doNotFitIntoExternalConstraintRange(long minute) {
+            NumRanges msg = minuteRange(minute);
+            assertNotValid(holderOf(msg));
+        }
+
+        private NumRanges minuteRange(long minute) {
+            return validRange().setMinute(minute)
+                               .build();
+        }
     }
 
     private static RangesHolder holderOf(NumRanges ranges) {
@@ -111,5 +155,25 @@ final class RangeTest extends MessageValidatorTest {
     private static Stream<Integer> validHalfDayHours() {
         return IntStream.range(0, 12)
                         .boxed();
+    }
+
+    private static Stream<Long> invalidHalfHourMinutes() {
+        return LongStream.of(-1, 31, 59, 60, Long.MAX_VALUE, Long.MIN_VALUE)
+                         .boxed();
+    }
+
+    private static Stream<Long> invalidMinutes() {
+        return LongStream.of(-1, 60, 61, Long.MAX_VALUE, Long.MIN_VALUE)
+                         .boxed();
+    }
+
+    private static Stream<Long> validMinutes() {
+        return LongStream.range(0, 59)
+                         .boxed();
+    }
+
+    private static Stream<Long> validHalfHourMinutes() {
+        return LongStream.range(0, 29)
+                         .boxed();
     }
 }

--- a/base/src/test/java/io/spine/validate/option/RangeTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeTest.java
@@ -164,6 +164,48 @@ final class RangeTest extends MessageValidatorTest {
         }
     }
 
+    @Nested
+    @DisplayName("doubles")
+    final class Doubles {
+
+        @DisplayName("fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validAngles")
+        void fitIntoRange(double angle) {
+            NumRanges msg = doubleRange(angle);
+            assertValid(msg);
+        }
+
+        @DisplayName("fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validHalfRangeAngles")
+        void fitIntoExternalConstraintRange(double angle) {
+            NumRanges msg = doubleRange(angle);
+            assertValid(holderOf(msg));
+        }
+
+        @DisplayName("do not fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidAngles")
+        void doNotFitIntoRange(double angle) {
+            NumRanges msg = doubleRange(angle);
+            assertNotValid(msg);
+        }
+
+        @DisplayName("do not fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidHalfRangeAngles")
+        void doNotFitIntoExternalConstraintRange(double angle) {
+            NumRanges msg = doubleRange(angle);
+            assertNotValid(holderOf(msg));
+        }
+
+        private NumRanges doubleRange(double angle) {
+            return validRange().setAngle(angle)
+                               .build();
+        }
+    }
+
     private static RangesHolder holderOf(NumRanges ranges) {
         return RangesHolder
                 .newBuilder()
@@ -242,5 +284,25 @@ final class RangeTest extends MessageValidatorTest {
         return DoubleStream.of(0, 0.54, 1.23, 31.3, 40, 59.9, 179.9)
                            .boxed()
                            .map(Float::new);
+    }
+
+    private static Stream<Double> invalidHalfRangeAngles() {
+        return DoubleStream.of(-1.0, 0, 90, 90.1, Double.MAX_VALUE, -Double.MAX_VALUE)
+                           .boxed();
+    }
+
+    private static Stream<Double> invalidAngles() {
+        return DoubleStream.of(-1.0, 0, 180, 180.1, Double.MAX_VALUE, -Double.MAX_VALUE)
+                           .boxed();
+    }
+
+    private static Stream<Double> validAngles() {
+        return DoubleStream.of(0.01, 0.54, 1.23, 31.3, 40, 59.9, 179.9)
+                           .boxed();
+    }
+
+    private static Stream<Double> validHalfRangeAngles() {
+        return DoubleStream.of(0.01, 0.54, 1.23, 31.3, 40, 59.9, 89.9)
+                           .boxed();
     }
 }

--- a/base/src/test/java/io/spine/validate/option/RangeTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.stream.DoubleStream;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -121,6 +122,48 @@ final class RangeTest extends MessageValidatorTest {
         }
     }
 
+    @Nested
+    @DisplayName("floats")
+    final class Floats {
+
+        @DisplayName("fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validDegrees")
+        void fitIntoRange(float degree) {
+            NumRanges msg = floatRange(degree);
+            assertValid(msg);
+        }
+
+        @DisplayName("fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#validHalfRangeDegrees")
+        void fitIntoExternalConstraintRange(float degree) {
+            NumRanges msg = floatRange(degree);
+            assertValid(holderOf(msg));
+        }
+
+        @DisplayName("do not fit into the defined range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidDegrees")
+        void doNotFitIntoRange(float degree) {
+            NumRanges msg = floatRange(degree);
+            assertNotValid(msg);
+        }
+
+        @DisplayName("do not fit into the defined external constraint range")
+        @ParameterizedTest
+        @MethodSource("io.spine.validate.option.RangeTest#invalidHalfRangeDegrees")
+        void doNotFitIntoExternalConstraintRange(float degree) {
+            NumRanges msg = floatRange(degree);
+            assertNotValid(holderOf(msg));
+        }
+
+        private NumRanges floatRange(float degree) {
+            return validRange().setDegree(degree)
+                               .build();
+        }
+    }
+
     private static RangesHolder holderOf(NumRanges ranges) {
         return RangesHolder
                 .newBuilder()
@@ -175,5 +218,29 @@ final class RangeTest extends MessageValidatorTest {
     private static Stream<Long> validHalfHourMinutes() {
         return LongStream.range(0, 29)
                          .boxed();
+    }
+
+    private static Stream<Float> invalidHalfRangeDegrees() {
+        return DoubleStream.of(-1.0, 180, 180.1, Float.MAX_VALUE, -Float.MAX_VALUE)
+                           .boxed()
+                           .map(Float::new);
+    }
+
+    private static Stream<Float> invalidDegrees() {
+        return DoubleStream.of(-1.0, 360, 360.1, Float.MAX_VALUE, -Float.MAX_VALUE)
+                           .boxed()
+                           .map(Float::new);
+    }
+
+    private static Stream<Float> validDegrees() {
+        return DoubleStream.of(0, 0.54, 1.23, 31.3, 40, 59.9, 180.1, 359.9)
+                           .boxed()
+                           .map(Float::new);
+    }
+
+    private static Stream<Float> validHalfRangeDegrees() {
+        return DoubleStream.of(0, 0.54, 1.23, 31.3, 40, 59.9, 179.9)
+                           .boxed()
+                           .map(Float::new);
     }
 }

--- a/base/src/test/java/io/spine/validate/option/RangeTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeTest.java
@@ -20,11 +20,14 @@
 
 package io.spine.validate.option;
 
+import com.google.common.collect.ImmutableList;
+import io.spine.test.validate.Hours;
 import io.spine.test.validate.NumRanges;
 import io.spine.test.validate.RangesHolder;
 import io.spine.validate.MessageValidatorTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -203,6 +206,31 @@ final class RangeTest extends MessageValidatorTest {
         private NumRanges doubleRange(double angle) {
             return validRange().setAngle(angle)
                                .build();
+        }
+    }
+
+    @Nested
+    @DisplayName("repeated option is")
+    final class RepeatedRange {
+
+        @DisplayName("valid")
+        @Test
+        void valid() {
+            Hours hours = Hours
+                    .newBuilder()
+                    .addAllHour(validHours().collect(ImmutableList.toImmutableList()))
+                    .build();
+            assertValid(hours);
+        }
+
+        @DisplayName("invalid")
+        @Test
+        void invalid() {
+            Hours hours = Hours
+                    .newBuilder()
+                    .addAllHour(invalidHours().collect(ImmutableList.toImmutableList()))
+                    .build();
+            assertNotValid(hours);
         }
     }
 

--- a/base/src/test/proto/spine/test/validate/test_range_option.proto
+++ b/base/src/test/proto/spine/test/validate/test_range_option.proto
@@ -49,3 +49,7 @@ message HalfRangesConstraint {
     float degree = 3 [(range) = "[0.0..180.0)"];
     double angle = 4 [(range) = "(0.0..90.0)"];
 }
+
+message Hours {
+    repeated int32 hour = 1 [(range) = "[0..23]"];
+}

--- a/license-report.md
+++ b/license-report.md
@@ -342,7 +342,7 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:30:58 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -873,7 +873,7 @@ This report was generated on **Mon Jun 10 16:30:58 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:30:58 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1222,7 +1222,7 @@ This report was generated on **Mon Jun 10 16:30:58 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:30:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1701,7 +1701,7 @@ This report was generated on **Mon Jun 10 16:30:59 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:30:59 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:31 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2196,7 +2196,7 @@ This report was generated on **Mon Jun 10 16:30:59 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -2612,7 +2612,7 @@ This report was generated on **Mon Jun 10 16:31:00 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:00 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3091,7 +3091,7 @@ This report was generated on **Mon Jun 10 16:31:00 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -3645,7 +3645,7 @@ This report was generated on **Mon Jun 10 16:31:01 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:01 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4124,7 +4124,7 @@ This report was generated on **Mon Jun 10 16:31:01 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:33 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4461,7 +4461,7 @@ This report was generated on **Mon Jun 10 16:31:02 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -4881,7 +4881,7 @@ This report was generated on **Mon Jun 10 16:31:02 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5297,7 +5297,7 @@ This report was generated on **Mon Jun 10 16:31:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:34 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -5646,4 +5646,4 @@ This report was generated on **Mon Jun 10 16:31:03 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Mon Jun 10 16:31:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jun 12 11:27:35 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@ all modules and does not describe the project structure per-subproject.
  
  -->
 
+<groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
 <version>1.0.0-SNAPSHOT</version>
 
@@ -25,9 +26,166 @@ all modules and does not describe the project structure per-subproject.
 
 <dependencies>
   <dependency>
+    <groupId>com.google.code.findbugs</groupId>
+    <artifactId>jsr305</artifactId>
+    <version>3.0.2</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_annotations</artifactId>
+    <version>2.3.3</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_type_annotations</artifactId>
+    <version>2.3.3</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava</artifactId>
+    <version>27.1-jre</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-gradle-plugin</artifactId>
+    <version>0.8.8</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java</artifactId>
+    <version>3.7.1</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java-util</artifactId>
+    <version>3.7.1</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.squareup</groupId>
+    <artifactId>javapoet</artifactId>
+    <version>1.11.0</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>javax.annotation</groupId>
+    <artifactId>javax.annotation-api</artifactId>
+    <version>1.3.1</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.checkerframework</groupId>
+    <artifactId>checker-qual</artifactId>
+    <version>2.8.0</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.jboss.forge.roaster</groupId>
+    <artifactId>roaster-api</artifactId>
+    <version>2.20.8.Final</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.jboss.forge.roaster</groupId>
+    <artifactId>roaster-jdt</artifactId>
+    <version>2.20.8.Final</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-api</artifactId>
+    <version>1.7.26</version>
+    <scope>compile</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>error_prone_test_helpers</artifactId>
+    <version>2.3.3</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.guava</groupId>
+    <artifactId>guava-testlib</artifactId>
+    <version>27.1-jre</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.truth</groupId>
+    <artifactId>truth</artifactId>
+    <version>0.44</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.truth.extensions</groupId>
+    <artifactId>truth-java8-extension</artifactId>
+    <version>0.44</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.truth.extensions</groupId>
+    <artifactId>truth-proto-extension</artifactId>
+    <version>0.44</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-protoc-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.apiguardian</groupId>
+    <artifactId>apiguardian-api</artifactId>
+    <version>1.0.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.hamcrest</groupId>
+    <artifactId>hamcrest-all</artifactId>
+    <version>1.3</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit-pioneer</groupId>
+    <artifactId>junit-pioneer</artifactId>
+    <version>0.3.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
     <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-engine</artifactId>
+    <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.junit.jupiter</groupId>
+    <artifactId>junit-jupiter-params</artifactId>
+    <version>5.4.2</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-core</artifactId>
+    <version>2.12.0</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-jdk14</artifactId>
+    <version>1.7.26</version>
+    <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>com.google.auto.service</groupId>
@@ -35,94 +193,9 @@ all modules and does not describe the project structure per-subproject.
     <version>1.0-rc5</version>
   </dependency>
   <dependency>
-    <groupId>com.google.protobuf</groupId>
-    <artifactId>protoc</artifactId>
-    <version>3.7.1</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.truth.extensions</groupId>
-    <artifactId>truth-java8-extension</artifactId>
-    <version>0.44</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.errorprone</groupId>
-    <artifactId>error_prone_type_annotations</artifactId>
-    <version>2.3.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-api</artifactId>
-    <version>1.7.26</version>
-  </dependency>
-  <dependency>
-    <groupId>net.sourceforge.pmd</groupId>
-    <artifactId>pmd-java</artifactId>
-    <version>6.13.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.protobuf</groupId>
-    <artifactId>protobuf-java</artifactId>
-    <version>3.7.1</version>
-  </dependency>
-  <dependency>
-    <groupId>org.junit-pioneer</groupId>
-    <artifactId>junit-pioneer</artifactId>
-    <version>0.3.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.errorprone</groupId>
-    <artifactId>javac</artifactId>
-    <version>9+181-r4173-1</version>
-  </dependency>
-  <dependency>
     <groupId>com.google.auto.service</groupId>
     <artifactId>auto-service-annotations</artifactId>
     <version>1.0-rc5</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.protobuf</groupId>
-    <artifactId>protobuf-gradle-plugin</artifactId>
-    <version>0.8.8</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jboss.forge.roaster</groupId>
-    <artifactId>roaster-api</artifactId>
-    <version>2.20.8.Final</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.guava</groupId>
-    <artifactId>guava-testlib</artifactId>
-    <version>27.1-jre</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.truth</groupId>
-    <artifactId>truth</artifactId>
-    <version>0.44</version>
-  </dependency>
-  <dependency>
-    <groupId>org.slf4j</groupId>
-    <artifactId>slf4j-jdk14</artifactId>
-    <version>1.7.26</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.guava</groupId>
-    <artifactId>guava</artifactId>
-    <version>27.1-jre</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.truth.extensions</groupId>
-    <artifactId>truth-proto-extension</artifactId>
-    <version>0.44</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jboss.forge.roaster</groupId>
-    <artifactId>roaster-jdt</artifactId>
-    <version>2.20.8.Final</version>
-  </dependency>
-  <dependency>
-    <groupId>javax.annotation</groupId>
-    <artifactId>javax.annotation-api</artifactId>
-    <version>1.3.1</version>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
@@ -130,74 +203,24 @@ all modules and does not describe the project structure per-subproject.
     <version>2.3.3</version>
   </dependency>
   <dependency>
-    <groupId>org.checkerframework</groupId>
-    <artifactId>checker-qual</artifactId>
-    <version>2.8.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.squareup</groupId>
-    <artifactId>javapoet</artifactId>
-    <version>1.11.0</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jacoco</groupId>
-    <artifactId>org.jacoco.ant</artifactId>
-    <version>0.8.3</version>
-  </dependency>
-  <dependency>
-    <groupId>io.spine.tools</groupId>
-    <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
-  </dependency>
-  <dependency>
     <groupId>com.google.errorprone</groupId>
-    <artifactId>error_prone_test_helpers</artifactId>
-    <version>2.3.3</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.errorprone</groupId>
-    <artifactId>error_prone_annotations</artifactId>
-    <version>2.3.3</version>
+    <artifactId>javac</artifactId>
+    <version>9+181-r4173-1</version>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
-    <artifactId>protobuf-java-util</artifactId>
+    <artifactId>protoc</artifactId>
     <version>3.7.1</version>
   </dependency>
   <dependency>
-    <groupId>org.hamcrest</groupId>
-    <artifactId>hamcrest-all</artifactId>
-    <version>1.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.mockito</groupId>
-    <artifactId>mockito-core</artifactId>
-    <version>2.12.0</version>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-params</artifactId>
-    <version>5.4.2</version>
-  </dependency>
-  <dependency>
-    <groupId>org.apiguardian</groupId>
-    <artifactId>apiguardian-api</artifactId>
-    <version>1.0.0</version>
-  </dependency>
-  <dependency>
-    <groupId>com.google.code.findbugs</groupId>
-    <artifactId>jsr305</artifactId>
-    <version>3.0.2</version>
+    <groupId>net.sourceforge.pmd</groupId>
+    <artifactId>pmd-java</artifactId>
+    <version>6.13.0</version>
   </dependency>
   <dependency>
     <groupId>org.jacoco</groupId>
     <artifactId>org.jacoco.agent</artifactId>
     <version>0.8.3</version>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.4.2</version>
   </dependency>
 </dependencies>
 </project>


### PR DESCRIPTION
This PR fixes #436.

The boundaries are now cast to the actual number type that is under validation. Such a cast allows us to have a unified number model for the boundaries and apply them to various numeric types just as Java does it for automatic primitive numbers conversions.