### PR TITLE
Structure the version file

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -23,12 +23,22 @@
  *
  * This file is used in both module `build.gradle` scripts and in the integration tests,
  * as we want to manage the versions in a single source.
+ *
+ * This version file adheres to the contract of the
+ * [publishing application](https://github.com/SpineEventEngine/publishing).
+ *
+ * When changing the version declarations or adding new ones, make sure to change
+ * the publishing application accordingly.
  */
 
-val SPINE_VERSION = "1.5.27"
+/**
+ * The version of this library.
+ */
+val base = "1.5.28"
+
 
 project.extra.apply {
-    this["spineVersion"] = SPINE_VERSION
-    this["spineBaseVersion"] = SPINE_VERSION // Used by `filter-internal-javadoc.gradle`.
-    this["versionToPublish"] = SPINE_VERSION
+    this["spineVersion"] = base
+    this["spineBaseVersion"] = base // Used by `filter-internal-javadoc.gradle`.
+    this["versionToPublish"] = base
 }


### PR DESCRIPTION
This PR changes the `version.gradle.kts` file to adhere to the contract of the [publishing application](https://github.com/SpineEventEngine/publishing.)