### PR TITLE
Change single quotes to backticks in error messages

### DIFF
--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -610,7 +610,7 @@ message PatternOption {
     //
     // The format parameter is the regular expression to which the value must match.
     //
-    option (default_message) = "String must match the regular expression '%s'.";
+    option (default_message) = "String must match the regular expression `%s`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -662,7 +662,7 @@ message GoesOption {
     // The first parameter is the name of the field for which we specify the option.
     // The second parameter is the name of the field set in the "with" value.
     //
-    option (default_message) = "The field '%s' can only be set when the field '%s' is defined.";
+    option (default_message) = "The field `%s` can only be set when the field `%s` is defined.";
 
     // A name of the field required for presence of the field for which we set the option.
     string with = 1;

--- a/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
+++ b/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
@@ -47,7 +47,7 @@ public class MessageValidatorTestEnv {
     public static final String OUTER_MSG_FIELD = "outer_msg_field";
     public static final String LESS_THAN_MIN_MSG = "Number must be greater than or equal to 16.5.";
     public static final String GREATER_MAX_MSG = "Number must be less than or equal to 64.5.";
-    public static final String MATCH_REGEXP_MSG = "String must match the regular expression '%s'.";
+    public static final String MATCH_REGEXP_MSG = "String must match the regular expression `%s`.";
 
     public static final double INT_DIGIT_COUNT_LESS_THAN_MAX = 1.5;
     public static final double LESS_THAN_MAX = EQUAL_MAX - 5;


### PR DESCRIPTION
Message values and validation parameters look more distinct when wrapped into backticks:
```
The field 'foo' can only be set when the field 'bar' is defined.
```
VS
```
The field `foo` can only be set when the field `bar` is defined.
```