### PR TITLE
Extend testlib

### DIFF
--- a/testlib/src/main/java/io/spine/testing/SubjectTest.java
+++ b/testlib/src/main/java/io/spine/testing/SubjectTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing;
+
+import com.google.common.truth.ExpectFailure.SimpleSubjectBuilderCallback;
+import com.google.common.truth.Subject;
+
+import static com.google.common.truth.ExpectFailure.expectFailureAbout;
+import static com.google.common.truth.Truth.assertAbout;
+
+/**
+ * An abstract base for custom {@link Subject} test suites.
+ *
+ * @param <S>
+ *         the type of the {@code Subject}
+ * @param <T>
+ *         the target type tested by the {@code Subject}
+ */
+public abstract class SubjectTest<S extends Subject<S, T>, T> {
+
+    protected static final String EXPECTED = "expected";
+    protected static final String BUT_WAS = "but was";
+    protected static final String EXPECTED_NOT_TO_BE = "expected not to be";
+    protected static final String NULL = "null";
+
+    protected abstract Subject.Factory<S, T> subjectFactory();
+
+    /**
+     * Creates a subject under the test with the passed actual value.
+     */
+    protected S assertWithSubjectThat(T actual) {
+        return assertAbout(subjectFactory()).that(actual);
+    }
+
+    /**
+     * Creates an {@code AssertionError} caused by the passed callback.
+     *
+     * <p>Example of usage:
+     * <pre> {@code
+     * AssertionError failure = expectFailure(whenTesting -> whenTesting.that(myType).hasProperty());
+     * }</pre>
+     */
+    protected AssertionError
+    expectFailure(SimpleSubjectBuilderCallback<S, T> assertionCallback) {
+        return expectFailureAbout(subjectFactory(), assertionCallback);
+    }
+
+    /**
+     * Expects that the passed callback causes {@code AssertionError} and ignores it.
+     *
+     * <p>This method is for test cases where the produced error is of no interest.
+     * Example of usage:
+     * <pre> {@code
+     * expectSomeFailure(whenTesting -> whenTesting.that(myType).hasProperty());
+     * }</pre>
+     */
+    @SuppressWarnings({"ThrowableNotThrown", "CheckReturnValue"}) // Ignore the AssertionError.
+    protected void
+    expectSomeFailure(SimpleSubjectBuilderCallback<S, T> assertionCallback) {
+        expectFailureAbout(subjectFactory(), assertionCallback);
+    }
+}

--- a/testlib/src/test/java/io/spine/testing/logging/LogRecordSubjectTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/LogRecordSubjectTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing.logging;
+
+import com.google.common.truth.Subject;
+import com.google.common.truth.TruthFailureSubject;
+import io.spine.testing.SubjectTest;
+import io.spine.testing.TestValues;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static com.google.common.truth.ExpectFailure.assertThat;
+import static io.spine.testing.logging.LogRecordSubject.NO_LOG_RECORD;
+import static io.spine.testing.logging.LogRecordSubject.records;
+
+@DisplayName("LogRecordSubject should have")
+class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
+
+    private LogRecord record;
+    private String msg;
+    private Level level;
+    private Throwable throwable;
+    private Object[] parameters;
+
+    @Override
+    protected Subject.Factory<LogRecordSubject, LogRecord> subjectFactory() {
+        return records();
+    }
+
+    @BeforeEach
+    void createRecord() {
+        msg = "Test log message" + TestValues.randomString();
+        level = Level.FINE;
+        record = new LogRecord(level, msg);
+        throwable = new RuntimeException("Testing LogRecordSubject handling of Throwable");
+        parameters = new Object[] { '0', "1", 2, 3L, 4.0f, 5.0d, true };
+        record.setParameters(parameters);
+        record.setThrown(throwable);
+    }
+
+    @Test
+    @DisplayName("the check for no logged records")
+    void noRecords() {
+        AssertionError failure = expectFailure(whenTesting -> whenTesting.that(null)
+                                                                         .hasLevelThat());
+        assertThat(failure)
+                .factKeys()
+                .contains(NO_LOG_RECORD);
+    }
+
+    @Test
+    void hasMessageThat() {
+        assertWithSubjectThat(record)
+                .hasMessageThat()
+                .isEqualTo(msg);
+
+        String notExpected = TestValues.randomString();
+
+        AssertionError failure = expectFailure(
+                whenTesting -> whenTesting.that(record)
+                                          .hasMessageThat()
+                                          .isEqualTo(notExpected)
+        );
+        TruthFailureSubject assertFailure = assertThat(failure);
+        assertFailure.factKeys()
+                     .containsAnyOf(EXPECTED, BUT_WAS);
+    }
+
+    @Test
+    void hasLevelThat() {
+        assertWithSubjectThat(record)
+                .hasLevelThat()
+                .isEqualTo(level);
+
+        expectSomeFailure(
+                whenTesting -> whenTesting.that(record)
+                                          .hasLevelThat()
+                                          .isEqualTo(Level.OFF)
+        );
+    }
+
+    @Test
+    void isDebug() {
+        assertWithSubjectThat(record)
+                .isDebug();
+
+        expectSomeFailure(whenTesting -> whenTesting.that(record)
+                                                    .isError());
+    }
+
+    @Test
+    void isError() {
+        record.setLevel(Level.SEVERE);
+        assertWithSubjectThat(record)
+                .isError();
+
+        expectSomeFailure(whenTesting -> whenTesting.that(record)
+                                                    .isDebug());
+    }
+
+    @Test
+    void hasParametersThat() {
+        assertWithSubjectThat(record)
+                .hasParametersThat()
+                .asList()
+                .containsExactlyElementsIn(parameters);
+
+        expectSomeFailure(whenTesting -> whenTesting.that(record)
+                                                    .hasParametersThat()
+                                                    .isEmpty());
+    }
+
+    @Test
+    void hasThrowableThat() {
+        assertWithSubjectThat(record)
+                .hasThrowableThat()
+                .isInstanceOf(throwable.getClass());
+
+        expectSomeFailure(whenTesting -> whenTesting.that(record)
+                                                    .hasThrowableThat()
+                                                    .isNull());
+    }
+}


### PR DESCRIPTION
This PR:
  * Adds `SubjectTest` which was previously used in tests of `core-java`.
  * Extends `LogRecordSubject` with
     * the assertion for  a `Throwable` associated with the `LogRecord` under the test.
     * `isError()` assertion.