### PR TITLE
Enum values

### DIFF
--- a/base/src/main/java/io/spine/type/TypeName.java
+++ b/base/src/main/java/io/spine/type/TypeName.java
@@ -136,16 +136,34 @@ public final class TypeName extends StringTypeValue {
 
     /**
      * Returns a message {@link Class} corresponding to the Protobuf message type represented
-     * by this type URL.
+     * by this type name.
      *
-     * <p>This is a convenience method. Use it only when you are sure that the {@link TypeUrl}
+     * <p>This is a convenience method. Use it only when you are sure that the name
      * represents a {@code Message} and is not an enum.
      *
-     * @throws IllegalStateException if the type URL represents an enum
+     * @param <T> the type of the message
+     * @throws UnknownTypeException if the type is not found among known types
      */
     public <T extends Message> Class<T> toMessageClass() throws UnknownTypeException {
         Class<?> cls = toJavaClass();
         checkState(Message.class.isAssignableFrom(cls));
+        @SuppressWarnings("unchecked")
+        Class<T> result = (Class<T>) cls;
+        return result;
+    }
+
+    /**
+     * Returns an enum class corresponding to this type name.
+     *
+     * <p>This is a convenience method. Use it only when you are sure that the name
+     * represents an enum not a {@code Message}.
+     *
+     * @param <T> the type of the enum
+     * @throws UnknownTypeException if the type is not found among known types
+     */
+    public <T extends Enum<?>> Class<T> toEnumClass() throws UnknownTypeException {
+        Class<?> cls = toJavaClass();
+        checkState(Enum.class.isAssignableFrom(cls));
         @SuppressWarnings("unchecked")
         Class<T> result = (Class<T>) cls;
         return result;

--- a/base/src/test/java/io/spine/base/FieldTest.java
+++ b/base/src/test/java/io/spine/base/FieldTest.java
@@ -26,6 +26,7 @@ import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import io.spine.test.protobuf.AnyHolder;
 import io.spine.test.protobuf.GenericHolder;
+import io.spine.test.protobuf.GenericHolder.Count;
 import io.spine.test.protobuf.StringHolder;
 import io.spine.test.protobuf.StringHolderHolder;
 import org.junit.jupiter.api.BeforeEach;
@@ -193,6 +194,19 @@ class FieldTest {
         }
 
         @Test
+        @DisplayName("if the value is enum")
+        void enumValue() {
+            GenericHolder holder = GenericHolder
+                    .newBuilder()
+                    .setCount(Count.TWO)
+                    .build();
+
+            Field field = Field.parse("count");
+            assertThat(field.valueIn(holder))
+                    .isEqualTo(Count.TWO);
+        }
+
+        @Test
         @DisplayName("throwing `ISE` if missed and getting directly")
         void directFailure() {
             assertThrows(IllegalStateException.class, () -> missingField.valueIn(message));
@@ -245,14 +259,14 @@ class FieldTest {
         }
 
         @Test
-        @DisplayName("for primitives")
+        @DisplayName("for enums")
         void primitiveType() {
             Truth8.assertThat(Field.named("count").findType(GenericHolder.class))
-                  .hasValue(GenericHolder.Count.class);
+                  .hasValue(Count.class);
         }
 
         @Test
-        @DisplayName("for enums")
+        @DisplayName("for primitives")
         void enumType() {
             Truth8.assertThat(Field.named("size").findType(GenericHolder.class))
                   .hasValue(int.class);


### PR DESCRIPTION
This PR fixes obtaining Java enum value from a message field. Previously, `EnumValueDescriptor` was returned, which was not what users would expect.
