### PR TITLE
Add collectors for diagnostic messages

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -25,6 +25,9 @@
         <ANNO name="org.junit.jupiter.api.Test" />
       </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
     <XML>
       <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
     </XML>
@@ -70,6 +73,9 @@
           </group>
         </groups>
       </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="JavaScriptSettings">
     <option name="languageLevel" value="ES6" />
   </component>

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -27,6 +27,8 @@ import io.spine.annotation.Internal;
 import java.util.stream.Collector;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /**
  * Utilities for debug and error diagnostics.
  */
@@ -46,6 +48,7 @@ public final class Diags {
      * Wraps the string representation of the passed object into backticks.
      */
     public static String backtick(Object object) {
+        checkNotNull(object);
         return BACKTICK + object.toString() + BACKTICK;
     }
 
@@ -53,6 +56,7 @@ public final class Diags {
      * Lists the passed items separating with a comma followed by a space character.
      */
     public static String join(Iterable<?> items) {
+        checkNotNull(items);
         return JOINER.join(items);
     }
 
@@ -61,6 +65,7 @@ public final class Diags {
      */
     @SafeVarargs
     public static <E> String join(E... elements) {
+        checkNotNull(elements);
         return JOINER.join(elements);
     }
 

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -50,7 +50,7 @@ public final class Diags {
     }
 
     /**
-     * Lists the passed items separating with comma followed by a space character.
+     * Lists the passed items separating with a comma followed by a space character.
      */
     public static String join(Iterable<?> items) {
         return JOINER.join(items);
@@ -65,10 +65,18 @@ public final class Diags {
     }
 
     /**
-     * Obtains the collector which enumerates items separating them comma followed
+     * Returns a {@code Collector} which enumerates items separating them a comma followed
      * by a space character.
      */
     public static Collector<CharSequence, ?, String> toEnumeration() {
         return Collectors.joining(COMMA_AND_SPACE);
+    }
+
+    /**
+     * Returns a {@code Collector} which wraps items into backticks and joins them
+     * into a string separating with a comma followed by a space character.
+     */
+    public static Collector<CharSequence, ?, String> toEnumerationBackticked() {
+        return Collectors.mapping(Diags::backtick, toEnumeration());
     }
 }

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -68,15 +68,15 @@ public final class Diags {
      * Returns a {@code Collector} which enumerates items separating them a comma followed
      * by a space character.
      */
-    public static Collector<CharSequence, ?, String> toEnumeration() {
-        return Collectors.joining(COMMA_AND_SPACE);
+    public static Collector<Object, ?, String> toEnumeration() {
+        return Collectors.mapping(Object::toString, Collectors.joining(COMMA_AND_SPACE));
     }
 
     /**
      * Returns a {@code Collector} which wraps items into backticks and joins them
      * into a string separating with a comma followed by a space character.
      */
-    public static Collector<CharSequence, ?, String> toEnumerationBackticked() {
+    public static Collector<Object, ?, String> toEnumerationBackticked() {
         return Collectors.mapping(Diags::backtick, toEnumeration());
     }
 }

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -74,7 +74,7 @@ public final class Diags {
      * representation with a comma followed by a space character.
      */
     public static Collector<Object, ?, String> toEnumeration() {
-        return Collectors.mapping(Object::toString, Collectors.joining(COMMA_AND_SPACE));
+        return Collectors.mapping(String::valueOf, Collectors.joining(COMMA_AND_SPACE));
     }
 
     /**

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -65,16 +65,17 @@ public final class Diags {
     }
 
     /**
-     * Returns a {@code Collector} which enumerates items separating them a comma followed
-     * by a space character.
+     * Returns a {@code Collector} which enumerates items separating their string
+     * representation with a comma followed by a space character.
      */
     public static Collector<Object, ?, String> toEnumeration() {
         return Collectors.mapping(Object::toString, Collectors.joining(COMMA_AND_SPACE));
     }
 
     /**
-     * Returns a {@code Collector} which wraps items into backticks and joins them
-     * into a string separating with a comma followed by a space character.
+     * Returns a {@code Collector} which wraps a string representation of an item
+     * into backticks and joins them into a string separating with a comma followed
+     * by a space character.
      */
     public static Collector<Object, ?, String> toEnumerationBackticked() {
         return Collectors.mapping(Diags::backtick, toEnumeration());

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -20,8 +20,12 @@
 
 package io.spine.string;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import io.spine.annotation.Internal;
+
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 /**
  * Utilities for debug and error diagnostics.
@@ -29,8 +33,10 @@ import io.spine.annotation.Internal;
 @Internal
 public final class Diags {
 
+    @VisibleForTesting
+    static final String COMMA_AND_SPACE = ", ";
+    private static final Joiner JOINER = Joiner.on(COMMA_AND_SPACE);
     private static final char BACKTICK = '`';
-    private static final Joiner COMMA_JOINER = Joiner.on(", ");
 
     /** Prevents instantiation of this utility class. */
     private Diags() {
@@ -47,7 +53,7 @@ public final class Diags {
      * Lists the passed items separating with comma followed by a space character.
      */
     public static String join(Iterable<?> items) {
-        return COMMA_JOINER.join(items);
+        return JOINER.join(items);
     }
 
     /**
@@ -55,6 +61,14 @@ public final class Diags {
      */
     @SafeVarargs
     public static <E> String join(E... elements) {
-        return COMMA_JOINER.join(elements);
+        return JOINER.join(elements);
+    }
+
+    /**
+     * Obtains the collector which enumerates items separating them comma followed
+     * by a space character.
+     */
+    public static Collector<CharSequence, ?, String> toEnumeration() {
+        return Collectors.joining(COMMA_AND_SPACE);
     }
 }

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -57,7 +57,7 @@ public final class Diags {
     }
 
     /**
-     * Lists the passed elements separating with comma followed by a space character.
+     * Lists the passed elements separating with a comma followed by a space character.
      */
     @SafeVarargs
     public static <E> String join(E... elements) {

--- a/base/src/main/java/io/spine/string/Diags.java
+++ b/base/src/main/java/io/spine/string/Diags.java
@@ -78,8 +78,8 @@ public final class Diags {
     }
 
     /**
-     * Returns a {@code Collector} which wraps a string representation of an item
-     * into backticks and joins them into a string separating with a comma followed
+     * Returns a {@code Collector} which backticks string representations of the passed
+     * items and joins items into a string, separating with a comma followed
      * by a space character.
      */
     public static Collector<Object, ?, String> toEnumerationBackticked() {

--- a/base/src/test/java/io/spine/string/DiagsTest.java
+++ b/base/src/test/java/io/spine/string/DiagsTest.java
@@ -43,7 +43,7 @@ class DiagsTest extends UtilityClassTest<Diags> {
     }
 
     @Test
-    @DisplayName("backtick string representation of a object")
+    @DisplayName("backtick string representation of an object")
     void backticks() {
         Object anObject = getClass();
         String backticked = backtick(anObject);

--- a/base/src/test/java/io/spine/string/DiagsTest.java
+++ b/base/src/test/java/io/spine/string/DiagsTest.java
@@ -21,6 +21,7 @@
 package io.spine.string;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.truth.StringSubject;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,8 +30,9 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.spine.string.Diags.COMMA_AND_SPACE;
 
-@DisplayName("Diags utility should")
+@DisplayName("`Diags` utility should")
 class DiagsTest extends UtilityClassTest<Diags> {
 
     DiagsTest() {
@@ -38,12 +40,15 @@ class DiagsTest extends UtilityClassTest<Diags> {
     }
 
     @Test
-    @DisplayName("backtick string representation of objects")
+    @DisplayName("backtick string representation of a object")
     void backticks() {
-        String backticked = Diags.backtick(getClass());
+        Object anObject = getClass();
+        String backticked = Diags.backtick(anObject);
 
-        assertThat(backticked.startsWith("`")).isTrue();
-        assertThat(backticked.endsWith("`")).isTrue();
+        StringSubject assertOutput = assertThat(backticked);
+        assertOutput.startsWith("`");
+        assertOutput.endsWith("`");
+        assertOutput.contains(anObject.toString());
     }
 
     @Nested
@@ -51,12 +56,14 @@ class DiagsTest extends UtilityClassTest<Diags> {
     class Joining {
 
         @Test
-        @DisplayName("Iterable")
+        @DisplayName("`Iterable`")
         void iterable() {
             List<String> items = ImmutableList.of("one", "two", "tree");
             String joined = Diags.join(items);
 
-            items.forEach(i -> assertThat(joined.contains(i)).isTrue());
+            StringSubject assertOutput = assertThat(joined);
+            assertOutput.contains(COMMA_AND_SPACE);
+            items.forEach(assertOutput::contains);
         }
 
         @Test
@@ -64,15 +71,32 @@ class DiagsTest extends UtilityClassTest<Diags> {
         void varArg() {
             String joined = Diags.join("uno", "dos", "tres");
 
+            StringSubject assertOutput = assertThat(joined);
             ImmutableList.of("uno", "dos", "tres")
-                         .forEach(i -> assertThat(joined.contains(i)).isTrue());
+                         .forEach(assertOutput::contains);
         }
 
         @Test
         @DisplayName("separating with comma followed by space char")
         void commaThenSpace() {
-            String joined = Diags.join("1", "2", "3");
-            assertThat(joined.contains(", ")).isTrue();
+            String joined = Diags.join(100, 200, 300);
+
+            StringSubject assertOutput = assertThat(joined);
+            assertOutput.contains(COMMA_AND_SPACE);
+            ImmutableList.of(100, 200, 300)
+                         .forEach(item -> assertOutput.contains(item.toString()));
         }
+    }
+
+    @Test
+    @DisplayName("provide collector to comma-separated string")
+    void stringEnum() {
+        ImmutableList<String> list = ImmutableList.of("foo", "bar", "baz");
+        String output = list.stream()
+                            .collect(Diags.toEnumeration());
+        StringSubject assertOutput = assertThat(output);
+        list.forEach(assertOutput::contains);
+
+        assertOutput.contains(COMMA_AND_SPACE);
     }
 }

--- a/base/src/test/java/io/spine/string/DiagsTest.java
+++ b/base/src/test/java/io/spine/string/DiagsTest.java
@@ -31,6 +31,9 @@ import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.string.Diags.COMMA_AND_SPACE;
+import static io.spine.string.Diags.backtick;
+import static io.spine.string.Diags.toEnumeration;
+import static io.spine.string.Diags.toEnumerationBackticked;
 
 @DisplayName("`Diags` utility should")
 class DiagsTest extends UtilityClassTest<Diags> {
@@ -43,7 +46,7 @@ class DiagsTest extends UtilityClassTest<Diags> {
     @DisplayName("backtick string representation of a object")
     void backticks() {
         Object anObject = getClass();
-        String backticked = Diags.backtick(anObject);
+        String backticked = backtick(anObject);
 
         StringSubject assertOutput = assertThat(backticked);
         assertOutput.startsWith("`");
@@ -88,15 +91,35 @@ class DiagsTest extends UtilityClassTest<Diags> {
         }
     }
 
-    @Test
+    @Nested
     @DisplayName("provide collector to comma-separated string")
-    void stringEnum() {
-        ImmutableList<String> list = ImmutableList.of("foo", "bar", "baz");
-        String output = list.stream()
-                            .collect(Diags.toEnumeration());
-        StringSubject assertOutput = assertThat(output);
-        list.forEach(assertOutput::contains);
+    class Collectors {
 
-        assertOutput.contains(COMMA_AND_SPACE);
+        private final ImmutableList<String> list = ImmutableList.of("foo", "bar", "baz");
+        private StringSubject assertOutput;
+
+        @Test
+        @DisplayName("with items")
+        void stringEnumeration() {
+            String output = list.stream()
+                                .collect(toEnumeration());
+
+            assertOutput = assertThat(output);
+
+            assertOutput.contains(COMMA_AND_SPACE);
+            list.forEach(assertOutput::contains);
+        }
+
+        @Test
+        @DisplayName("with backticked items")
+        void backtickedEnumeration() {
+            String output = list.stream()
+                                .collect(toEnumerationBackticked());
+
+            assertOutput = assertThat(output);
+
+            assertOutput.contains(COMMA_AND_SPACE);
+            list.forEach(item -> assertOutput.contains(backtick(item)));
+        }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -34,7 +34,7 @@
 /**
  * The version of this library.
  */
-val base = "1.6.11"
+val base = "1.6.12"
 
 
 project.extra.apply {


### PR DESCRIPTION
This PR starts addressing #590, providing `Collector`s for popular cases of enumerating objects in diagnostic messages.
