### PR TITLE
Fix `Stringifiers.toString(...)` not processing enum values

### DIFF
--- a/.idea/dictionaries/common.xml
+++ b/.idea/dictionaries/common.xml
@@ -43,6 +43,7 @@
       <w>processmanager</w>
       <w>procman</w>
       <w>proto's</w>
+      <w>protobuf</w>
       <w>protos</w>
       <w>sfixed</w>
       <w>stderr</w>

--- a/base/src/main/java/io/spine/protobuf/Messages.java
+++ b/base/src/main/java/io/spine/protobuf/Messages.java
@@ -29,7 +29,6 @@ import io.spine.annotation.Internal;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Type;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
@@ -87,23 +86,6 @@ public final class Messages {
                                    clazz.getCanonicalName());
             throw new IllegalArgumentException(errMsg, e);
         }
-    }
-
-    /**
-     * Checks that the {@code Type} is a {@code Class} of the {@code Message}.
-     *
-     * @param typeToCheck the type to check
-     * @return {@code true} if the type is message class, {@code false} otherwise
-     */
-    @Internal
-    public static boolean isMessage(Type typeToCheck) {
-        checkNotNull(typeToCheck);
-        if (typeToCheck instanceof Class) {
-            Class<?> aClass = (Class) typeToCheck;
-            boolean isMessage = Message.class.isAssignableFrom(aClass);
-            return isMessage;
-        }
-        return false;
     }
 
     /**

--- a/base/src/main/java/io/spine/reflect/Types.java
+++ b/base/src/main/java/io/spine/reflect/Types.java
@@ -87,6 +87,20 @@ public final class Types {
     }
 
     /**
+     * Checks if the given type is a {@code enum} type.
+     *
+     * @param type
+     *         the type to check
+     * @return {@code true} if the given type is a {@code enum} type and {@code false} otherwise
+     */
+    public static boolean isEnum(Type type) {
+        TypeToken<?> token = TypeToken.of(type);
+        Class<?> rawClass = token.getRawType();
+        boolean result = rawClass.isEnum();
+        return result;
+    }
+
+    /**
      * Obtains parameter values of a parameterized type.
      *
      * <p>If the parameters are generic types themselves, their arguments are preserved.

--- a/base/src/main/java/io/spine/reflect/Types.java
+++ b/base/src/main/java/io/spine/reflect/Types.java
@@ -92,7 +92,7 @@ public final class Types {
      *
      * @param type
      *         the type to check
-     * @return {@code true} if the given type is a {@code enum} type and {@code false} otherwise
+     * @return {@code true} if the given type is a {@code enum} class and {@code false} otherwise
      */
     public static boolean isEnumClass(Type type) {
         checkNotNull(type);

--- a/base/src/main/java/io/spine/reflect/Types.java
+++ b/base/src/main/java/io/spine/reflect/Types.java
@@ -23,6 +23,7 @@ package io.spine.reflect;
 import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeParameter;
 import com.google.common.reflect.TypeToken;
+import com.google.protobuf.Message;
 
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
@@ -87,17 +88,37 @@ public final class Types {
     }
 
     /**
-     * Checks if the given type is a {@code enum} type.
+     * Checks if the given type is a {@code enum} {@code Class}.
      *
      * @param type
      *         the type to check
      * @return {@code true} if the given type is a {@code enum} type and {@code false} otherwise
      */
-    public static boolean isEnum(Type type) {
-        TypeToken<?> token = TypeToken.of(type);
-        Class<?> rawClass = token.getRawType();
-        boolean result = rawClass.isEnum();
-        return result;
+    public static boolean isEnumClass(Type type) {
+        checkNotNull(type);
+        if (type instanceof Class) {
+            Class aClass = (Class) type;
+            boolean isEnum = aClass.isEnum();
+            return isEnum;
+        }
+        return false;
+    }
+
+    /**
+     * Checks that the type is a {@code Class} of the {@code Message}.
+     *
+     * @param type
+     *         the type to check
+     * @return {@code true} if the type is message class, {@code false} otherwise
+     */
+    public static boolean isMessageClass(Type type) {
+        checkNotNull(type);
+        if (type instanceof Class) {
+            Class<?> aClass = (Class) type;
+            boolean isMessage = Message.class.isAssignableFrom(aClass);
+            return isMessage;
+        }
+        return false;
     }
 
     /**

--- a/base/src/main/java/io/spine/string/EnumStringifier.java
+++ b/base/src/main/java/io/spine/string/EnumStringifier.java
@@ -25,16 +25,16 @@ import com.google.common.annotations.VisibleForTesting;
 import static java.lang.String.format;
 
 /**
- * Abstract base for stringifiers that work with enum values.
+ * A stringifier for {@code enum} values.
  *
  * @param <E>
- *         the type of the enum
+ *         the type of the {@code enum}
  */
 public final class EnumStringifier<E extends Enum<E>> extends SerializableStringifier<E> {
 
     private static final long serialVersionUID = 0L;
 
-    private static final String DEFAULT_IDENTITY = "a stringifier of enum class `%s`";
+    private static final String DEFAULT_IDENTITY_FORMAT = "a stringifier of enum class `%s`";
 
     private final Class<E> enumClass;
 
@@ -60,6 +60,6 @@ public final class EnumStringifier<E extends Enum<E>> extends SerializableString
 
     @VisibleForTesting
     static <E extends Enum<E>> String defaultIdentity(Class<E> enumClass) {
-        return format(DEFAULT_IDENTITY, enumClass.getCanonicalName());
+        return format(DEFAULT_IDENTITY_FORMAT, enumClass.getCanonicalName());
     }
 }

--- a/base/src/main/java/io/spine/string/EnumStringifier.java
+++ b/base/src/main/java/io/spine/string/EnumStringifier.java
@@ -30,7 +30,7 @@ import static java.lang.String.format;
  * @param <E>
  *         the type of the {@code enum}
  */
-public final class EnumStringifier<E extends Enum<E>> extends SerializableStringifier<E> {
+final class EnumStringifier<E extends Enum<E>> extends SerializableStringifier<E> {
 
     private static final long serialVersionUID = 0L;
 
@@ -38,7 +38,7 @@ public final class EnumStringifier<E extends Enum<E>> extends SerializableString
 
     private final Class<E> enumClass;
 
-    public EnumStringifier(Class<E> enumClass) {
+    EnumStringifier(Class<E> enumClass) {
         super(identity(enumClass));
         this.enumClass = enumClass;
     }

--- a/base/src/main/java/io/spine/string/EnumStringifier.java
+++ b/base/src/main/java/io/spine/string/EnumStringifier.java
@@ -20,20 +20,31 @@
 
 package io.spine.string;
 
+import com.google.common.annotations.VisibleForTesting;
+
+import static java.lang.String.format;
+
 /**
  * Abstract base for stringifiers that work with enum values.
  *
- * @param <E> the type of the enum
+ * @param <E>
+ *         the type of the enum
  */
-public abstract class EnumStringifier<E extends Enum<E>> extends SerializableStringifier<E> {
+public final class EnumStringifier<E extends Enum<E>> extends SerializableStringifier<E> {
 
     private static final long serialVersionUID = 0L;
 
+    private static final String DEFAULT_IDENTITY = "a stringifier of enum class `%s`";
+
     private final Class<E> enumClass;
 
-    protected EnumStringifier(String identity, Class<E> aClass) {
+    public EnumStringifier(String identity, Class<E> enumClass) {
         super(identity);
-        enumClass = aClass;
+        this.enumClass = enumClass;
+    }
+
+    public EnumStringifier(Class<E> enumClass) {
+        this(defaultIdentity(enumClass), enumClass);
     }
 
     @Override
@@ -45,5 +56,10 @@ public abstract class EnumStringifier<E extends Enum<E>> extends SerializableStr
     protected final E fromString(String s) {
         E result = Enum.valueOf(enumClass, s);
         return result;
+    }
+
+    @VisibleForTesting
+    static <E extends Enum<E>> String defaultIdentity(Class<E> enumClass) {
+        return format(DEFAULT_IDENTITY, enumClass.getCanonicalName());
     }
 }

--- a/base/src/main/java/io/spine/string/EnumStringifier.java
+++ b/base/src/main/java/io/spine/string/EnumStringifier.java
@@ -34,17 +34,13 @@ public final class EnumStringifier<E extends Enum<E>> extends SerializableString
 
     private static final long serialVersionUID = 0L;
 
-    private static final String DEFAULT_IDENTITY_FORMAT = "a stringifier of enum class `%s`";
+    private static final String IDENTITY_FORMAT = "Stringifiers.newForEnum(%s.class)";
 
     private final Class<E> enumClass;
 
-    public EnumStringifier(String identity, Class<E> enumClass) {
-        super(identity);
-        this.enumClass = enumClass;
-    }
-
     public EnumStringifier(Class<E> enumClass) {
-        this(defaultIdentity(enumClass), enumClass);
+        super(identity(enumClass));
+        this.enumClass = enumClass;
     }
 
     @Override
@@ -59,7 +55,7 @@ public final class EnumStringifier<E extends Enum<E>> extends SerializableString
     }
 
     @VisibleForTesting
-    static <E extends Enum<E>> String defaultIdentity(Class<E> enumClass) {
-        return format(DEFAULT_IDENTITY_FORMAT, enumClass.getCanonicalName());
+    static <E extends Enum<E>> String identity(Class<E> enumClass) {
+        return format(IDENTITY_FORMAT, enumClass.getSimpleName());
     }
 }

--- a/base/src/main/java/io/spine/string/StringifierRegistry.java
+++ b/base/src/main/java/io/spine/string/StringifierRegistry.java
@@ -32,12 +32,14 @@ import java.util.Optional;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMap;
 import static io.spine.protobuf.Messages.isMessage;
+import static io.spine.reflect.Types.isEnum;
 import static io.spine.string.Stringifiers.forBoolean;
 import static io.spine.string.Stringifiers.forDuration;
 import static io.spine.string.Stringifiers.forInteger;
 import static io.spine.string.Stringifiers.forLong;
 import static io.spine.string.Stringifiers.forString;
 import static io.spine.string.Stringifiers.forTimestamp;
+import static io.spine.string.Stringifiers.newForEnum;
 import static io.spine.string.Stringifiers.newForMessage;
 import static java.lang.String.format;
 import static java.util.Collections.synchronizedMap;
@@ -80,6 +82,12 @@ public final class StringifierRegistry {
         if (optional.isPresent()) {
             Stringifier<T> stringifier = optional.get();
             return stringifier;
+        }
+
+        if (isEnum(typeOfT)) {
+            @SuppressWarnings("unchecked") // OK since the type is checked above.
+            Stringifier<T> result = (Stringifier<T>) newForEnum((Class<Enum>) typeOfT);
+            return result;
         }
 
         if (isMessage(typeOfT)) {

--- a/base/src/main/java/io/spine/string/StringifierRegistry.java
+++ b/base/src/main/java/io/spine/string/StringifierRegistry.java
@@ -31,8 +31,8 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.Maps.newHashMap;
-import static io.spine.protobuf.Messages.isMessage;
-import static io.spine.reflect.Types.isEnum;
+import static io.spine.reflect.Types.isEnumClass;
+import static io.spine.reflect.Types.isMessageClass;
 import static io.spine.string.Stringifiers.forBoolean;
 import static io.spine.string.Stringifiers.forDuration;
 import static io.spine.string.Stringifiers.forInteger;
@@ -84,13 +84,13 @@ public final class StringifierRegistry {
             return stringifier;
         }
 
-        if (isEnum(typeOfT)) {
+        if (isEnumClass(typeOfT)) {
             @SuppressWarnings("unchecked") // OK since the type is checked above.
             Stringifier<T> result = (Stringifier<T>) newForEnum((Class<Enum>) typeOfT);
             return result;
         }
 
-        if (isMessage(typeOfT)) {
+        if (isMessageClass(typeOfT)) {
             @SuppressWarnings("unchecked") // OK since the type is checked above.
             Stringifier<T> result = (Stringifier<T>) newForMessage((Class<Message>) typeOfT);
             return result;

--- a/base/src/main/java/io/spine/string/StringifierRegistry.java
+++ b/base/src/main/java/io/spine/string/StringifierRegistry.java
@@ -114,9 +114,12 @@ public final class StringifierRegistry {
     /**
      * Registers the passed stringifier in the registry.
      *
-     * @param stringifier the stringifier to register
-     * @param typeOfT     the value of the type of objects handled by the stringifier
-     * @param <T>         the type of the objects handled by the stringifier
+     * @param stringifier
+     *         the stringifier to register
+     * @param typeOfT
+     *         the value of the type of objects handled by the stringifier
+     * @param <T>
+     *         the type of the objects handled by the stringifier
      */
     public <T> void register(Stringifier<T> stringifier, Type typeOfT) {
         checkNotNull(typeOfT);
@@ -127,8 +130,10 @@ public final class StringifierRegistry {
     /**
      * Obtains a {@code Stringifier} for the passed type.
      *
-     * @param typeOfT the type to stringify
-     * @param <T>     the type of the values to convert
+     * @param typeOfT
+     *         the type to stringify
+     * @param <T>
+     *         the type of the values to convert
      * @return the found {@code Stringifier} or empty {@code Optional}
      */
     public <T> Optional<Stringifier<T>> get(Type typeOfT) {

--- a/base/src/main/java/io/spine/string/Stringifiers.java
+++ b/base/src/main/java/io/spine/string/Stringifiers.java
@@ -241,7 +241,7 @@ public final class Stringifiers {
      *         the type of the {@code enum}
      * @return the stringifier for the passed {@code enum} class
      */
-    static <T extends Enum<T>> Stringifier<T> newForEnum(Class<T> enumClass) {
+    public static <T extends Enum<T>> Stringifier<T> newForEnum(Class<T> enumClass) {
         checkNotNull(enumClass);
         EnumStringifier<T> result = new EnumStringifier<>(enumClass);
         return result;

--- a/base/src/main/java/io/spine/string/Stringifiers.java
+++ b/base/src/main/java/io/spine/string/Stringifiers.java
@@ -47,8 +47,10 @@ public final class Stringifiers {
      * <p>Use this method for converting non-generic objects. For generic objects,
      * please use {@link #toString(Object, Type)}.
      *
-     * @param object the object to convert
-     * @param <T>    the type of the object
+     * @param object
+     *         the object to convert
+     * @param <T>
+     *         the type of the object
      * @return the string representation of the passed object
      */
     public static <T> String toString(T object) {
@@ -61,11 +63,15 @@ public final class Stringifiers {
      *
      * <p>This method must be used if the passed object is a generic type.
      *
-     * @param object  to object to convert
-     * @param typeOfT the type of the passed object
-     * @param <T>     the type of the object to convert
+     * @param object
+     *         to object to convert
+     * @param typeOfT
+     *         the type of the passed object
+     * @param <T>
+     *         the type of the object to convert
      * @return the string representation of the passed object
-     * @throws MissingStringifierException if passed value cannot be converted
+     * @throws MissingStringifierException
+     *         if passed value cannot be converted
      */
     public static <T> String toString(T object, Type typeOfT) {
         checkNotNull(object);
@@ -78,11 +84,15 @@ public final class Stringifiers {
     /**
      * Converts string value to the specified type.
      *
-     * @param str     the string to convert
-     * @param typeOfT the type into which to convert the string
-     * @param <T>     the type of the value to return
+     * @param str
+     *         the string to convert
+     * @param typeOfT
+     *         the type into which to convert the string
+     * @param <T>
+     *         the type of the value to return
      * @return the parsed value from string
-     * @throws MissingStringifierException if passed value cannot be converted
+     * @throws MissingStringifierException
+     *         if passed value cannot be converted
      */
     public static <T> T fromString(String str, Class<T> typeOfT) {
         checkNotNull(str);
@@ -96,10 +106,14 @@ public final class Stringifiers {
     /**
      * Obtains {@code Stringifier} for the map with default delimiter for the passed map elements.
      *
-     * @param keyClass   the class of keys are maintained by this map
-     * @param valueClass the class  of mapped values
-     * @param <K>        the type of keys are maintained by this map
-     * @param <V>        the type of the values stored in this map
+     * @param keyClass
+     *         the class of keys are maintained by this map
+     * @param valueClass
+     *         the class  of mapped values
+     * @param <K>
+     *         the type of keys are maintained by this map
+     * @param <V>
+     *         the type of the values stored in this map
      * @return the stringifier for the map
      */
     public static <K, V>
@@ -113,11 +127,16 @@ public final class Stringifiers {
     /**
      * Obtains {@code Stringifier} for the map with custom delimiter for the passed map elements.
      *
-     * @param keyClass   the class of keys are maintained by this map
-     * @param valueClass the class  of mapped values
-     * @param delimiter  the delimiter for the passed map elements via string
-     * @param <K>        the type of keys are maintained by this map
-     * @param <V>        the type of mapped values
+     * @param keyClass
+     *         the class of keys are maintained by this map
+     * @param valueClass
+     *         the class  of mapped values
+     * @param delimiter
+     *         the delimiter for the passed map elements via string
+     * @param <K>
+     *         the type of keys are maintained by this map
+     * @param <V>
+     *         the type of mapped values
      * @return the stringifier for the map
      */
     public static <K, V>
@@ -184,8 +203,10 @@ public final class Stringifiers {
     /**
      * Obtains {@code Stringifier} for list with default delimiter for the passed list elements.
      *
-     * @param elementClass the class of the list elements
-     * @param <T>          the type of the elements in this list
+     * @param elementClass
+     *         the class of the list elements
+     * @param <T>
+     *         the type of the elements in this list
      * @return the stringifier for the list
      */
     public static <T> Stringifier<List<T>> newForListOf(Class<T> elementClass) {
@@ -197,9 +218,12 @@ public final class Stringifiers {
     /**
      * Obtains {@code Stringifier} for list with the custom delimiter for the passed list elements.
      *
-     * @param elementClass the class of the list elements
-     * @param delimiter    the delimiter or the list elements passed via string
-     * @param <T>          the type of the elements in this list
+     * @param elementClass
+     *         the class of the list elements
+     * @param delimiter
+     *         the delimiter or the list elements passed via string
+     * @param <T>
+     *         the type of the elements in this list
      * @return the stringifier for the list
      */
     public static <T> Stringifier<List<T>> newForListOf(Class<T> elementClass, char delimiter) {
@@ -208,6 +232,15 @@ public final class Stringifiers {
         return result;
     }
 
+    /**
+     * Obtains a {@code Stringifier} for the passed {@code enum} class.
+     *
+     * @param enumClass
+     *         the {@code enum} class
+     * @param <T>
+     *         the type of the {@code enum}
+     * @return the stringifier for the passed {@code enum} class
+     */
     static <T extends Enum<T>> Stringifier<T> newForEnum(Class<T> enumClass) {
         checkNotNull(enumClass);
         EnumStringifier<T> result = new EnumStringifier<>(enumClass);
@@ -217,8 +250,10 @@ public final class Stringifiers {
     /**
      * Obtains the default {@code Stringifier} for the {@code Message} classes.
      *
-     * @param messageClass the message class
-     * @param <T>          the type of the message
+     * @param messageClass
+     *         the message class
+     * @param <T>
+     *         the type of the message
      * @return the default stringifier
      */
     static <T extends Message> Stringifier<T> newForMessage(Class<T> messageClass) {
@@ -230,7 +265,8 @@ public final class Stringifiers {
     /**
      * Creates the {@code Escaper} which escapes contained '\' and passed characters.
      *
-     * @param charToEscape the char to escape
+     * @param charToEscape
+     *         the char to escape
      * @return the constructed escaper
      */
     static Escaper createEscaper(char charToEscape) {

--- a/base/src/main/java/io/spine/string/Stringifiers.java
+++ b/base/src/main/java/io/spine/string/Stringifiers.java
@@ -208,6 +208,12 @@ public final class Stringifiers {
         return result;
     }
 
+    static <T extends Enum<T>> Stringifier<T> newForEnum(Class<T> enumClass) {
+        checkNotNull(enumClass);
+        EnumStringifier<T> result = new EnumStringifier<>(enumClass);
+        return result;
+    }
+
     /**
      * Obtains the default {@code Stringifier} for the {@code Message} classes.
      *

--- a/base/src/test/java/io/spine/protobuf/MessagesTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessagesTest.java
@@ -35,11 +35,9 @@ import static io.spine.protobuf.Messages.builderFor;
 import static io.spine.protobuf.Messages.ensureMessage;
 import static io.spine.protobuf.TypeConverter.toAny;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("Messages utility class should")
 class MessagesTest extends UtilityClassTest<Messages> {
@@ -77,18 +75,6 @@ class MessagesTest extends UtilityClassTest<Messages> {
     void failGettingNonGeneratedBuilder() {
         assertThrows(IllegalArgumentException.class,
                      () -> builderFor(Message.class));
-    }
-
-    @Test
-    @DisplayName("tell if a class is a Message")
-    void tellIfMessage() {
-        assertTrue(Messages.isMessage(MessageWithStringValue.class));
-    }
-
-    @Test
-    @DisplayName("tell if a class is not Message")
-    void tellNotMessage() {
-        assertFalse(Messages.isMessage(getClass()));
     }
 
     @Test

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -25,18 +25,21 @@ import com.google.common.reflect.TypeToken;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
+import io.spine.reflect.given.TypesTestEnv.ListOfMessages;
+import io.spine.reflect.given.TypesTestEnv.TaskStatus;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.reflect.Types.argumentIn;
+import static io.spine.reflect.Types.isEnumClass;
+import static io.spine.reflect.Types.isMessageClass;
 import static io.spine.reflect.Types.listTypeOf;
 import static io.spine.reflect.Types.mapTypeOf;
 import static io.spine.reflect.Types.resolveArguments;
@@ -68,6 +71,26 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
+    @DisplayName("tell if type is a enum class")
+    void tellIfIsEnumClass() {
+
+        assertThat(isEnumClass(TaskStatus.class))
+                .isTrue();
+        assertThat(isEnumClass(Message.class))
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("tell if type is a message class")
+    void tellIfIsMessageClass() {
+
+        assertThat(isMessageClass(StringValue.class))
+                .isTrue();
+        assertThat(isMessageClass(TaskStatus.class))
+                .isFalse();
+    }
+
+    @Test
     @DisplayName("resolve params of a generic type")
     void resolveTypeParams() {
         Type type = new TypeToken<Function<String, StringValue>>() {}.getType();
@@ -94,12 +117,5 @@ class TypesTest extends UtilityClassTest<Types> {
     protected void configure(NullPointerTester tester) {
         super.configure(tester);
         tester.testStaticMethods(Types.class, NullPointerTester.Visibility.PACKAGE);
-    }
-
-    /**
-     * Stub class for testing obtaining generic argument.
-     */
-    @SuppressWarnings({"serial", "ClassExtendsConcreteCollection"})
-    private static class ListOfMessages extends ArrayList<Message> {
     }
 }

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -55,7 +55,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("create map type")
+    @DisplayName("create a map type")
     void createMapType() {
         Type type = mapTypeOf(String.class, Integer.class);
         Type expectedType = new TypeToken<Map<String, Integer>>(){}.getType();
@@ -63,7 +63,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("create list type")
+    @DisplayName("create a list type")
     void createListType() {
         Type type = listTypeOf(String.class);
         Type expectedType = new TypeToken<List<String>>(){}.getType();
@@ -71,7 +71,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("tell if type is a enum class")
+    @DisplayName("tell if the type is a enum class")
     void tellIfIsEnumClass() {
 
         assertThat(isEnumClass(TaskStatus.class))
@@ -81,7 +81,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("tell if type is a message class")
+    @DisplayName("tell if the type is a message class")
     void tellIfIsMessageClass() {
 
         assertThat(isMessageClass(StringValue.class))
@@ -99,7 +99,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("return empty list when resolving params of non-parameterized type")
+    @DisplayName("return an empty list when resolving params of a non-parameterized type")
     void resolveRawTypeParams() {
         Type type = new TypeToken<String>() {}.getType();
         ImmutableList<Type> types = resolveArguments(type);
@@ -107,7 +107,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("obtain type argument value from the inheritance chain")
+    @DisplayName("obtain a type argument value from the inheritance chain")
     void getTypeArgument() {
         Class<?> argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
         assertEquals(argument, Message.class);

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -71,7 +71,7 @@ class TypesTest extends UtilityClassTest<Types> {
     }
 
     @Test
-    @DisplayName("tell if the type is a enum class")
+    @DisplayName("tell if the type is an enum class")
     void tellIfIsEnumClass() {
 
         assertThat(isEnumClass(TaskStatus.class))

--- a/base/src/test/java/io/spine/reflect/given/TypesTestEnv.java
+++ b/base/src/test/java/io/spine/reflect/given/TypesTestEnv.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.reflect.given;
+
+import com.google.protobuf.Message;
+
+import java.util.ArrayList;
+
+public final class TypesTestEnv {
+
+    /** Prevents instantiation of this test env class. */
+    private TypesTestEnv() {
+    }
+
+    @SuppressWarnings({"serial", "ClassExtendsConcreteCollection"})
+    public static class ListOfMessages extends ArrayList<Message> {
+    }
+
+    public enum TaskStatus {
+        OPEN,
+        DONE
+    }
+}

--- a/base/src/test/java/io/spine/reflect/given/package-info.java
+++ b/base/src/test/java/io/spine/reflect/given/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * The test environment classes for Spine reflection utils.
+ */
+@CheckReturnValue
+@ParametersAreNonnullByDefault
+package io.spine.reflect.given;
+
+import com.google.errorprone.annotations.CheckReturnValue;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/base/src/test/java/io/spine/string/EnumStringifierTest.java
+++ b/base/src/test/java/io/spine/string/EnumStringifierTest.java
@@ -43,7 +43,7 @@ class EnumStringifierTest {
     }
 
     @Test
-    @DisplayName("have an identity tied to a processed class name")
+    @DisplayName("have an identity tied to the name of a processed class")
     void provideDefaultIdentity() {
         EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
         String identity = stringifier.toString();

--- a/base/src/test/java/io/spine/string/EnumStringifierTest.java
+++ b/base/src/test/java/io/spine/string/EnumStringifierTest.java
@@ -24,6 +24,7 @@ import com.google.common.base.Converter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @DisplayName("EnumStringifier should")
@@ -32,7 +33,8 @@ class EnumStringifierTest {
     @Test
     @DisplayName("convert values to String and back")
     void convert() {
-        DayOfWeekStringifier stringifier = DayOfWeekStringifier.INSTANCE;
+        EnumStringifier<DayOfWeek> stringifier =
+                new EnumStringifier<>(DayOfWeek.class.getName(), DayOfWeek.class);
         Converter<String, DayOfWeek> reverse = stringifier.reverse();
 
         for (DayOfWeek value : DayOfWeek.values()) {
@@ -41,19 +43,18 @@ class EnumStringifierTest {
         }
     }
 
+    @Test
+    @DisplayName("provide a default identity if it's not specified in c-tor")
+    void provideDefaultIdentity() {
+        EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
+        String identity = stringifier.toString();
+
+        String expected = EnumStringifier.defaultIdentity(DayOfWeek.class);
+        assertThat(identity).isEqualTo(expected);
+    }
 
     private enum DayOfWeek {
         MONDAY, TUESDAY, WEDNESDAY,
         THURSDAY, FRIDAY, SATURDAY, SUNDAY
-    }
-
-    private static final class DayOfWeekStringifier extends EnumStringifier<DayOfWeek> {
-
-        private static final long serialVersionUID = 0L;
-        private static final DayOfWeekStringifier INSTANCE = new DayOfWeekStringifier();
-
-        private DayOfWeekStringifier() {
-            super(DayOfWeekStringifier.class.getName(), DayOfWeek.class);
-        }
     }
 }

--- a/base/src/test/java/io/spine/string/EnumStringifierTest.java
+++ b/base/src/test/java/io/spine/string/EnumStringifierTest.java
@@ -33,8 +33,7 @@ class EnumStringifierTest {
     @Test
     @DisplayName("convert values to String and back")
     void convert() {
-        EnumStringifier<DayOfWeek> stringifier =
-                new EnumStringifier<>(DayOfWeek.class.getName(), DayOfWeek.class);
+        EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
         Converter<String, DayOfWeek> reverse = stringifier.reverse();
 
         for (DayOfWeek value : DayOfWeek.values()) {
@@ -44,12 +43,12 @@ class EnumStringifierTest {
     }
 
     @Test
-    @DisplayName("provide a default identity if it's not specified in c-tor")
+    @DisplayName("have an identity tied to a processed class name")
     void provideDefaultIdentity() {
         EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
         String identity = stringifier.toString();
 
-        String expected = EnumStringifier.defaultIdentity(DayOfWeek.class);
+        String expected = EnumStringifier.identity(DayOfWeek.class);
         assertThat(identity).isEqualTo(expected);
     }
 

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -101,7 +101,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         }
 
         @Test
-        @DisplayName("a enum")
+        @DisplayName("an enum")
         void aEnum() {
             checkStringifies(DONE, "DONE");
         }

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -36,9 +36,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -124,25 +121,6 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
 
             String expected = Json.toCompactJson(message);
             checkConverts(message, expected);
-        }
-
-        @Test
-        @DisplayName("a `List`")
-        void aList() {
-            List<Integer> list = new ArrayList<>(Arrays.asList(1, 2, 3));
-
-            checkConverts(list, "1, 2, 3");
-        }
-
-        @Test
-        @DisplayName("a `Map`")
-        void aMap() {
-            Map<String, Integer> map = new HashMap<>();
-            map.put("number-one", 1);
-            map.put("number-two", 2);
-            map.put("number-three", 3);
-
-            checkConverts(map, "number-one:1,number-two:2,number-three:3");
         }
 
         private void checkConverts(Object value, String expected) {

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -59,19 +59,19 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("a `boolean`")
         void aBoolean() {
-            checkConverts(false, "false");
+            checkStringifies(false, "false");
         }
 
         @Test
         @DisplayName("an `int`")
         void anInteger() {
-            checkConverts(1, "1");
+            checkStringifies(1, "1");
         }
 
         @Test
         @DisplayName(" a `long`")
         void aLong() {
-            checkConverts(1L, "1");
+            checkStringifies(1L, "1");
         }
 
         @Test
@@ -79,7 +79,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         void aString() {
             String theString = "some-string";
 
-            checkConverts(theString, theString);
+            checkStringifies(theString, theString);
         }
 
         @Test
@@ -88,7 +88,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
             Timestamp timestamp = Timestamp.getDefaultInstance();
             String expected = Timestamps.toString(timestamp);
 
-            checkConverts(timestamp, expected);
+            checkStringifies(timestamp, expected);
         }
 
         @Test
@@ -97,13 +97,13 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
             Duration duration = Duration.getDefaultInstance();
             String expected = Durations.toString(duration);
 
-            checkConverts(duration, expected);
+            checkStringifies(duration, expected);
         }
 
         @Test
         @DisplayName("a enum")
         void aEnum() {
-            checkConverts(DONE, "DONE");
+            checkStringifies(DONE, "DONE");
         }
 
         @Test
@@ -120,10 +120,10 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
                     .build();
 
             String expected = Json.toCompactJson(message);
-            checkConverts(message, expected);
+            checkStringifies(message, expected);
         }
 
-        private void checkConverts(Object value, String expected) {
+        private void checkStringifies(Object value, String expected) {
             String conversionResult = Stringifiers.toString(value);
             assertThat(conversionResult).isEqualTo(expected);
         }

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -104,8 +104,8 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         }
 
         @Test
-        @DisplayName("an enum")
-        void anEnum() {
+        @DisplayName("a enum")
+        void aEnum() {
             checkConverts(DONE, "DONE");
         }
 

--- a/base/src/test/proto/spine/test/string/stringifiers_test.proto
+++ b/base/src/test/proto/spine/test/string/stringifiers_test.proto
@@ -38,8 +38,6 @@ message STask {
 }
 
 enum STaskStatus {
-
     OPEN = 0;
-
     DONE = 1;
 }

--- a/base/src/test/proto/spine/test/string/stringifiers_test.proto
+++ b/base/src/test/proto/spine/test/string/stringifiers_test.proto
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+syntax = "proto3";
+
+package spine.test.string;
+
+import "spine/options.proto";
+
+option (type_url_prefix) = "type.spine.io";
+option java_package="io.spine.test.string";
+option java_multiple_files = true;
+option java_outer_classname = "StringifiersTestProto";
+
+message STaskId {
+    string uuid = 1;
+}
+
+message STask {
+    STaskId id = 1;
+    STaskStatus status = 2;
+}
+
+enum STaskStatus {
+
+    OPEN = 0;
+
+    DONE = 1;
+}

--- a/tools/proto-js-plugin/src/test/java/io/spine/js/generate/AppendTypeUrlGetterTest.java
+++ b/tools/proto-js-plugin/src/test/java/io/spine/js/generate/AppendTypeUrlGetterTest.java
@@ -108,7 +108,7 @@ class AppendTypeUrlGetterTest {
         }
 
         @Test
-        @DisplayName("for a enum class")
+        @DisplayName("for an enum class")
         void forEnumClass() {
             Method method = typeUrlMethod(enumType());
             CodeLines codeLines = method.value();

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.0.1'
+final def SPINE_VERSION = '1.0.2-SNAPSHOT'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes `Stringifiers.toString(...)` throwing an exception on receiving an `enum` value.

The `enum` values were not supported because the `EnumStringifier` was actually abstract and was intended for inheritance only. It was done so because the `EnumStringifier` is a `SerializableStringifier` and all serializable stringifiers are persisted as singletons. But it's impossible to persist an arbitrary enum stringifier as a singleton.

This PR makes an `EnumStringifier` a concrete class which is still a `SerializableStringifier` but is not persisted as a singleton (but rather as an ordinary serializable object).

