### PR TITLE
Remove build number in the version

### DIFF
--- a/tools/model-compiler/src/main/java/io/spine/tools/compiler/check/DependencyConfigurer.java
+++ b/tools/model-compiler/src/main/java/io/spine/tools/compiler/check/DependencyConfigurer.java
@@ -96,7 +96,7 @@ public final class DependencyConfigurer implements Logging {
      * Adds the {@code spine-erroprone-checks} dependency to the project configuration.
      */
     private void dependOnErrorProneChecks(String version, Configuration configuration) {
-        _debug().log("Adding dependency on %s:%s:%s to the %s configuration",
+        _debug().log("Adding dependency on %s:%s:%s to the %s configuration.",
                     SPINE_TOOLS_GROUP, SPINE_CHECKER_MODULE, version,
                     annotationProcessor.value());
         DependencySet dependencies = configuration.getDependencies();

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.1.3+2'
+final def SPINE_VERSION = '1.1.3'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR removes the build number made with the `+number` notation because it is not compatible with Maven client.