### PR TITLE
Deprecate duplicating `Duration2` utils

### DIFF
--- a/base/src/main/java/io/spine/protobuf/Durations2.java
+++ b/base/src/main/java/io/spine/protobuf/Durations2.java
@@ -32,7 +32,6 @@ import io.spine.string.Stringifiers;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.protobuf.util.Durations.compare;
@@ -60,10 +59,6 @@ import static java.util.Objects.requireNonNull;
 public final class Durations2 {
 
     public static final Duration ZERO = fromMillis(0L);
-
-    /** The count of minutes in one hour. */
-    @SuppressWarnings("NumericCastThatLosesPrecision")
-    private static final int MINUTES_PER_HOUR = (int) TimeUnit.HOURS.toMinutes(1);
 
     /** Prevent instantiation of this utility class. */
     private Durations2() {
@@ -234,7 +229,9 @@ public final class Durations2 {
     public static int getMinutes(Duration value) {
         checkNotNull(value);
         long allMinutes = Durations.toMinutes(value);
-        long remainder = allMinutes % MINUTES_PER_HOUR;
+        @SuppressWarnings("MagicNumber") // not that magic.
+        int minutesPerHour = 60;
+        long remainder = allMinutes % minutesPerHour;
         int result = Long.valueOf(remainder)
                          .intValue();
         return result;

--- a/base/src/main/java/io/spine/protobuf/Durations2.java
+++ b/base/src/main/java/io/spine/protobuf/Durations2.java
@@ -40,8 +40,7 @@ import static com.google.protobuf.util.Durations.fromMillis;
 import static com.google.protobuf.util.Durations.fromNanos;
 import static com.google.protobuf.util.Durations.fromSeconds;
 import static com.google.protobuf.util.Durations.toMillis;
-import static io.spine.util.Math2.floorDiv;
-import static io.spine.util.Math2.safeMultiply;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Utility class for working with durations in addition to those available from the
@@ -62,17 +61,9 @@ public final class Durations2 {
 
     public static final Duration ZERO = fromMillis(0L);
 
-    /** The count of seconds in one minute. */
-    @SuppressWarnings("NumericCastThatLosesPrecision")
-    private static final int SECONDS_PER_MINUTE = (int) TimeUnit.MINUTES.toSeconds(1);
-
     /** The count of minutes in one hour. */
     @SuppressWarnings("NumericCastThatLosesPrecision")
     private static final int MINUTES_PER_HOUR = (int) TimeUnit.HOURS.toMinutes(1);
-
-    /** The count of milliseconds in one second. */
-    @SuppressWarnings("NumericCastThatLosesPrecision")
-    private static final int MILLIS_PER_SECOND = (int) TimeUnit.SECONDS.toMillis(1);
 
     /** Prevent instantiation of this utility class. */
     private Durations2() {
@@ -81,27 +72,22 @@ public final class Durations2 {
     /**
      * Obtains an instance of {@code Duration} representing the passed number of minutes.
      *
-     * @param minutes
-     *         the number of minutes, positive or negative.
-     * @return a non-null {@code Duration}
+     * @deprecated please use {@link Durations#fromMinutes(long)}.
      */
+    @Deprecated
     public static Duration fromMinutes(long minutes) {
-        Duration duration = fromSeconds(safeMultiply(minutes, SECONDS_PER_MINUTE));
-        return duration;
+        return Durations.fromMinutes(minutes);
     }
 
     /**
      * Obtains an instance of {@code Duration} representing the passed number of hours.
      *
-     * @param hours
-     *         the number of hours, positive or negative
-     * @return a non-null {@code Duration}
+     * @deprecated please use {@link Durations#fromHours(long)}.
      */
+    @Deprecated
     public static Duration fromHours(long hours) {
-        Duration duration = fromMinutes(safeMultiply(hours, MINUTES_PER_HOUR));
-        return duration;
+        return Durations.fromHours(hours);
     }
-
 
     /*
      * Methods for brief computations with Durations like
@@ -116,8 +102,7 @@ public final class Durations2 {
      * @return a non-null {@code Duration}
      */
     public static Duration nanos(long nanos) {
-        Duration duration = fromNanos(nanos);
-        return duration;
+        return fromNanos(nanos);
     }
 
     /**
@@ -147,7 +132,7 @@ public final class Durations2 {
      * {@code Duration} instance with minutes.
      */
     public static Duration minutes(long minutes) {
-        return fromMinutes(minutes);
+        return Durations.fromMinutes(minutes);
     }
 
     /**
@@ -155,7 +140,7 @@ public final class Durations2 {
      * {@code Duration} instance with hours.
      */
     public static Duration hours(long hours) {
-        return fromHours(hours);
+        return Durations.fromHours(hours);
     }
 
     /**
@@ -199,62 +184,56 @@ public final class Durations2 {
         return result;
     }
 
-    /** Convert a duration to the number of nanoseconds. */
+    /**
+     * Convert a duration to the number of nanoseconds.
+     *
+     * @deprecated please use {@link Durations#toNanos(Duration)}.
+     */
+    @Deprecated
     public static long toNanos(Duration duration) {
-        /* The sole purpose of this method is minimize the dependencies of the classes
-           working with durations. */
-        checkNotNull(duration);
-        long result = Durations.toNanos(duration);
-        return result;
+        return Durations.toNanos(duration);
     }
 
-    /** Convert a duration to the number of seconds. */
+    /**
+     * Convert a duration to the number of seconds.
+     *
+     * @deprecated please use {@link Durations#toSeconds(Duration)}.
+     */
+    @Deprecated
     public static long toSeconds(Duration duration) {
-        checkNotNull(duration);
-        long millis = toMillis(duration);
-        long seconds = floorDiv(millis, MILLIS_PER_SECOND);
-        return seconds;
+        return Durations.toSeconds(duration);
     }
 
     /**
      * Converts passed duration to long value of minutes.
      *
-     * @param duration
-     *         duration to convert
-     * @return duration in minutes
+     * @deprecated please use {@link Durations#toMinutes(Duration)}.
      */
+    @Deprecated
     public static long toMinutes(Duration duration) {
-        checkNotNull(duration);
-        long millis = toMillis(duration);
-        long result = (millis / MILLIS_PER_SECOND) / SECONDS_PER_MINUTE;
-        return result;
+        return Durations.toMinutes(duration);
     }
 
     /**
      * Returns the number of hours in the passed duration.
      *
-     * @param value
-     *         duration
-     * @return number of hours
+     * @deprecated please use {@link Durations#toHours(Duration)}.
      */
+    @Deprecated
     public static long getHours(Duration value) {
-        checkNotNull(value);
-        long hours = toMinutes(value);
-        long result = hours / MINUTES_PER_HOUR;
-        return result;
+        return Durations.toHours(value);
     }
 
     /**
      * Returns the only remainder of minutes from the passed duration subtracting
      * the amount of full hours.
      *
-     * @param value
-     *         duration
-     * @return number of minutes
+     * @deprecated please use {@code Durations.toMinutes(value) % 60}.
      */
+    @Deprecated
     public static int getMinutes(Duration value) {
         checkNotNull(value);
-        long allMinutes = toMinutes(value);
+        long allMinutes = Durations.toMinutes(value);
         long remainder = allMinutes % MINUTES_PER_HOUR;
         int result = Long.valueOf(remainder)
                          .intValue();
@@ -312,12 +291,14 @@ public final class Durations2 {
         return result;
     }
 
-    /** Returns {@code true} if the passed duration is negative, {@code false} otherwise. */
+    /**
+     * Returns {@code true} if the passed duration is negative, {@code false} otherwise.
+     *
+     * @deprecated please use {@link Durations#isNegative(Duration)}.
+     */
+    @Deprecated
     public static boolean isNegative(Duration value) {
-        checkNotNull(value);
-        long nanos = toNanos(value);
-        boolean isNegative = nanos < 0;
-        return isNegative;
+        return Durations.isNegative(value);
     }
 
     /**
@@ -325,7 +306,8 @@ public final class Durations2 {
      */
     public static Duration of(java.time.Duration value) {
         checkNotNull(value);
-        return converter().convert(value);
+        Duration result = converter().convert(value);
+        return requireNonNull(result);
     }
 
     /**
@@ -333,8 +315,10 @@ public final class Durations2 {
      */
     public static java.time.Duration toJavaTime(Duration value) {
         checkNotNull(value);
-        return converter().reverse()
-                          .convert(value);
+        java.time.Duration result =
+                converter().reverse()
+                           .convert(value);
+        return requireNonNull(result);
     }
 
     /**
@@ -348,9 +332,11 @@ public final class Durations2 {
      */
     public static Duration parse(String str) {
         checkNotNull(str);
-        return Stringifiers.forDuration()
-                           .reverse()
-                           .convert(str);
+        Duration result =
+                Stringifiers.forDuration()
+                            .reverse()
+                            .convert(str);
+        return requireNonNull(result);
     }
 
     /**
@@ -372,18 +358,15 @@ public final class Durations2 {
 
         @Override
         protected Duration doForward(java.time.Duration duration) {
-            Duration.Builder result = Duration
-                    .newBuilder()
+            return Duration.newBuilder()
                     .setSeconds(duration.getSeconds())
-                    .setNanos(duration.getNano());
-            return result.build();
+                    .setNanos(duration.getNano())
+                    .build();
         }
 
         @Override
         protected java.time.Duration doBackward(Duration duration) {
-            java.time.Duration result = java.time.Duration
-                    .ofSeconds(duration.getSeconds(), duration.getNanos());
-            return result;
+            return java.time.Duration.ofSeconds(duration.getSeconds(), duration.getNanos());
         }
 
         @Override
@@ -394,6 +377,5 @@ public final class Durations2 {
         private Object readResolve() {
             return INSTANCE;
         }
-
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
     
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -435,12 +435,12 @@
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:22 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:44 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-errorprone-checks:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-errorprone-checks:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.github.ben-manes.caffeine **Name:** caffeine **Version:** 2.8.8
@@ -993,12 +993,12 @@ This report was generated on **Thu Apr 08 14:06:22 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:26 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:44 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-filter:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-javadoc-filter:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.android **Name:** annotations **Version:** 4.1.1.4
@@ -1487,12 +1487,12 @@ This report was generated on **Thu Apr 08 14:06:26 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:28 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:45 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-javadoc-prettifier:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-javadoc-prettifier:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -1973,12 +1973,12 @@ This report was generated on **Thu Apr 08 14:06:28 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:31 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:46 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-model-compiler:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -2475,12 +2475,12 @@ This report was generated on **Thu Apr 08 14:06:31 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:34 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:46 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-mute-logging:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-mute-logging:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.8
@@ -2966,12 +2966,12 @@ This report was generated on **Thu Apr 08 14:06:34 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:35 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:47 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-plugin-base:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -3452,12 +3452,12 @@ This report was generated on **Thu Apr 08 14:06:35 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:39 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:47 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-plugin-testlib:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.8
@@ -3993,12 +3993,12 @@ This report was generated on **Thu Apr 08 14:06:39 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:42 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-proto-dart-plugin:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-proto-dart-plugin:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4479,12 +4479,12 @@ This report was generated on **Thu Apr 08 14:06:42 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:45 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:48 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-proto-js-plugin:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-proto-js-plugin:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -4965,12 +4965,12 @@ This report was generated on **Thu Apr 08 14:06:45 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:06:49 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:49 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-protoc-plugin:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-protoc-plugin:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -5451,12 +5451,12 @@ This report was generated on **Thu Apr 08 14:06:49 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:07:02 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:49 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.auto.value **Name:** auto-value-annotations **Version:** 1.8
@@ -5942,12 +5942,12 @@ This report was generated on **Thu Apr 08 14:07:02 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:07:04 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:50 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-tool-base:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -6396,12 +6396,12 @@ This report was generated on **Thu Apr 08 14:07:04 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:07:07 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:50 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
     
-# Dependencies of `io.spine.tools:spine-validation-generator:2.0.0-SNAPSHOT.14`
+# Dependencies of `io.spine.tools:spine-validation-generator:2.0.0-SNAPSHOT.15`
 
 ## Runtime
 1. **Group:** com.google.code.findbugs **Name:** jsr305 **Version:** 3.0.2
@@ -6850,4 +6850,4 @@ This report was generated on **Thu Apr 08 14:07:07 EEST 2021** using [Gradle-Lic
  The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
 
-This report was generated on **Thu Apr 08 14:07:08 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 09 22:34:50 EEST 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@ all modules and does not describe the project structure per-subproject.
 
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.14</version>
+<version>2.0.0-SNAPSHOT.15</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.14"
+val base = "2.0.0-SNAPSHOT.15"
 
 project.extra.apply {
     this["spineVersion"] = base


### PR DESCRIPTION
This PR deprecates some of the `Duration2`  utilities that are already available from `com.google.protobuf.Durations`.