### PR TITLE
[2.x-jdk8] Remove a warning in the generated code of Entity state

### DIFF
--- a/tools/tool-base/src/main/java/io/spine/code/gen/java/column/ColumnContainerSpec.java
+++ b/tools/tool-base/src/main/java/io/spine/code/gen/java/column/ColumnContainerSpec.java
@@ -154,8 +154,9 @@ public final class ColumnContainerSpec implements GeneratedTypeSpec {
                 .addModifiers(PUBLIC, STATIC)
                 .returns(definitionsReturnType);
         ClassName setName = ClassName.get(HashSet.class);
+        TypeName parameterizedSetName = columnHashSetOfType(messageType);
         builder.addStatement("$T result = new $T<>()",
-                             setName, setName);
+                             parameterizedSetName, setName);
         for (MethodSpec methodSpec : columns) {
             builder.addStatement("result.add($N())", methodSpec);
         }
@@ -166,15 +167,21 @@ public final class ColumnContainerSpec implements GeneratedTypeSpec {
     }
 
     private static TypeName immutableColumnSetOfType(MessageType type) {
+        return paramdColSetOf(type, ClassName.get(ImmutableSet.class));
+    }
+
+    private static TypeName columnHashSetOfType(MessageType type) {
+        return paramdColSetOf(type, ClassName.get(HashSet.class));
+    }
+
+    private static TypeName paramdColSetOf(MessageType type, ClassName setType) {
         JavaPoetName entityColumnType = JavaPoetName.of(EntityColumn.class);
         JavaPoetName messageTypeName = JavaPoetName.of(type);
         ParameterizedTypeName parameterizedColumn =
                 ParameterizedTypeName.get(entityColumnType.className(),
                                           messageTypeName.className(),
                                           WildcardTypeName.subtypeOf(Object.class));
-
-        ParameterizedTypeName result = ParameterizedTypeName.get(ClassName.get(ImmutableSet.class),
-                                                                 parameterizedColumn);
+        ParameterizedTypeName result = ParameterizedTypeName.get(setType, parameterizedColumn);
         return result;
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * The version of this library.
  */
-val base = "2.0.0-jdk8.SNAPSHOT.5"
+val base = "2.0.0-jdk8.SNAPSHOT.6"
 
 
 project.extra.apply {


### PR DESCRIPTION
Previously, we were generating a piece of code into the Java class of an Entity state, and we were doing it like this:

```java
...  // column `definitions()` method:
HashSet result = new HashSet<>();
...
```

However, this expression uses a raw `HashSet` type type instead of a parameterized one. It results in Checkstyle failures in the projects in which the code-generated Entity states are used.

Therefore, this changeset updates the generation routines to produce the piece as follows.
```java
...
HashSet<EntityColumn<EntityStateType, ?>> result = new HashSet<>();
...
```

The snapshot counter in the version has been increased by one to `SNAPSHOT.6`.