### PR TITLE
Allow to force individual dependency versions in `Dependant`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-base:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-base:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -349,12 +349,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:43 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-errorprone-checks:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-errorprone-checks:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -883,12 +883,12 @@ This report was generated on **Wed Aug 28 14:06:43 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-filter:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-javadoc-filter:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1291,12 +1291,12 @@ This report was generated on **Wed Aug 28 14:06:44 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:44 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:23 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-prettifier:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-javadoc-prettifier:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1773,12 +1773,12 @@ This report was generated on **Wed Aug 28 14:06:44 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-compiler:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-model-compiler:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -2271,12 +2271,12 @@ This report was generated on **Wed Aug 28 14:06:45 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:42 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-mute-logging:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-mute-logging:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -2695,12 +2695,12 @@ This report was generated on **Wed Aug 28 14:06:46 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:42:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-base:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-plugin-base:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -3177,12 +3177,12 @@ This report was generated on **Wed Aug 28 14:06:46 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:47 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:02 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-testlib:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -3735,12 +3735,12 @@ This report was generated on **Wed Aug 28 14:06:47 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-proto-js-plugin:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-proto-js-plugin:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -4217,12 +4217,12 @@ This report was generated on **Wed Aug 28 14:06:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:24 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-protoc-api:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-protoc-api:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4557,12 +4557,12 @@ This report was generated on **Wed Aug 28 14:06:48 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:32 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-protoc-plugin:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-protoc-plugin:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4905,12 +4905,12 @@ This report was generated on **Wed Aug 28 14:06:49 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:49 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:40 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testlib:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine:spine-testlib:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -5321,12 +5321,12 @@ This report was generated on **Wed Aug 28 14:06:49 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:48 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-tool-base:1.0.2-SNAPSHOT`
+# Dependencies of `io.spine.tools:spine-tool-base:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -5677,4 +5677,4 @@ This report was generated on **Wed Aug 28 14:06:50 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Wed Aug 28 14:06:50 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 28 20:43:56 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-base:1.0.1`
+# Dependencies of `io.spine:spine-base:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -355,12 +355,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:07 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:30:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-errorprone-checks:1.0.1`
+# Dependencies of `io.spine.tools:spine-errorprone-checks:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -895,12 +895,12 @@ This report was generated on **Thu Aug 08 16:46:07 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:08 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:30:39 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-filter:1.0.1`
+# Dependencies of `io.spine.tools:spine-javadoc-filter:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1309,12 +1309,12 @@ This report was generated on **Thu Aug 08 16:46:08 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:09 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:30:46 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-prettifier:1.0.1`
+# Dependencies of `io.spine.tools:spine-javadoc-prettifier:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -1797,12 +1797,12 @@ This report was generated on **Thu Aug 08 16:46:09 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:30:55 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-compiler:1.0.1`
+# Dependencies of `io.spine.tools:spine-model-compiler:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -2301,12 +2301,12 @@ This report was generated on **Thu Aug 08 16:46:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:10 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:04 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-mute-logging:1.0.1`
+# Dependencies of `io.spine.tools:spine-mute-logging:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -2731,12 +2731,12 @@ This report was generated on **Thu Aug 08 16:46:10 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:11 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-base:1.0.1`
+# Dependencies of `io.spine.tools:spine-plugin-base:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -3219,12 +3219,12 @@ This report was generated on **Thu Aug 08 16:46:11 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:21 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-testlib:1.0.1`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -3783,12 +3783,12 @@ This report was generated on **Thu Aug 08 16:46:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:12 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:30 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-proto-js-plugin:1.0.1`
+# Dependencies of `io.spine.tools:spine-proto-js-plugin:1.0.2`
 
 ## Runtime
 1. **Group:** aopalliance **Name:** aopalliance **Version:** 1.0
