### PR TITLE
Pass custom messages to null checks

### DIFF
--- a/base/src/main/java/io/spine/util/Preconditions2.java
+++ b/base/src/main/java/io/spine/util/Preconditions2.java
@@ -54,9 +54,12 @@ public final class Preconditions2 {
      */
     @CanIgnoreReturnValue
     public static String checkNotEmptyOrBlank(String str) {
-        return checkNotEmptyOrBlank(
+        checkNotNull(str);
+        checkArgument(
+                !str.trim().isEmpty(),
                 str, "Non-empty and non-blank string expected. Encountered: \"%s\".", str
         );
+        return str;
     }
 
     /**
@@ -118,9 +121,9 @@ public final class Preconditions2 {
     /**
      * Ensures that the passed message is not in the default state.
      *
-     * @param message
+     * @param object
      *         the message to check
-     * @param <T>
+     * @param <M>
      *         the type of the message
      * @return the passed message
      * @throws IllegalArgumentException
@@ -129,48 +132,27 @@ public final class Preconditions2 {
      *          if the passed message is {@code null}
      */
     @CanIgnoreReturnValue
-    public static <T extends @NonNull Message> T checkNotDefaultArg(T message) {
-        checkArgument(!Messages.isDefault(message));
-        return message;
+    public static <M extends @NonNull Message> M checkNotDefaultArg(M object) {
+        checkArgument(!Messages.isDefault(object));
+        return object;
     }
 
     /**
      * Ensures that the passed message is not in the default state.
      *
-     * @param message
-     *         the message to check
-     * @param <T>
-     *         the type of the message
-     * @return the passed message
-     * @throws IllegalStateException
-     *          if the passed message has the default state
-     * @throws NullPointerException
-     *          if the passed message is {@code null}
-     */
-    @CanIgnoreReturnValue
-    public static <T extends @NonNull Message> T checkNotDefaultState(T message) {
-        checkState(!Messages.isDefault(message));
-        return message;
-    }
-
-    /**
-     * Ensures that the passed object is not in its default state and is not {@code null}.
-     *
      * @param object
      *         the {@code Message} instance to check
-     * @param errorMessage
-     *         the message for the exception to be thrown;
-     *         will be converted to a string using {@link String#valueOf(Object)}
+     * @param <M>
+     *         the type of the message to check
+     * @return the passed message
      * @throws IllegalStateException
-     *         if the object is in its default state
+     *         if the passed message has the default state
      * @throws NullPointerException
      *         if the passed message is {@code null}
      */
     @CanIgnoreReturnValue
-    public static <M extends Message>
-    M checkNotDefaultArg(M object, @Nullable Object errorMessage) {
-        checkNotNull(object);
-        checkArgument(isNotDefault(object), errorMessage);
+    public static <M extends @NonNull Message> M checkNotDefaultState(M object) {
+        checkState(!Messages.isDefault(object));
         return object;
     }
 
@@ -182,6 +164,31 @@ public final class Preconditions2 {
      * @param errorMessage
      *         the message for the exception to be thrown;
      *         will be converted to a string using {@link String#valueOf(Object)}
+     * @param <M>
+     *         the type of the message to check
+     * @throws IllegalStateException
+     *         if the object is in its default state
+     * @throws NullPointerException
+     *         if the passed message is {@code null}
+     */
+    @CanIgnoreReturnValue
+    public static <M extends Message>
+    M checkNotDefaultArg(M object, @Nullable Object errorMessage) {
+        checkNotNull(object, errorMessage);
+        checkArgument(isNotDefault(object), errorMessage);
+        return object;
+    }
+
+    /**
+     * Ensures that the passed object is not in its default state and is not {@code null}.
+     *
+     * @param object
+     *         the {@code Message} instance to check
+     * @param <M>
+     *         the type of the message to check
+     * @param errorMessage
+     *         the message for the exception to be thrown;
+     *         will be converted to a string using {@link String#valueOf(Object)}
      * @throws IllegalStateException
      *         if the object is in its default state
      * @throws NullPointerException
@@ -190,7 +197,7 @@ public final class Preconditions2 {
     @CanIgnoreReturnValue
     public static <M extends Message>
     M checkNotDefaultState(M object, @Nullable Object errorMessage) {
-        checkNotNull(object);
+        checkNotNull(object, errorMessage);
         checkState(isNotDefault(object), errorMessage);
         return object;
     }
@@ -215,7 +222,7 @@ public final class Preconditions2 {
     M checkNotDefaultArg(M object,
                          @Nullable String errorMessageTemplate,
                          @Nullable Object @Nullable ... errorMessageArgs) {
-        checkNotNull(object);
+        checkNotNull(object, errorMessageTemplate, errorMessageArgs);
         checkArgument(isNotDefault(object), errorMessageTemplate, errorMessageArgs);
         return object;
     }
@@ -240,7 +247,7 @@ public final class Preconditions2 {
     M checkNotDefaultState(M object,
                            @Nullable String errorMessageTemplate,
                            @Nullable Object @Nullable ... errorMessageArgs) {
-        checkNotNull(object);
+        checkNotNull(object, errorMessageTemplate, errorMessageArgs);
         checkState(isNotDefault(object), errorMessageTemplate, errorMessageArgs);
         return object;
     }

--- a/base/src/main/java/io/spine/util/Preconditions2.java
+++ b/base/src/main/java/io/spine/util/Preconditions2.java
@@ -78,7 +78,7 @@ public final class Preconditions2 {
     public static String checkNotEmptyOrBlank(String str,
                                               @Nullable String errorMessageTemplate,
                                               @Nullable Object @Nullable ... errorMessageArgs) {
-        checkNotNull(str, errorMessageTemplate);
+        checkNotNull(str, errorMessageTemplate, errorMessageArgs);
         checkArgument(!str.trim().isEmpty(), errorMessageTemplate, errorMessageArgs);
         return str;
     }

--- a/base/src/main/java/io/spine/util/Preconditions2.java
+++ b/base/src/main/java/io/spine/util/Preconditions2.java
@@ -67,6 +67,25 @@ public final class Preconditions2 {
      *
      * @param str
      *         the string to check
+     * @param errorMessage
+     *         the exception message to use if the check fails
+     * @return the passed string
+     * @throws IllegalArgumentException
+     *         if the string is empty or blank
+     * @throws NullPointerException
+     *         if the passed string is {@code null}
+     */
+    public static String checkNotEmptyOrBlank(String str, @Nullable Object errorMessage) {
+        checkNotNull(str, errorMessage);
+        checkArgument(!str.trim().isEmpty(), errorMessage);
+        return str;
+    }
+
+    /**
+     * Ensures that the passed string is not {@code null}, empty or blank string.
+     *
+     * @param str
+     *         the string to check
      * @param errorMessageTemplate
      *         the exception message template to use if the check fails
      * @param errorMessageArgs

--- a/base/src/test/java/io/spine/util/Preconditions2Test.java
+++ b/base/src/test/java/io/spine/util/Preconditions2Test.java
@@ -20,6 +20,7 @@
 
 package io.spine.util;
 
+import com.google.common.truth.StringSubject;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.testing.TestValues;
@@ -63,6 +64,26 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
             );
             assertThat(exception).hasMessageThat()
                                  .contains(errorMessage);
+        }
+
+        @Test
+        @DisplayName("null")
+        void nullStr() {
+            assertThrows(NullPointerException.class, () -> checkNotEmptyOrBlank(null));
+
+            String errorTemplateBase = randomString();
+            String[] errorArg = { randomString(), randomString() };
+            String errorTemplate = errorTemplateBase + "%s %s";
+
+            NullPointerException exception = assertThrows(
+                    NullPointerException.class,
+                    () -> checkNotEmptyOrBlank(null, errorTemplate, errorArg[0], errorArg[1])
+            );
+
+            StringSubject assertExceptionMessage = assertThat(exception).hasMessageThat();
+            assertExceptionMessage.contains(errorTemplateBase);
+            assertExceptionMessage.contains(errorArg[0]);
+            assertExceptionMessage.contains(errorArg[1]);
         }
 
         @Test

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>1.1.6</version>
+<version>1.1.7</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -154,7 +154,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine.tools</groupId>
     <artifactId>spine-protoc-plugin</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle
+++ b/version.gradle
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-final def SPINE_VERSION = '1.1.6'
+final def SPINE_VERSION = '1.1.7'
 
 ext {
     spineVersion = SPINE_VERSION


### PR DESCRIPTION
This PR fixes treating custom messages passed to precondition checks on `null` values. Previously, formatted messages were used only on non-null values, which could be misleading.

Version bumped to 1.1.7.