### PR TITLE
Slow tests annotation

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,11 +4,9 @@
     <option name="languageLevel" value="ES6" />
   </component>
   <component name="NullableNotNullManager">
-    <option name="myDefaultNullable" value="org.checkerframework.checker.nullness.qual.Nullable" />
-    <option name="myDefaultNotNull" value="org.jetbrains.annotations.NotNull" />
     <option name="myNullables">
       <value>
-        <list size="11">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.Nullable" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nullable" />
           <item index="2" class="java.lang.String" itemvalue="javax.annotation.CheckForNull" />
@@ -18,14 +16,12 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.Nullable" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NullableType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNullable" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.Nullable" />
         </list>
       </value>
     </option>
     <option name="myNotNulls">
       <value>
-        <list size="11">
+        <list size="9">
           <item index="0" class="java.lang.String" itemvalue="org.jetbrains.annotations.NotNull" />
           <item index="1" class="java.lang.String" itemvalue="javax.annotation.Nonnull" />
           <item index="2" class="java.lang.String" itemvalue="javax.validation.constraints.NotNull" />
@@ -35,8 +31,6 @@
           <item index="6" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.qual.NonNull" />
           <item index="7" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullDecl" />
           <item index="8" class="java.lang.String" itemvalue="org.checkerframework.checker.nullness.compatqual.NonNullType" />
-          <item index="9" class="java.lang.String" itemvalue="androidx.annotation.RecentlyNonNull" />
-          <item index="10" class="java.lang.String" itemvalue="com.android.annotations.NonNull" />
         </list>
       </value>
     </option>

--- a/testlib/src/main/java/io/spine/testing/SlowTest.java
+++ b/testlib/src/main/java/io/spine/testing/SlowTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing;
+
+import org.junit.jupiter.api.Tag;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks tests which are known to be slow and should not normally be run together with the main test
+ * suite.
+ *
+ * <p>Slow tests typically are functional test, which may call network API, perform I/O operations,
+ * spawn many threads and wait for execution, etc.
+ *
+ * <p>This annotation is an alias for {@code Tag("slow")}. Adding the {@code slow} tag on a test
+ * case produces the same effect as adding this annotation.
+ */
+@Retention(RUNTIME)
+@Target({TYPE, METHOD})
+@Tag(SlowTest.TAG)
+@SuppressWarnings("unused") // The annotation should be handled by the JUnit runner.
+public @interface SlowTest {
+
+    String TAG = "slow";
+}


### PR DESCRIPTION
The repository, as well as in the others, contains a number of slow functional tests. When building the project, it is not always necessary to run those tests.

This PR introduces the `@SlowTest` annotation. The annotation marks slow test cases/classes in order for the test runner to exclude them from the default build process.

The respective [Gradle configuration](https://github.com/SpineEventEngine/config/pull/76) is added to the `config` repository in order to apply it where it's needed.