@@ -4271,12 +4271,12 @@ This report was generated on **Thu Aug 08 16:46:12 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:13 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:38 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-protoc-api:1.0.1`
+# Dependencies of `io.spine.tools:spine-protoc-api:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4617,12 +4617,12 @@ This report was generated on **Thu Aug 08 16:46:13 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:45 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-protoc-plugin:1.0.1`
+# Dependencies of `io.spine.tools:spine-protoc-plugin:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4971,12 +4971,12 @@ This report was generated on **Thu Aug 08 16:46:14 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:14 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:51 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine:spine-testlib:1.0.1`
+# Dependencies of `io.spine:spine-testlib:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.6.3
@@ -5393,12 +5393,12 @@ This report was generated on **Thu Aug 08 16:46:14 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:15 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:31:57 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-tool-base:1.0.1`
+# Dependencies of `io.spine.tools:spine-tool-base:1.0.2`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -5755,4 +5755,4 @@ This report was generated on **Thu Aug 08 16:46:15 EEST 2019** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Aug 08 16:46:16 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 23 14:32:03 EEST 2019** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>1.0.2-SNAPSHOT</version>
+<version>1.0.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -148,7 +148,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>1.0.1</version>
+<version>1.0.2</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -148,7 +148,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/Artifact.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/Artifact.java
@@ -109,6 +109,20 @@ public final class Artifact {
         return result.toString();
     }
 
+    /**
+     * Returns the artifact group.
+     */
+    public String group() {
+        return group;
+    }
+
+    /**
+     * Returns the artifact name.
+     */
+    public String name() {
+        return name;
+    }
+
     @Override
     public String toString() {
         return notation();

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/Artifact.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/Artifact.java
@@ -109,20 +109,6 @@ public final class Artifact {
         return result.toString();
     }
 
-    /**
-     * Returns the artifact group.
-     */
-    public String group() {
-        return group;
-    }
-
-    /**
-     * Returns the artifact name.
-     */
-    public String name() {
-        return name;
-    }
-
     @Override
     public String toString() {
         return notation();

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -62,12 +62,28 @@ public interface Dependant {
     void force(Artifact artifact);
 
     /**
+     * Forces all project configurations to fetch the particular dependency version.
+     *
+     * @param notation
+     *         the dependency spec, e.g. {@code com.google.protobuf:protoc:3.9.0}
+     */
+    void force(String notation);
+
+    /**
      * Removes a forced dependency from resolution strategies of all project configurations.
      *
      * @param dependency
      *         the dependency to remove from the list of forced dependencies
      */
     void removeForcedDependency(Dependency dependency);
+
+    /**
+     * Removes a forced dependency from resolution strategies of all project configurations.
+     *
+     * @param notation
+     *         the dependency spec, e.g. {@code com.google.protobuf:protoc:3.9.0}
+     */
+    void removeForcedDependency(String notation);
 
     /**
      * Adds a new dependency within the {@code compile} configuration.

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -53,8 +53,22 @@ public interface Dependant {
      */
     void exclude(Dependency dependency);
 
+    /**
+     * Forces all project configurations to use the particular dependency version.
+     *
+     * @param dependency
+     *         the dependency to force
+     * @param version
+     *         the version of the dependency
+     */
     void force(Dependency dependency, String version);
 
+    /**
+     * Removes a forced dependency from resolution strategies of all configurations.
+     *
+     * @param dependency
+     *         the dependency to remove from the list of forced dependencies
+     */
     void removeForcedDependency(Dependency dependency);
 
     /**

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -57,14 +57,14 @@ public interface Dependant {
      * Forces all project configurations to use the particular dependency version.
      *
      * @param dependency
-     *         the dependency to force
+     *         the dependency for which the particular version should be forced
      * @param version
-     *         the version of the dependency
+     *         the required version of the dependency
      */
     void force(Dependency dependency, String version);
 
     /**
-     * Removes a forced dependency from resolution strategies of all configurations.
+     * Removes a forced dependency from resolution strategies of all project configurations.
      *
      * @param dependency
      *         the dependency to remove from the list of forced dependencies

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -53,6 +53,10 @@ public interface Dependant {
      */
     void exclude(Dependency dependency);
 
+    void force(Dependency dependency, String version);
+
+    void removeForcedDependency(Dependency dependency);
+
     /**
      * Adds a new dependency within the {@code compile} configuration.
      *

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -56,12 +56,10 @@ public interface Dependant {
     /**
      * Forces all project configurations to fetch the particular dependency version.
      *
-     * @param dependency
-     *         the forced dependency
-     * @param version
-     *         the required version of the dependency
+     * @param artifact
+     *         the artifact which represents a dependency resolved to the required version
      */
-    void force(Dependency dependency, String version);
+    void force(Artifact artifact);
 
     /**
      * Removes a forced dependency from resolution strategies of all project configurations.

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/Dependant.java
@@ -54,10 +54,10 @@ public interface Dependant {
     void exclude(Dependency dependency);
 
     /**
-     * Forces all project configurations to use the particular dependency version.
+     * Forces all project configurations to fetch the particular dependency version.
      *
      * @param dependency
-     *         the dependency for which the particular version should be forced
+     *         the forced dependency
      * @param version
      *         the required version of the dependency
      */

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
@@ -116,17 +116,17 @@ public final class DependantProject implements Dependant {
     private static void
     removeForcedDependency(Configuration configuration, Dependency dependency) {
         Set<ModuleVersionSelector> forcedModules = configuration.getResolutionStrategy()
-                                                         .getForcedModules();
+                                                                .getForcedModules();
         Collection<ModuleVersionSelector> newForcedModules = new HashSet<>(forcedModules);
         newForcedModules.removeIf(equalsTo(dependency));
 
         configuration.getResolutionStrategy()
-              .setForcedModules(newForcedModules);
+                     .setForcedModules(newForcedModules);
     }
 
     /**
-     * Returns a predicate which compares the given {@link ModuleVersionSelector} to
-     * a Spine {@link Dependency}.
+     * Returns a predicate which tests the equality of the given {@link ModuleVersionSelector} to
+     * a {@link Dependency}.
      */
     private static Predicate<ModuleVersionSelector> equalsTo(Dependency dependency) {
         return selector -> {

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
@@ -105,16 +105,29 @@ public final class DependantProject implements Dependant {
         ));
     }
 
-    private static void removeForcedDependency(Configuration config, Dependency dependency) {
-        Set<ModuleVersionSelector> forcedModules = config.getResolutionStrategy()
+    /**
+     * Removes a forced dependency from the resolution strategy of a given configuration.
+     *
+     * @param configuration
+     *         the configuration to remove a forced dependency from
+     * @param dependency
+     *         the forced dependency
+     */
+    private static void
+    removeForcedDependency(Configuration configuration, Dependency dependency) {
+        Set<ModuleVersionSelector> forcedModules = configuration.getResolutionStrategy()
                                                          .getForcedModules();
         Collection<ModuleVersionSelector> newForcedModules = new HashSet<>(forcedModules);
         newForcedModules.removeIf(equalsTo(dependency));
 
-        config.getResolutionStrategy()
+        configuration.getResolutionStrategy()
               .setForcedModules(newForcedModules);
     }
 
+    /**
+     * Returns a predicate which compares the given {@link ModuleVersionSelector} to
+     * a Spine {@link Dependency}.
+     */
     private static Predicate<ModuleVersionSelector> equalsTo(Dependency dependency) {
         return selector -> {
             boolean groupEquals = dependency.groupId()

--- a/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
+++ b/tools/plugin-base/src/main/java/io/spine/tools/gradle/project/DependantProject.java
@@ -21,6 +21,7 @@
 package io.spine.tools.gradle.project;
 
 import com.google.common.collect.ImmutableMap;
+import io.spine.tools.gradle.Artifact;
 import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.Dependency;
 import org.gradle.api.Project;
@@ -78,11 +79,10 @@ public final class DependantProject implements Dependant {
     }
 
     @Override
-    public void force(Dependency dependency, String version) {
-        String dependencyNotation = dependency.ofVersion(version)
-                                              .notation();
+    public void force(Artifact artifact) {
+        String dependencySpec = artifact.notation();
         configurations.all(config -> config.getResolutionStrategy()
-                                           .force(dependencyNotation));
+                                           .force(dependencySpec));
     }
 
     @Override

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
@@ -163,8 +163,9 @@ class ProjectDependantTest {
                                     .notation();
         Set<ModuleVersionSelector> forcedModules = config.getResolutionStrategy()
                                                          .getForcedModules();
+        String description = "in string form equals to";
         Correspondence<ModuleVersionSelector, String> correspondence =
-                Correspondence.transforming(new ModuleVersionSelectorToNotation(), "");
+                Correspondence.transforming(new ModuleVersionSelectorToNotation(), description);
         assertThat(forcedModules)
                 .comparingElementsUsing(correspondence)
                 .contains(notation);

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
@@ -113,11 +113,6 @@ class ProjectDependantTest {
         checkExcluded(testRuntimeClasspath, unwanted);
     }
 
-    @Test
-    @DisplayName("force the dependency to resolve to a particular version")
-    void forceDependency() {
-        }
-
     @Nested
     @DisplayName("force the dependency to resolve to a particular version")
     class ForceDependency {
@@ -170,7 +165,9 @@ class ProjectDependantTest {
         void asDependency() {
             Dependency dependency = dependency();
             String version = version();
-            forceDependency(dependency, version);
+            String notation = dependency.ofVersion(version)
+                                        .notation();
+            forceDependency(notation);
 
             DependantProject container = DependantProject.from(project);
             container.removeForcedDependency(dependency);
@@ -183,22 +180,20 @@ class ProjectDependantTest {
         void asString() {
             Dependency dependency = dependency();
             String version = version();
-            forceDependency(dependency, version);
-
-            DependantProject container = DependantProject.from(project);
             String notation = dependency.ofVersion(version)
                                         .notation();
+            forceDependency(notation);
+
+            DependantProject container = DependantProject.from(project);
             container.removeForcedDependency(notation);
 
             checkNotForced();
         }
 
-        private void forceDependency(Dependency dependency, String version) {
-            String dependencyNotation = dependency.ofVersion(version)
-                                                  .notation();
+        private void forceDependency(String notation) {
             project.getConfigurations()
                    .forEach(config -> config.getResolutionStrategy()
-                                            .setForcedModules(dependencyNotation));
+                                            .setForcedModules(notation));
         }
 
         private void checkNotForced() {

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
@@ -112,7 +112,7 @@ class ProjectDependantTest {
     }
 
     @Test
-    @DisplayName("force a particular version of the dependency")
+    @DisplayName("force the dependency to resolve to a particular version")
     void forceDependency() {
         DependantProject container = DependantProject.from(project);
         Dependency dependency = dependency();

--- a/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
+++ b/tools/plugin-base/src/test/java/io/spine/tools/gradle/project/ProjectDependantTest.java
@@ -115,12 +115,11 @@ class ProjectDependantTest {
     @DisplayName("force the dependency to resolve to a particular version")
     void forceDependency() {
         DependantProject container = DependantProject.from(project);
-        Dependency dependency = dependency();
-        String version = version();
-        container.force(dependency, version);
+        Artifact artifact = artifact();
+        container.force(artifact);
 
         ConfigurationContainer configurations = project.getConfigurations();
-        configurations.forEach(config -> checkForced(config, dependency, version));
+        configurations.forEach(config -> checkForced(config, artifact));
     }
 
     @Test
@@ -158,9 +157,8 @@ class ProjectDependantTest {
         assertThat(runtimeExclusionRules).containsExactly(excludeRule);
     }
 
-    private static void checkForced(Configuration config, Dependency dependency, String version) {
-        String notation = dependency.ofVersion(version)
-                                    .notation();
+    private static void checkForced(Configuration config, Artifact artifact) {
+        String notation = artifact.notation();
         Set<ModuleVersionSelector> forcedModules = config.getResolutionStrategy()
                                                          .getForcedModules();
         String description = "in string form equals to";

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/testing/MemoizingDependant.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/testing/MemoizingDependant.java
@@ -38,7 +38,7 @@ public final class MemoizingDependant implements Dependant {
 
     private final Set<String> dependencies = newHashSet();
     private final Set<Dependency> exclusions = newHashSet();
-    private final Set<Artifact> forcedDependencies = newHashSet();
+    private final Set<String> forcedDependencies = newHashSet();
 
     @Override
     public void depend(ConfigurationName configuration, String notation) {
@@ -52,12 +52,22 @@ public final class MemoizingDependant implements Dependant {
 
     @Override
     public void force(Artifact artifact) {
-        forcedDependencies.add(artifact);
+        forcedDependencies.add(artifact.notation());
+    }
+
+    @Override
+    public void force(String notation) {
+        forcedDependencies.add(notation);
     }
 
     @Override
     public void removeForcedDependency(Dependency dependency) {
         forcedDependencies.removeIf(matches(dependency));
+    }
+
+    @Override
+    public void removeForcedDependency(String notation) {
+        forcedDependencies.remove(notation);
     }
 
     public ImmutableSet<String> dependencies() {
@@ -68,17 +78,15 @@ public final class MemoizingDependant implements Dependant {
         return ImmutableSet.copyOf(exclusions);
     }
 
-    public ImmutableSet<Artifact> forcedDependencies() {
+    public ImmutableSet<String> forcedDependencies() {
         return ImmutableSet.copyOf(forcedDependencies);
     }
 
-    private static Predicate<Artifact> matches(Dependency dependency) {
-        return artifact -> {
-            boolean groupEquals = dependency.groupId()
-                                            .equals(artifact.group());
-            boolean nameEquals = dependency.name()
-                                           .equals(artifact.name());
-            return groupEquals && nameEquals;
+    private static Predicate<String> matches(Dependency dependency) {
+        return notation -> {
+            String spec = String.format("%s:%s", dependency.groupId(), dependency.name());
+            boolean result = notation.startsWith(spec);
+            return result;
         };
     }
 }

--- a/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/testing/MemoizingDependant.java
+++ b/tools/plugin-testlib/src/main/java/io/spine/tools/gradle/testing/MemoizingDependant.java
@@ -20,13 +20,16 @@
 
 package io.spine.tools.gradle.testing;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.spine.tools.gradle.ConfigurationName;
 import io.spine.tools.gradle.Dependency;
 import io.spine.tools.gradle.project.Dependant;
 
+import java.util.Map;
 import java.util.Set;
 
+import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.collect.Sets.newHashSet;
 
 /**
@@ -36,6 +39,7 @@ public final class MemoizingDependant implements Dependant {
 
     private final Set<String> dependencies = newHashSet();
     private final Set<Dependency> exclusions = newHashSet();
+    private final Map<Dependency, String> forcedDependencies = newHashMap();
 
     @Override
     public void depend(ConfigurationName configuration, String notation) {
@@ -47,11 +51,25 @@ public final class MemoizingDependant implements Dependant {
         exclusions.add(dependency);
     }
 
+    @Override
+    public void force(Dependency dependency, String version) {
+        forcedDependencies.put(dependency, version);
+    }
+
+    @Override
+    public void removeForcedDependency(Dependency dependency) {
+        forcedDependencies.remove(dependency);
+    }
+
     public ImmutableSet<String> dependencies() {
         return ImmutableSet.copyOf(dependencies);
     }
 
     public ImmutableSet<Dependency> exclusions() {
         return ImmutableSet.copyOf(exclusions);
+    }
+
+    public ImmutableMap<Dependency, String> forcedDependencies() {
+        return ImmutableMap.copyOf(forcedDependencies);
     }
 }

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
@@ -20,6 +20,7 @@
 
 package io.spine.tools.gradle.testing;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.spine.tools.gradle.Artifact;
 import io.spine.tools.gradle.Dependency;
@@ -58,6 +59,27 @@ class MemoizingDependantTest {
         checkExcluded(unwanted);
     }
 
+    @Test
+    @DisplayName("memoize a forced dependency")
+    void addForcedDependency() {
+        Dependency dependency = dependency();
+        String version = version();
+        container.force(dependency, version);
+
+        checkForced(dependency, version);
+    }
+
+    @Test
+    @DisplayName("remove memoized forced dependency")
+    void removeForcedDependency() {
+        Dependency dependency = dependency();
+        String version = version();
+        container.force(dependency, version);
+
+        container.removeForcedDependency(dependency);
+        assertThat(container.forcedDependencies()).isEmpty();
+    }
+
     private void checkDependency(Artifact dependency) {
         ImmutableSet<String> dependencies = container.dependencies();
         assertThat(dependencies).contains(dependency.notation());
@@ -68,11 +90,20 @@ class MemoizingDependantTest {
         assertThat(exclusions).contains(unwanted);
     }
 
+    private void checkForced(Dependency dependency, String version) {
+        ImmutableMap<Dependency, String> forcedDependencies = container.forcedDependencies();
+        assertThat(forcedDependencies).containsExactly(dependency, version);
+    }
+
     private static Dependency dependency() {
         return new ThirdPartyDependency("test.dependency", "test-dependency");
     }
 
+    private static String version() {
+        return "3.14";
+    }
+
     private static Artifact artifact() {
-        return dependency().ofVersion("3.14");
+        return dependency().ofVersion(version());
     }
 }

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
@@ -26,10 +26,12 @@ import io.spine.tools.gradle.Dependency;
 import io.spine.tools.gradle.ThirdPartyDependency;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
+@SuppressWarnings("DuplicateStringLiteralInspection") // Test display names duplication.
 @DisplayName("MemoizingDependant should")
 class MemoizingDependantTest {
 
@@ -58,24 +60,61 @@ class MemoizingDependantTest {
         checkExcluded(unwanted);
     }
 
-    @Test
+    @Nested
     @DisplayName("memoize a forced dependency")
-    void addForcedDependency() {
-        Artifact artifact = artifact();
-        container.force(artifact);
+    class MemoizeForcedDependency {
 
-        checkForced(artifact);
+        @Test
+        @DisplayName("represented as `Artifact`")
+        void representedAsArtifact() {
+            Artifact artifact = artifact();
+            container.force(artifact);
+
+            checkForced(artifact);
+        }
+
+        @Test
+        @DisplayName("represented as `String` notation")
+        void representedAsString() {
+            Artifact artifact = artifact();
+            String notation = artifact.notation();
+            container.force(notation);
+
+            checkForced(artifact);
+        }
+
+        private void checkForced(Artifact artifact) {
+            ImmutableSet<String> forcedDependencies = container.forcedDependencies();
+            String notation = artifact.notation();
+            assertThat(forcedDependencies).contains(notation);
+        }
     }
 
-    @Test
+    @Nested
     @DisplayName("remove memoized forced dependency")
-    void removeForcedDependency() {
-        container.force(artifact());
+    class RemoveMemoizedForcedDependency {
 
-        Dependency dependency = dependency();
-        container.removeForcedDependency(dependency);
+        @Test
+        @DisplayName("represented as `Dependency`")
+        void representedAsDependency() {
+            container.force(artifact());
 
-        assertThat(container.forcedDependencies()).isEmpty();
+            Dependency dependency = dependency();
+            container.removeForcedDependency(dependency);
+
+            assertThat(container.forcedDependencies()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("represented as `String` notation")
+        void representedAsString() {
+            container.force(artifact());
+
+            String notation = artifact().notation();
+            container.removeForcedDependency(notation);
+
+            assertThat(container.forcedDependencies()).isEmpty();
+        }
     }
 
     private void checkDependency(Artifact dependency) {
@@ -86,11 +125,6 @@ class MemoizingDependantTest {
     private void checkExcluded(Dependency unwanted) {
         ImmutableSet<Dependency> exclusions = container.exclusions();
         assertThat(exclusions).contains(unwanted);
-    }
-
-    private void checkForced(Artifact artifact) {
-        ImmutableSet<Artifact> forcedDependencies = container.forcedDependencies();
-        assertThat(forcedDependencies).contains(artifact);
     }
 
     private static Dependency dependency() {

--- a/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
+++ b/tools/plugin-testlib/src/test/java/io/spine/tools/gradle/testing/MemoizingDependantTest.java
@@ -20,7 +20,6 @@
 
 package io.spine.tools.gradle.testing;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.spine.tools.gradle.Artifact;
 import io.spine.tools.gradle.Dependency;
@@ -62,21 +61,20 @@ class MemoizingDependantTest {
     @Test
     @DisplayName("memoize a forced dependency")
     void addForcedDependency() {
-        Dependency dependency = dependency();
-        String version = version();
-        container.force(dependency, version);
+        Artifact artifact = artifact();
+        container.force(artifact);
 
-        checkForced(dependency, version);
+        checkForced(artifact);
     }
 
     @Test
     @DisplayName("remove memoized forced dependency")
     void removeForcedDependency() {
-        Dependency dependency = dependency();
-        String version = version();
-        container.force(dependency, version);
+        container.force(artifact());
 
+        Dependency dependency = dependency();
         container.removeForcedDependency(dependency);
+
         assertThat(container.forcedDependencies()).isEmpty();
     }
 
@@ -90,9 +88,9 @@ class MemoizingDependantTest {
         assertThat(exclusions).contains(unwanted);
     }
 
-    private void checkForced(Dependency dependency, String version) {
-        ImmutableMap<Dependency, String> forcedDependencies = container.forcedDependencies();
-        assertThat(forcedDependencies).containsExactly(dependency, version);
+    private void checkForced(Artifact artifact) {
+        ImmutableSet<Artifact> forcedDependencies = container.forcedDependencies();
+        assertThat(forcedDependencies).contains(artifact);
     }
 
     private static Dependency dependency() {

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.0.2-SNAPSHOT'
+final def SPINE_VERSION = '1.0.2'
 
 ext {
     spineVersion = SPINE_VERSION

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.0.1'
+final def SPINE_VERSION = '1.0.2-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR is a part of https://github.com/SpineEventEngine/bootstrap/pull/30.

The `Dependant` is expanded with `force(...)` and `removeForcedDependency(...)` methods which allow to force the required dependency version and remove the forced dependency from the project respectively.

Spine version is updated to `1.0.2`.