### PR TITLE
 Convert ValidationExceptions into Errors with ValidationError

### DIFF
--- a/base/src/main/java/io/spine/base/Errors.java
+++ b/base/src/main/java/io/spine/base/Errors.java
@@ -47,7 +47,8 @@ public final class Errors {
     /**
      * Creates an instance by the root cause of the passed {@link Throwable}.
      *
-     * @param throwable the {@code Throwable} to convert
+     * @param throwable
+     *         the {@code Throwable} to convert
      * @return new instance of {@link Error}
      */
     public static Error causeOf(Throwable throwable) {
@@ -59,10 +60,12 @@ public final class Errors {
      * Creates an instance by the root cause of the given {@link Throwable} with
      * the given error code.
      *
-     * <p>The error code may represent a number in an enum or a native error number
+     * <p>The error code may represent a number in an enum or a native error number.
      *
-     * @param throwable the {@code Throwable} to convert
-     * @param errorCode the error code to include in the resulting {@link Error}
+     * @param throwable
+     *         the {@code Throwable} to convert
+     * @param errorCode
+     *         the error code to include in the resulting {@link Error}
      * @return new instance of {@link Error}
      * @see #causeOf(Throwable) as the recommended overload
      */
@@ -75,16 +78,34 @@ public final class Errors {
         return toErrorBuilder(getRootCause(throwable));
     }
 
+    /**
+     * Converts the given {@code Throwable} into an {@link Error} builder.
+     *
+     * <p>The class FQN of the {@code Throwable} becomes the {@code Error.type}.
+     *
+     * <p>The message of the {@code Throwable} becomes the {@code Error.message}.
+     *
+     * <p>The {@code Error.stacktrace} is populated by dumping the stacktrace of
+     * the {@code Throwable} into a string.
+     *
+     * <p>If the {@code Throwable} is a {@link ValidationException},
+     * the {@code Error.validation_error} is populated from the validation exception.
+     *
+     * @param throwable
+     *         the {@code Throwable} to convert
+     * @return new builder of {@link Error}
+     */
     private static Error.Builder toErrorBuilder(Throwable throwable) {
         checkNotNull(throwable);
         String type = throwable.getClass()
-                               .getName();
+                               .getCanonicalName();
         String message = nullToEmpty(throwable.getMessage());
         String stacktrace = getStackTraceAsString(throwable);
-        Error.Builder result = Error.newBuilder()
-                                     .setType(type)
-                                     .setMessage(message)
-                                     .setStacktrace(stacktrace);
+        Error.Builder result = Error
+                .newBuilder()
+                .setType(type)
+                .setMessage(message)
+                .setStacktrace(stacktrace);
         if (throwable instanceof ValidationException) {
             ValidationException validationException = (ValidationException) throwable;
             result.setValidationError(validationException.asValidationError());

--- a/base/src/test/java/io/spine/base/ErrorsTest.java
+++ b/base/src/test/java/io/spine/base/ErrorsTest.java
@@ -21,9 +21,13 @@
 package io.spine.base;
 
 import io.spine.testing.UtilityClassTest;
+import io.spine.validate.ConstraintViolation;
+import io.spine.validate.ValidationException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import com.google.common.collect.ImmutableList;
 
+import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Errors.causeOf;
 import static io.spine.base.Errors.fromThrowable;
 import static io.spine.base.Identifier.newUuid;
@@ -38,7 +42,7 @@ class ErrorsTest extends UtilityClassTest<Errors> {
 
     @Test
     @DisplayName("convert cause of throwable to Error")
-    void convert_cause_of_throwable_to_Error() {
+    void convertCauseOfThrowableToError() {
         int errorCode = 404;
         String errorMessage = newUuid();
 
@@ -55,12 +59,23 @@ class ErrorsTest extends UtilityClassTest<Errors> {
 
     @Test
     @DisplayName("convert throwable to Error")
-    void convert_throwable_to_Error() {
+    void convertThrowableToError() {
         String errorMessage = newUuid();
         RuntimeException throwable = new RuntimeException(errorMessage);
 
         Error error = fromThrowable(throwable);
 
         assertEquals(errorMessage, error.getMessage());
+    }
+
+    @Test
+    @DisplayName("convert ValidationException into an error with validation_error")
+    void validation() {
+        ConstraintViolation violation = ConstraintViolation
+                .newBuilder()
+                .build();
+        ValidationException exception = new ValidationException(ImmutableList.of(violation));
+        Error error = fromThrowable(exception);
+        assertThat(error.getValidationError()).isEqualTo(exception.asValidationError());
     }
 }


### PR DESCRIPTION
`Errors` utility converts Java's `Throwable`s into `spine.base.Error`s. 

If a given `Throwable` was caused by a constraint violation, the resulting `Error` should reflect that.