### PR TITLE
[2.x-jdk8] Enable publishing

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * The version of this library.
  */
-val base = "2.0.0-jdk8.SNAPSHOT.3"
+val base = "2.0.0-jdk8.SNAPSHOT.4"
 
 
 project.extra.apply {


### PR DESCRIPTION
This PR updates the configuration files, so that the modules of this repository are published from `2.x-jdk8-master` branch.

The version of the modules has been set to `2.0.0-jdk8-SNAPSHOT.4`.