### PR TITLE
Truncate time to milliseconds

### DIFF
--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -153,12 +153,13 @@ public final class Time {
          * {@inheritDoc}
          *
          * <p>Starting from Java 9 the precision of time may differ from platform to platform and
-         * depends on the underlying clock used by the JVM, the
-         * <a href='https://bugs.openjdk.java.net/browse/JDK-8068730'>issue</a> on this in the
-         * JDK bug system. To be consistent on different platforms and use {@link IncrementalNanos}
-         * without risk of overflowing the {@code nano} values this method intentionally calculates
-         * time in millisecond precision even if the underlying clock may offer more precise
-         * values.
+         * depends on the underlying clock used by the JVM. See the corresponding
+         * <a href='https://bugs.openjdk.java.net/browse/JDK-8068730'>issue</a> on this matter.
+         *
+         * <p>In order to provide consistent behavior on different platforms and avoid the overflow
+         * of the emulated nanosecond value, this method intentionally uses the system time
+         * in millisecond precision. Therefore even if the system clock may offer more precise
+         * values, the {@code System.currentTimeMillis()} is used as a base for the returned values.
          */
         @Override
         public Timestamp currentTime() {
@@ -194,8 +195,7 @@ public final class Time {
      * <p>The returned nanosecond value starts at {@code 0} and never exceeds {@code 999 999}.
      * It is designed to keep the millisecond value provided by a typical-JVM system clock intact.
      *
-     * <p>The nanosecond value is reset for each new passed {@code seconds} and {@code nanos}
-     * values.
+     * <p>The nanosecond value is reset for each new passed {@code seconds} and {@code nanos} values.
      * That allows to receive {@code 1 000} distinct time values per millisecond.
      *
      * <p>In case the upper bound of the nanos is reached, meaning that there were more than

--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -149,6 +149,17 @@ public final class Time {
         private SystemTimeProvider() {
         }
 
+        /**
+         * {@inheritDoc}
+         *
+         * <p>Starting from Java 9 the precision of time may differ from platform to platform and
+         * depends on the underlying clock used by the JVM, the
+         * <a href='https://bugs.openjdk.java.net/browse/JDK-8068730'>issue</a> on this in the
+         * JDK bug system. To be consistent on different platforms and use {@link IncrementalNanos}
+         * without risk of overflowing the {@code nano} values this method intentionally calculates
+         * time in millisecond precision even if the underlying clock may offer more precise
+         * values.
+         */
         @Override
         public Timestamp currentTime() {
             long millis = System.currentTimeMillis();
@@ -183,7 +194,8 @@ public final class Time {
      * <p>The returned nanosecond value starts at {@code 0} and never exceeds {@code 999 999}.
      * It is designed to keep the millisecond value provided by a typical-JVM system clock intact.
      *
-     * <p>The nanosecond value is reset for each new passed {@link Instant} value.
+     * <p>The nanosecond value is reset for each new passed {@code seconds} and {@code nanos}
+     * values.
      * That allows to receive {@code 1 000} distinct time values per millisecond.
      *
      * <p>In case the upper bound of the nanos is reached, meaning that there were more than

--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -27,6 +27,7 @@ import io.spine.annotation.Internal;
 import javax.annotation.concurrent.ThreadSafe;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
@@ -149,12 +150,14 @@ public final class Time {
 
         @Override
         public Timestamp currentTime() {
-            Instant now = Instant.now();
+            Instant now = Instant.now()
+                                 .truncatedTo(ChronoUnit.MILLIS);
             int nanosOnly = IncrementalNanos.valueForTime(now);
-            Timestamp result = Timestamp.newBuilder()
-                                        .setSeconds(now.getEpochSecond())
-                                        .setNanos(now.getNano() + nanosOnly)
-                                        .build();
+            Timestamp result = Timestamp
+                    .newBuilder()
+                    .setSeconds(now.getEpochSecond())
+                    .setNanos(now.getNano() + nanosOnly)
+                    .build();
             return result;
         }
     }

--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -30,6 +30,7 @@ import java.time.ZoneId;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Utilities for working with time information.
@@ -140,8 +141,6 @@ public final class Time {
     @VisibleForTesting
     static class SystemTimeProvider implements Provider {
 
-        public static final int NANOSECONDS_IN_MILLISECOND = 1_000_000;
-
         @VisibleForTesting
         static final Provider INSTANCE = new SystemTimeProvider();
 
@@ -165,7 +164,8 @@ public final class Time {
         public Timestamp currentTime() {
             long millis = System.currentTimeMillis();
             long seconds = (millis / 1000);
-            int nanos = (int) (millis % 1000) * NANOSECONDS_IN_MILLISECOND;
+            @SuppressWarnings("NumericCastThatLosesPrecision")
+            int nanos = (int) (millis % 1000) * (int) MILLISECONDS.toNanos(1);
             int nanosOnly = IncrementalNanos.valueForTime(seconds, nanos);
             Timestamp result = Timestamp
                     .newBuilder()

--- a/base/src/main/java/io/spine/base/Time.java
+++ b/base/src/main/java/io/spine/base/Time.java
@@ -195,8 +195,8 @@ public final class Time {
      * <p>The returned nanosecond value starts at {@code 0} and never exceeds {@code 999 999}.
      * It is designed to keep the millisecond value provided by a typical-JVM system clock intact.
      *
-     * <p>The nanosecond value is reset for each new passed {@code seconds} and {@code nanos} values.
-     * That allows to receive {@code 1 000} distinct time values per millisecond.
+     * <p>The nanosecond value is reset for each new passed {@code seconds} and {@code nanos}
+     * values. That allows to receive {@code 1 000} distinct time values per millisecond.
      *
      * <p>In case the upper bound of the nanos is reached, meaning that there were more than
      * {@code 1 000} calls to this class within a millisecond, the nanosecond value is reset

--- a/base/src/test/java/io/spine/base/TimeTest.java
+++ b/base/src/test/java/io/spine/base/TimeTest.java
@@ -106,8 +106,10 @@ class TimeTest {
                 " within a single point of wall-clock time")
         void differentValuesForTheSameTime() {
             Instant now = Instant.now();
-            assertThat(IncrementalNanos.valueForTime(now))
-                    .isLessThan(IncrementalNanos.valueForTime(now));
+            long seconds = now.getEpochSecond();
+            int nanos = now.getNano();
+            assertThat(IncrementalNanos.valueForTime(seconds, nanos))
+                    .isLessThan(IncrementalNanos.valueForTime(seconds, nanos));
         }
 
         @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -116,8 +118,11 @@ class TimeTest {
         void resetsNanosForNewInstant() {
             Instant now = Instant.now();
             Instant oneMsLater = now.plus(1, ChronoUnit.MILLIS);
-            IncrementalNanos.valueForTime(now); // Ignore this value.
-            int value = IncrementalNanos.valueForTime(oneMsLater);
+            IncrementalNanos
+                    .valueForTime(now.getEpochSecond(), now.getNano()); // Ignore this value.
+            long oneMsLaterSeconds = oneMsLater.getEpochSecond();
+            int oneMsLaterNanos = oneMsLater.getNano();
+            int value = IncrementalNanos.valueForTime(oneMsLaterSeconds, oneMsLaterNanos);
             assertThat(value).isEqualTo(0);
         }
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -25,7 +25,7 @@
  * as we want to manage the versions in a single source.
  */
 
-val SPINE_VERSION = "1.5.22"
+val SPINE_VERSION = "1.5.23"
 
 project.extra.apply {
     this["spineVersion"] = SPINE_VERSION


### PR DESCRIPTION
If we run a spine-based project under the Java 11 platform we randomly may encounter the issue when `Time.currentTime()` returns an invalid timestamp.

The issue is that `Time` uses the `SystemTimeProvider` by default, which rely on the fact that `Instant.now()` returns time in millisecond precision, that was true for Java 8. The `SystemTimeProvider` emulates nanoseconds in order to split in time events that happened in the same millisecond, but if we have time with increased precision it leads us to the situation when the resulting amount of nanoseconds with emulation is bigger than allowed. This happens because starting from Java 9 `Instant.now()` may return time with increased precision if the underlying clock supports it. This issue also described in #553.

In this PR I made the `SystemTimeProvider` explicitly truncate time to the millisecond precision.