### PR TITLE
Improve `Environment` accessor name and `InterfaceGenerator ` Javadocs

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,9 +4,11 @@
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="NullableNotNullManager">
+    <option name="myDefaultNullable" value="org.checkerframework.checker.nullness.qual.Nullable" />
+    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
     <option name="myNullables">
       <value>
-        <list size="9">
+        <list size="11">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -16,12 +18,14 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
+          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
+          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="9">
+        <list size="11">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
@@ -31,6 +35,8 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
+          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
+          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
         </list>
       </value>
     </option>

--- a/base/src/main/java/io/spine/base/Environment.java
+++ b/base/src/main/java/io/spine/base/Environment.java
@@ -46,15 +46,26 @@ public final class Environment {
     private @Nullable Boolean tests;
 
     /** Prevents instantiation of this singleton class from outside. */
-    private Environment() {}
+    private Environment() {
+    }
 
     /** Creates a new instance with the copy of the state of the passed environment. */
     private Environment(Environment copy) {
         this.tests = copy.tests;
     }
 
-    /** Returns the singleton instance. */
+    /**
+     * Returns the singleton instance.
+     * 
+     * @deprecated please use {@link #instance()}.
+     */
+    @Deprecated
     public static Environment getInstance() {
+        return instance();
+    }
+
+    /** Returns the singleton instance. */
+    public static Environment instance() {
         return INSTANCE;
     }
 

--- a/base/src/main/java/io/spine/logging/LoggerClassValue.java
+++ b/base/src/main/java/io/spine/logging/LoggerClassValue.java
@@ -55,7 +55,7 @@ class LoggerClassValue extends ClassValue<Logger> {
 
     private LoggerClassValue() {
         super();
-        this.substFactory = Environment.getInstance()
+        this.substFactory = Environment.instance()
                                        .isTests()
                             ? new SubstituteLoggerFactory()
                             : null;

--- a/base/src/test/java/io/spine/base/EnvironmentTest.java
+++ b/base/src/test/java/io/spine/base/EnvironmentTest.java
@@ -53,14 +53,14 @@ class EnvironmentTest extends UtilityClassTest<Environment> {
 
     @BeforeAll
     static void storeEnvironment() {
-        storedEnvironment = Environment.getInstance()
+        storedEnvironment = Environment.instance()
                                        .createCopy();
     }
 
     @SuppressWarnings("StaticVariableUsedBeforeInitialization")
     @AfterAll
     static void restoreEnvironment() {
-        Environment.getInstance()
+        Environment.instance()
                    .restoreFrom(storedEnvironment);
     }
 
@@ -68,19 +68,19 @@ class EnvironmentTest extends UtilityClassTest<Environment> {
 
     @BeforeEach
     void setUp() {
-        environment = Environment.getInstance();
+        environment = Environment.instance();
     }
 
     @AfterEach
     void cleanUp() {
-        Environment.getInstance()
+        Environment.instance()
                    .reset();
     }
 
     @Test
     @DisplayName("tell that we are under tests if env. variable set to true")
     void environmentVarTrue() {
-        Environment.getInstance()
+        Environment.instance()
                    .setToTests();
 
         assertTrue(environment.isTests());

--- a/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/iface/InterfaceGenerator.java
+++ b/tools/protoc-plugin/src/main/java/io/spine/tools/protoc/iface/InterfaceGenerator.java
@@ -53,7 +53,6 @@ public final class InterfaceGenerator extends SpineProtoGenerator {
 
     private final CodeGenerationTasks codeGenerationTasks;
 
-    /** Prevents singleton class instantiation. */
     private InterfaceGenerator(ImmutableList<CodeGenerationTask> tasks) {
         super();
         this.codeGenerationTasks = new CodeGenerationTasks(tasks);
@@ -76,21 +75,20 @@ public final class InterfaceGenerator extends SpineProtoGenerator {
     }
 
     /**
-     * {@inheritDoc}
+     * Makes a generated message class implement an interface according to specified proto options.
      *
-     * <p>The {@code MessageInterfaceGenerator} implementation performs the message processing
-     * as follows:
+     * <p>The method processes the passed message type as follows:
      * <ol>
-     *     <li>Checks the message declaration matches any built-in interface contract. If it does,
+     *     <li>If the message declaration matches any built-in interface contract,
      *         the message insertion point with the appropriate interface name is generated.
-     *     <li>Checks the message has {@code (is)} option. If it does, the interface name is
+     *     <li>If the message has {@code (is)} option, the interface name is
      *         extracted from it and both the interface and the message insertion point are
      *         generated.
-     *     <li>Checks the message file has {@code (every_is)} option. If it does, the interface
-     *         name is extracted from it and both the interface and the message insertion point are
-     *         generated.
-     *     <li>Otherwise, no compiler response is generated for this message type.
+     *     <li>If the file where the message is declared has the {@code (every_is)} option,
+     *         the interface name is extracted from this option and both the interface and
+     *         the message insertion point are generated.
      * </ol>
+     * Otherwise, no compiler response is generated for this message type.
      */
     @Override
     protected Collection<CompilerOutput> generate(Type<?, ?> type) {


### PR DESCRIPTION
This PR:
  * Deprecates `Environment.getInstance()` in favor of `instance()`.
  * Improves documentation of `InterfaceGenerator` class.