### PR TITLE
Expose required Model Compiler APIs

### DIFF
--- a/tools/mc-dart/build.gradle.kts
+++ b/tools/mc-dart/build.gradle.kts
@@ -27,6 +27,6 @@
 group = "io.spine.tools"
 
 dependencies {
-    implementation(project(":plugin-base"))
+    api(project(":plugin-base"))
     testImplementation(project(":testlib"))
 }

--- a/tools/mc-java-checks/build.gradle.kts
+++ b/tools/mc-java-checks/build.gradle.kts
@@ -36,7 +36,7 @@ repositories {
 
 dependencies {
     annotationProcessor(AutoService.processor)
-    compileOnly(AutoService.annotations)
+    compileOnlyApi(AutoService.annotations)
     implementation(project(":base"))
     implementation(project(":plugin-base"))
     implementation(ErrorProne.core)

--- a/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/CodeGeneratorTest.java
+++ b/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/CodeGeneratorTest.java
@@ -40,7 +40,7 @@ import io.spine.tools.protoc.Interfaces;
 import io.spine.tools.protoc.MessageSelectorFactory;
 import io.spine.tools.protoc.Methods;
 import io.spine.tools.protoc.NestedClasses;
-import io.spine.tools.protoc.SuffixSelector;
+import io.spine.tools.protoc.WithSuffix;
 import io.spine.tools.protoc.plugin.EnhancedWithCodeGeneration;
 import io.spine.tools.protoc.plugin.TestGeneratorsProto;
 import io.spine.type.MessageType;
@@ -83,7 +83,7 @@ final class CodeGeneratorTest {
         methods.applyFactory(UuidMethodFactory.class.getName(), messages.uuid());
         NestedClasses nestedClasses = new NestedClasses();
         nestedClasses.applyFactory(TestNestedClassFactory.class.getCanonicalName(),
-                                   new SuffixSelector("*file.proto"));
+                                   new WithSuffix("*file.proto"));
         CodeGeneratorRequest request = requestBuilder()
                 .addProtoFile(TestGeneratorsProto.getDescriptor()
                                                  .toProto())

--- a/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/PluginTest.java
+++ b/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/PluginTest.java
@@ -38,11 +38,11 @@ import io.spine.tools.mc.java.protoc.given.TestInterface;
 import io.spine.tools.mc.java.protoc.given.TestMethodFactory;
 import io.spine.tools.mc.java.protoc.given.TestNestedClassFactory;
 import io.spine.tools.mc.java.protoc.given.UuidMethodFactory;
+import io.spine.tools.protoc.ByPattern;
 import io.spine.tools.protoc.Interfaces;
 import io.spine.tools.protoc.MessageSelectorFactory;
 import io.spine.tools.protoc.Methods;
 import io.spine.tools.protoc.NestedClasses;
-import io.spine.tools.protoc.PatternSelector;
 import io.spine.tools.protoc.plugin.EnhancedWithCodeGeneration;
 import io.spine.tools.protoc.plugin.TestGeneratorsProto;
 import io.spine.tools.protoc.plugin.method.TestMethodProtos;
@@ -93,7 +93,7 @@ final class PluginTest {
     void processSuffixPatterns() {
         Interfaces interfaces = new Interfaces();
         MessageSelectorFactory messages = interfaces.messages();
-        PatternSelector suffixSelector = messages.inFiles(suffix(TEST_PROTO_SUFFIX));
+        ByPattern suffixSelector = messages.inFiles(suffix(TEST_PROTO_SUFFIX));
         interfaces.mark(suffixSelector, ClassName.of(TestInterface.class));
         Methods methods = new Methods();
         methods.applyFactory(TestMethodFactory.class.getName(), suffixSelector);
@@ -135,7 +135,7 @@ final class PluginTest {
     void processPrefixPatterns() {
         Interfaces interfaces = new Interfaces();
         MessageSelectorFactory messages = interfaces.messages();
-        PatternSelector prefixSelector = messages.inFiles(prefix(TEST_PROTO_PREFIX));
+        ByPattern prefixSelector = messages.inFiles(prefix(TEST_PROTO_PREFIX));
         interfaces.mark(prefixSelector, ClassName.of(TestInterface.class));
         Methods methods = new Methods();
         methods.applyFactory(TestMethodFactory.class.getName(), prefixSelector);
@@ -158,7 +158,7 @@ final class PluginTest {
     void processRegexPatterns() {
         Interfaces interfaces = new Interfaces();
         MessageSelectorFactory messages = interfaces.messages();
-        PatternSelector regexSelector = messages.inFiles(regex(TEST_PROTO_REGEX));
+        ByPattern regexSelector = messages.inFiles(regex(TEST_PROTO_REGEX));
         interfaces.mark(regexSelector, ClassName.of(TestInterface.class));
         Methods methods = new Methods();
         methods.applyFactory(TestMethodFactory.class.getName(), regexSelector);
@@ -258,9 +258,9 @@ final class PluginTest {
         );
         ImmutableList<String> possibleInsertions = ImmutableList.of(
                 TestMethodFactory.TEST_METHOD.toString()
-                        + TestNestedClassFactory.NESTED_CLASS.toString(),
+                        + TestNestedClassFactory.NESTED_CLASS,
                 TestNestedClassFactory.NESTED_CLASS.toString()
-                        + TestMethodFactory.TEST_METHOD.toString()
+                        + TestMethodFactory.TEST_METHOD
         );
         assertThat(fileContents).containsAnyIn(possibleInsertions);
     }

--- a/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/given/UuidMethodFactory.java
+++ b/tools/mc-java-protoc/src/test/java/io/spine/tools/mc/java/protoc/given/UuidMethodFactory.java
@@ -30,14 +30,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.tools.protoc.Method;
 import io.spine.tools.protoc.MethodFactory;
-import io.spine.tools.protoc.UuidMessage;
+import io.spine.tools.protoc.IsUuidMessage;
 import io.spine.type.MessageType;
 
 import java.util.List;
 
 /**
- * A test-only implementation of a {@link MethodFactory} to be used with
- * {@link UuidMessage UuidMessage}.
+ * A test-only implementation of a {@link MethodFactory} to be used with {@link IsUuidMessage}.
  */
 @Immutable
 public class UuidMethodFactory implements MethodFactory {

--- a/tools/mc-java/build.gradle.kts
+++ b/tools/mc-java/build.gradle.kts
@@ -36,7 +36,7 @@ var protocPluginDependency: Dependency? = null
 val spineVersion: String by extra
 
 dependencies {
-    implementation(project(":plugin-base"))
+    api(project(":plugin-base"))
     implementation(JavaPoet.lib)
 
     // A library for parsing Java sources.

--- a/tools/mc-js/build.gradle.kts
+++ b/tools/mc-js/build.gradle.kts
@@ -27,8 +27,7 @@
 group = "io.spine.tools"
 
 dependencies {
-    implementation(project(":base"))
-    implementation(project(":plugin-base"))
+    api(project(":plugin-base"))
     testImplementation(project(":testlib"))
     testImplementation(project(":plugin-testlib"))
     testImplementation(gradleTestKit())

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/ByPattern.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/ByPattern.java
@@ -35,15 +35,15 @@ import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
  * A selector which signalizes that the configuration should be applied to all messages declared in
  * proto files matching some pattern.
  *
- * @see PrefixSelector
- * @see RegexSelector
- * @see SuffixSelector
+ * @see WithPrefix
+ * @see ByRegex
+ * @see WithSuffix
  */
-public abstract class PatternSelector extends MessageSelector {
+public abstract class ByPattern extends MessageSelector {
 
     private final String pattern;
 
-    PatternSelector(String pattern) {
+    ByPattern(String pattern) {
         super();
         this.pattern = checkNotEmptyOrBlank(pattern);
     }
@@ -62,9 +62,10 @@ public abstract class PatternSelector extends MessageSelector {
 
     @Override
     public String toString() {
-        return MoreObjects.toStringHelper(this)
-                          .add("pattern", pattern)
-                          .toString();
+        return MoreObjects
+                .toStringHelper(this)
+                .add("pattern", pattern)
+                .toString();
     }
 
     @SuppressWarnings("EqualsGetClass") // we do want to distinguish different file patterns here
@@ -76,7 +77,7 @@ public abstract class PatternSelector extends MessageSelector {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PatternSelector selector = (PatternSelector) o;
+        ByPattern selector = (ByPattern) o;
         return Objects.equal(getPattern(), selector.getPattern());
     }
 

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/ByRegex.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/ByRegex.java
@@ -29,16 +29,16 @@ package io.spine.tools.protoc;
 import org.checkerframework.checker.regex.qual.Regex;
 
 /**
- * A selector of proto files whose names start with a certain prefix.
+ * A selector of proto files whose names qualify the supplied regex.
  */
-public final class PrefixSelector extends PatternSelector {
+public final class ByRegex extends ByPattern {
 
-    PrefixSelector(@Regex String prefix) {
-        super(prefix);
+    ByRegex(@Regex String regex) {
+        super(regex);
     }
 
     @Override
     FilePattern toProto() {
-        return FilePatterns.filePrefix(getPattern());
+        return FilePatterns.fileRegex(getPattern());
     }
 }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/EntityState.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/EntityState.java
@@ -34,7 +34,7 @@ import io.spine.code.java.ClassName;
  *
  * @see Interfaces#mark(EntityState, ClassName)
  */
-final class EntityState extends MessageSelector {
+public final class EntityState extends MessageSelector {
 
     EntityState() {
         super();

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/Fields.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/Fields.java
@@ -63,7 +63,7 @@ public final class Fields extends ModelCompilerConfiguration<AddFields> {
      * argument.
      */
     @SuppressWarnings("unused") // Gradle DSL.
-    public final void generateFor(EntityState entityState, ClassName markAs) {
+    public final void generateFor(IsEntityState entityState, ClassName markAs) {
         entityStateConfig = EntityStateConfig
                 .newBuilder()
                 .setValue(markAs.value())
@@ -95,7 +95,7 @@ public final class Fields extends ModelCompilerConfiguration<AddFields> {
      * <p>The configuration may be applied multiple times to enable code generation for multiple
      * file patterns.
      */
-    public final void generateFor(PatternSelector pattern, ClassName markAs) {
+    public final void generateFor(ByPattern pattern, ClassName markAs) {
         addPattern(pattern, markAs);
     }
 

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/Interfaces.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/Interfaces.java
@@ -49,7 +49,7 @@ import static io.spine.tools.protoc.ProtocTaskConfigs.uuidConfig;
  * }
  * </pre>
  *
- * @see #mark(PatternSelector, ClassName)
+ * @see #mark(ByPattern, ClassName)
  */
 public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> {
 
@@ -104,7 +104,7 @@ public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> 
      * {@link EventMessage io.spine.base.EventMessage} and thus it is safe to mark all events with
      * this interface instead of the default one.
      */
-    public final void mark(PatternSelector selector, ClassName interfaceName) {
+    public final void mark(ByPattern selector, ClassName interfaceName) {
         checkNotNull(selector);
         checkNotNull(interfaceName);
         addPattern(selector, interfaceName);
@@ -114,7 +114,7 @@ public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> 
      * Configures an interface generation for messages with a single {@code string} field called
      * {@code uuid}.
      *
-     * <p>This method functions similarly to the {@link #mark(PatternSelector, ClassName)} except
+     * <p>This method functions similarly to the {@link #mark(ByPattern, ClassName)} except
      * for several differences:
      * <ul>
      *     <li>the file in which the message type is defined does not matter;
@@ -126,7 +126,7 @@ public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> 
      * mark messages().uuid(), asType("my.custom.Identifier")
      * </pre>
      */
-    public final void mark(UuidMessage uuidMessage, ClassName interfaceName) {
+    public final void mark(IsUuidMessage uuidMessage, ClassName interfaceName) {
         checkNotNull(uuidMessage);
         uuidInterface = uuidConfig(interfaceName);
     }
@@ -139,14 +139,14 @@ public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> 
      *
      * <p>Sample usage is as follows:
      * <pre>
-     * mark messages().entityState(), asType("my.custom.EntityState")
+     * mark messages().entityState(), asType("my.custom.IsEntityState")
      * </pre>
      *
      * <p>Note that it is required for the provided interface to extend the
      * {@link io.spine.base.EntityState} interface, otherwise the inner Spine routines will work
      * incorrectly.
      */
-    public final void mark(EntityState entityState, ClassName interfaceName) {
+    public final void mark(IsEntityState entityState, ClassName interfaceName) {
         checkNotNull(entityState);
         entityStateInterface = entityStateConfig(interfaceName);
     }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/Interfaces.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/Interfaces.java
@@ -139,7 +139,7 @@ public final class Interfaces extends ModelCompilerConfiguration<AddInterfaces> 
      *
      * <p>Sample usage is as follows:
      * <pre>
-     * mark messages().entityState(), asType("my.custom.IsEntityState")
+     * mark messages().entityState(), asType("my.custom.EntityState")
      * </pre>
      *
      * <p>Note that it is required for the provided interface to extend the

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/IsEntityState.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/IsEntityState.java
@@ -26,18 +26,17 @@
 
 package io.spine.tools.protoc;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import io.spine.code.java.ClassName;
 
-@DisplayName("SuffixPattern should")
-final class SuffixPatternTest {
+/**
+ * A selector which signalizes that the configuration should be applied to all messages that
+ * represent an entity state.
+ *
+ * @see Interfaces#mark(IsEntityState, ClassName)
+ */
+public final class IsEntityState extends MessageSelector {
 
-    @DisplayName("translate itself to Protobuf counterpart")
-    @Test
-    void convertToProtobufCounterpart() {
-        String suffix = "test.proto";
-        FilePattern pattern = new SuffixSelector(suffix).toProto();
-        Assertions.assertEquals(suffix, pattern.getSuffix());
+    IsEntityState() {
+        super();
     }
 }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/IsUuidMessage.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/IsUuidMessage.java
@@ -26,19 +26,19 @@
 
 package io.spine.tools.protoc;
 
-import org.checkerframework.checker.regex.qual.Regex;
+import io.spine.code.java.ClassName;
 
 /**
- * A selector of proto files whose names qualify the supplied regex.
+ * A selector which signalizes that the configuration should be applied to all UUID messages.
+ *
+ * <p>A UUID message is a message with a single {@code string} field named {@code uuid}.
+ *
+ * @see Interfaces#mark(IsUuidMessage, ClassName)
+ * @see Methods#applyFactory(String, IsUuidMessage)
  */
-public final class RegexSelector extends PatternSelector {
+public final class IsUuidMessage extends MessageSelector {
 
-    RegexSelector(@Regex String regex) {
-        super(regex);
-    }
-
-    @Override
-    FilePattern toProto() {
-        return FilePatterns.fileRegex(getPattern());
+    IsUuidMessage() {
+        super();
     }
 }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/MessageSelector.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/MessageSelector.java
@@ -27,9 +27,10 @@
 package io.spine.tools.protoc;
 
 /**
- * An abstract base for selectors targeting {@link com.google.protobuf.Message messages}.
+ * An abstract base for selectors targeting {@linkplain com.google.protobuf.Message messages}.
  */
-class MessageSelector implements Selector {
+@SuppressWarnings("AbstractClassWithoutAbstractMethods") // is abstract by design
+abstract class MessageSelector implements Selector {
 
     private boolean enabled = true;
 

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/MessageSelectorFactory.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/MessageSelectorFactory.java
@@ -143,16 +143,17 @@ public final class MessageSelectorFactory {
                     "File selector should have a single value, but had: '%s'",
                     conf
             );
-            Set<String> filePatterns = configurations.keySet();
-            for (String filePattern : filePatterns) {
+            Set<String> patternTypes = configurations.keySet();
+            for (String patternType : patternTypes) {
+                String filePattern = conf.get(patternType);
                 if (!isNullOrEmpty(filePattern)) {
-                    Function<String, ByPattern> factory = configurations.get(filePattern);
+                    Function<String, ByPattern> factory = configurations.get(patternType);
                     return factory.apply(filePattern);
                 }
             }
             throw newIllegalArgumentException(
                     "Unsupported parameter `%s` supplied. Supported parameters are: `%s`.",
-                    conf, filePatterns
+                    conf, patternTypes
             );
         }
     }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/Methods.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/Methods.java
@@ -89,7 +89,7 @@ public final class Methods extends ModelCompilerConfiguration<AddMethods> {
      *        provided implementation of {@code MethodFactory} should be {@code public} and have
      *        a {@code public} no-argument constructor.
      */
-    public final void applyFactory(@FullyQualifiedName String factory, PatternSelector selector) {
+    public final void applyFactory(@FullyQualifiedName String factory, ByPattern selector) {
         checkNotNull(factory);
         checkNotNull(selector);
         addPattern(selector, ClassName.of(factory));
@@ -99,7 +99,7 @@ public final class Methods extends ModelCompilerConfiguration<AddMethods> {
      * Configures method generation for messages with a single {@code string} field called
      * {@code uuid}.
      *
-     * <p>This method functions similarly to the {@link #applyFactory(String, PatternSelector)}
+     * <p>This method functions similarly to the {@link #applyFactory(String, ByPattern)}
      * except the file in which the message type is defined does not matter.
      *
      * <p>Example:
@@ -112,7 +112,7 @@ public final class Methods extends ModelCompilerConfiguration<AddMethods> {
      *        provided implementation of {@code MethodFactory} should be {@code public} and have
      *        a {@code public} no-argument constructor.
      */
-    public final void applyFactory(@FullyQualifiedName String factory, UuidMessage selector) {
+    public final void applyFactory(@FullyQualifiedName String factory, IsUuidMessage selector) {
         checkNotNull(selector);
         uuidFactoryConfig = uuidConfig(ClassName.of(factory));
     }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/ModelCompilerConfiguration.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/ModelCompilerConfiguration.java
@@ -49,7 +49,7 @@ import static io.spine.tools.protoc.ProtocTaskConfigs.byPatternConfig;
  */
 abstract class ModelCompilerConfiguration<C extends Message> {
 
-    private final Map<PatternSelector, ClassName> patterns;
+    private final Map<ByPattern, ClassName> patterns;
 
     ModelCompilerConfiguration() {
         this.patterns = Maps.newConcurrentMap();
@@ -69,27 +69,27 @@ abstract class ModelCompilerConfiguration<C extends Message> {
     public abstract C asProtocConfig();
 
     /**
-     * Adds a new {@link PatternSelector} configuration with a supplied {@link ClassName}.
+     * Adds a new {@link ByPattern} configuration with a supplied {@link ClassName}.
      *
      * <p>The {@code className} can represent a fully-qualified name of an interface, method
      * factory, nested class factory or field type.
      */
-    void addPattern(PatternSelector pattern, ClassName className) {
+    void addPattern(ByPattern pattern, ClassName className) {
         patterns.put(pattern, className);
     }
 
     /**
      * Obtains current unique pattern configurations.
      */
-    ImmutableSet<Map.Entry<PatternSelector, ClassName>> patternConfigurations() {
+    ImmutableSet<Map.Entry<ByPattern, ClassName>> patternConfigurations() {
         return ImmutableSet.copyOf(patterns.entrySet());
     }
 
     /**
-     * Converts {@link PatternSelector} — {@link ClassName} pair to {@link ConfigByPattern}.
+     * Converts {@link ByPattern} — {@link ClassName} pair to {@link ConfigByPattern}.
      */
-    static ConfigByPattern toPatternConfig(Map.Entry<PatternSelector, ClassName> e) {
-        PatternSelector patternSelector = e.getKey();
+    static ConfigByPattern toPatternConfig(Map.Entry<ByPattern, ClassName> e) {
+        ByPattern patternSelector = e.getKey();
         ClassName className = e.getValue();
         return byPatternConfig(patternSelector.toProto(), className);
     }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/NestedClasses.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/NestedClasses.java
@@ -55,7 +55,7 @@ public final class NestedClasses extends ModelCompilerConfiguration<AddNestedCla
      *        provided implementation of {@code NestedClassFactory} should be {@code public} and
      *        have a {@code public} no-argument constructor.
      */
-    public final void applyFactory(@FullyQualifiedName String factory, PatternSelector selector) {
+    public final void applyFactory(@FullyQualifiedName String factory, ByPattern selector) {
         checkNotNull(factory);
         checkNotNull(selector);
         addPattern(selector, ClassName.of(factory));

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/Selector.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/Selector.java
@@ -36,7 +36,7 @@ package io.spine.tools.protoc;
  * <pre>
  *     mark messages().uuid(), asType("my.custom.Identifier")
  * </pre>
- * where {@code messages().uuid()} is a {@linkplain UuidMessage selector} for the UUID messages
+ * where {@code messages().uuid()} is a {@linkplain IsUuidMessage selector} for the UUID messages
  * configuration and the rest of the expression are the additional params provided for the
  * configuration.
  */

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/WithPrefix.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/WithPrefix.java
@@ -26,17 +26,19 @@
 
 package io.spine.tools.protoc;
 
-import io.spine.code.java.ClassName;
+import org.checkerframework.checker.regex.qual.Regex;
 
 /**
- * A selector which signalizes that the configuration should be applied to all messages that
- * represent an entity state.
- *
- * @see Interfaces#mark(EntityState, ClassName)
+ * A selector of proto files whose names start with a certain prefix.
  */
-public final class EntityState extends MessageSelector {
+public final class WithPrefix extends ByPattern {
 
-    EntityState() {
-        super();
+    WithPrefix(@Regex String prefix) {
+        super(prefix);
+    }
+
+    @Override
+    FilePattern toProto() {
+        return FilePatterns.filePrefix(getPattern());
     }
 }

--- a/tools/tool-base/src/main/java/io/spine/tools/protoc/WithSuffix.java
+++ b/tools/tool-base/src/main/java/io/spine/tools/protoc/WithSuffix.java
@@ -26,29 +26,19 @@
 
 package io.spine.tools.protoc;
 
-import com.google.common.truth.Subject;
-import com.google.common.truth.Truth;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.checkerframework.checker.regex.qual.Regex;
 
-@DisplayName("`PatternSelector` implementations should")
-final class PatternSelectorsTest {
+/**
+ * A selector of proto files whose names end with a certain postfix.
+ */
+public final class WithSuffix extends ByPattern {
 
-    @DisplayName("be different from each other")
-    @Test
-    void implementationsDiffer() {
-        String pattern = "testPattern";
+    public WithSuffix(@Regex String suffix) {
+        super(suffix);
+    }
 
-        Subject prefix = Truth.assertThat(new PrefixSelector(pattern));
-        prefix.isNotEqualTo(new SuffixSelector(pattern));
-        prefix.isNotEqualTo(new RegexSelector(pattern));
-
-        Subject suffix = Truth.assertThat(new SuffixSelector(pattern));
-        suffix.isNotEqualTo(new PrefixSelector(pattern));
-        suffix.isNotEqualTo(new RegexSelector(pattern));
-
-        Subject regex = Truth.assertThat(new RegexSelector(pattern));
-        regex.isNotEqualTo(new SuffixSelector(pattern));
-        regex.isNotEqualTo(new PrefixSelector(pattern));
+    @Override
+    FilePattern toProto() {
+        return FilePatterns.fileSuffix(getPattern());
     }
 }

--- a/tools/tool-base/src/test/java/io/spine/tools/java/code/UuidMethodFactoryTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/java/code/UuidMethodFactoryTest.java
@@ -66,7 +66,7 @@ final class UuidMethodFactoryTest {
                                        " * Creates a new instance with a random UUID value.\n" +
                                        " * @see java.util.UUID#randomUUID\n" +
                                        " */\n" +
-                                       "public static final io.spine.test.code.generate.uuid.IsUuidMessage generate() {\n" +
+                                       "public static final io.spine.test.code.generate.uuid.UuidMessage generate() {\n" +
                                        "  return newBuilder().setUuid(java.util.UUID.randomUUID().toString()).build();\n" +
                                        "}\n");
         }
@@ -82,7 +82,7 @@ final class UuidMethodFactoryTest {
                                        " * Creates a new instance from the passed value.\n" +
                                        " * @throws java.lang.IllegalArgumentException if the passed value is not a valid UUID string\n" +
                                        " */\n" +
-                                       "public static final io.spine.test.code.generate.uuid.IsUuidMessage of(java.lang.String uuid) {\n" +
+                                       "public static final io.spine.test.code.generate.uuid.UuidMessage of(java.lang.String uuid) {\n" +
                                        "  io.spine.util.Preconditions2.checkNotEmptyOrBlank(uuid);\n" +
                                        "  try {\n" +
                                        "    java.util.UUID.fromString(uuid);\n" +

--- a/tools/tool-base/src/test/java/io/spine/tools/java/code/UuidMethodFactoryTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/java/code/UuidMethodFactoryTest.java
@@ -27,7 +27,6 @@
 package io.spine.tools.java.code;
 
 import io.spine.test.code.generate.uuid.UuidMessage;
-import io.spine.tools.java.code.UuidMethodFactory;
 import io.spine.tools.protoc.Method;
 import io.spine.type.MessageType;
 import org.junit.jupiter.api.DisplayName;
@@ -38,25 +37,26 @@ import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.Assertions.assertNpe;
+import static io.spine.testing.TestValues.nullRef;
 
 @DisplayName("`UuidMethodFactory` should")
 final class UuidMethodFactoryTest {
 
     private final UuidMethodFactory factory = new UuidMethodFactory();
 
-    @DisplayName("not allow null values")
     @Test
+    @DisplayName("not allow null values")
     void notAllowNulls() {
-        assertNpe(() -> factory.generateMethodsFor(null));
+        assertNpe(() -> factory.generateMethodsFor(nullRef()));
     }
 
     @SuppressWarnings("HardcodedLineSeparator")
-    @DisplayName("create new")
     @Nested
+    @DisplayName("create new")
     final class CreateNew {
 
-        @DisplayName("`generate` method")
         @Test
+        @DisplayName("`generate` method")
         void generateMethod() {
             MessageType uuidType = new MessageType(UuidMessage.getDescriptor());
             List<Method> methods = factory.generateMethodsFor(uuidType);
@@ -66,13 +66,13 @@ final class UuidMethodFactoryTest {
                                        " * Creates a new instance with a random UUID value.\n" +
                                        " * @see java.util.UUID#randomUUID\n" +
                                        " */\n" +
-                                       "public static final io.spine.test.code.generate.uuid.UuidMessage generate() {\n" +
+                                       "public static final io.spine.test.code.generate.uuid.IsUuidMessage generate() {\n" +
                                        "  return newBuilder().setUuid(java.util.UUID.randomUUID().toString()).build();\n" +
                                        "}\n");
         }
 
-        @DisplayName("`of` method")
         @Test
+        @DisplayName("`of` method")
         void ofMethod() {
             MessageType uuidType = new MessageType(UuidMessage.getDescriptor());
             List<Method> methods = factory.generateMethodsFor(uuidType);
@@ -82,7 +82,7 @@ final class UuidMethodFactoryTest {
                                        " * Creates a new instance from the passed value.\n" +
                                        " * @throws java.lang.IllegalArgumentException if the passed value is not a valid UUID string\n" +
                                        " */\n" +
-                                       "public static final io.spine.test.code.generate.uuid.UuidMessage of(java.lang.String uuid) {\n" +
+                                       "public static final io.spine.test.code.generate.uuid.IsUuidMessage of(java.lang.String uuid) {\n" +
                                        "  io.spine.util.Preconditions2.checkNotEmptyOrBlank(uuid);\n" +
                                        "  try {\n" +
                                        "    java.util.UUID.fromString(uuid);\n" +

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/ByPatternSelectorsTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/ByPatternSelectorsTest.java
@@ -26,18 +26,30 @@
 
 package io.spine.tools.protoc;
 
-import org.junit.jupiter.api.Assertions;
+import com.google.common.truth.Subject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("PrefixPattern should")
-final class PrefixPatternTest {
+import static com.google.common.truth.Truth.assertThat;
 
-    @DisplayName("translate itself to Protobuf counterpart")
+@DisplayName("`ByPattern` implementations should")
+final class ByPatternSelectorsTest {
+
     @Test
-    void convertToProtobufCounterpart() {
-        String prefix = "io/spine/test_";
-        FilePattern pattern = new PrefixSelector(prefix).toProto();
-        Assertions.assertEquals(prefix, pattern.getPrefix());
+    @DisplayName("be different from each other")
+    void implementationsDiffer() {
+        String pattern = "testPattern";
+
+        Subject prefix = assertThat(new WithPrefix(pattern));
+        prefix.isNotEqualTo(new WithSuffix(pattern));
+        prefix.isNotEqualTo(new ByRegex(pattern));
+
+        Subject suffix = assertThat(new WithSuffix(pattern));
+        suffix.isNotEqualTo(new WithPrefix(pattern));
+        suffix.isNotEqualTo(new ByRegex(pattern));
+
+        Subject regex = assertThat(new ByRegex(pattern));
+        regex.isNotEqualTo(new WithSuffix(pattern));
+        regex.isNotEqualTo(new WithPrefix(pattern));
     }
 }

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorFactoryTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorFactoryTest.java
@@ -82,30 +82,42 @@ final class MessageSelectorFactoryTest {
 
     @Nested
     @DisplayName("create `ByPattern` out of")
-    final class CreatePatternSelector {
+    final class CreateByPatternSelector {
 
         @Test
         @DisplayName(MessageSelectorFactory.SUFFIX)
         void suffix() {
             String suffix = "_documents.proto";
-            assertThat(inFiles(MessageSelectorFactory.suffix(suffix)))
+            ByPattern withSuffix = inFiles(MessageSelectorFactory.suffix(suffix));
+            assertThat(withSuffix)
                     .isInstanceOf(WithSuffix.class);
+            FilePattern filePattern = withSuffix.toProto();
+            assertThat(filePattern.getSuffix())
+                    .isEqualTo(suffix);
         }
 
         @Test
         @DisplayName(MessageSelectorFactory.PREFIX)
         void prefix() {
             String prefix = "io/spine/test/orders_";
-            assertThat(inFiles(MessageSelectorFactory.prefix(prefix)))
+            ByPattern withPrefix = inFiles(MessageSelectorFactory.prefix(prefix));
+            assertThat(withPrefix)
                     .isInstanceOf(WithPrefix.class);
+            FilePattern filePattern = withPrefix.toProto();
+            assertThat(filePattern.getPrefix())
+                    .isEqualTo(prefix);
         }
 
         @Test
         @DisplayName(MessageSelectorFactory.REGEX)
         void regex() {
             String regex = ".*test.*";
-            assertThat(inFiles(MessageSelectorFactory.regex(regex)))
+            ByPattern byRegex = inFiles(MessageSelectorFactory.regex(regex));
+            assertThat(byRegex)
                     .isInstanceOf(ByRegex.class);
+            FilePattern filePattern = byRegex.toProto();
+            assertThat(filePattern.getRegex())
+                    .isEqualTo(regex);
         }
     }
 

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorFactoryTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorFactoryTest.java
@@ -44,7 +44,7 @@ final class MessageSelectorFactoryTest {
     private final MessageSelectorFactory factory = MessageSelectorFactory.INSTANCE;
 
     @CanIgnoreReturnValue
-    private PatternSelector inFiles(ImmutableMap<String, String> conf) {
+    private ByPattern inFiles(ImmutableMap<String, String> conf) {
         return factory.inFiles(conf);
     }
 
@@ -57,27 +57,31 @@ final class MessageSelectorFactoryTest {
     }
 
     @Test
-    @DisplayName("create `UuidMessage` selector")
+    @DisplayName("create `IsUuidMessage` selector")
     void createUuidSelector() {
-        assertThat(factory.uuid()).isInstanceOf(UuidMessage.class);
+        assertThat(factory.uuid())
+                .isInstanceOf(IsUuidMessage.class);
     }
 
     @Test
-    @DisplayName("create `EntityState` selector")
+    @DisplayName("create `IsEntityState` selector")
     void createEntityStateSelector() {
-        assertThat(factory.entityState()).isInstanceOf(EntityState.class);
+        assertThat(factory.entityState())
+                .isInstanceOf(IsEntityState.class);
     }
 
     @Test
     @DisplayName("create all messages selector")
     void createAllSelector() {
-        PatternSelector allSelector = factory.all();
-        assertThat(allSelector).isInstanceOf(SuffixSelector.class);
-        assertThat(allSelector.getPattern()).isEqualTo(FileName.EXTENSION);
+        ByPattern allSelector = factory.all();
+        assertThat(allSelector)
+                .isInstanceOf(WithSuffix.class);
+        assertThat(allSelector.getPattern())
+                .isEqualTo(FileName.EXTENSION);
     }
 
     @Nested
-    @DisplayName("create `PatternSelector` out of")
+    @DisplayName("create `ByPattern` out of")
     final class CreatePatternSelector {
 
         @Test
@@ -85,7 +89,7 @@ final class MessageSelectorFactoryTest {
         void suffix() {
             String suffix = "_documents.proto";
             assertThat(inFiles(MessageSelectorFactory.suffix(suffix)))
-                 .isInstanceOf(SuffixSelector.class);
+                    .isInstanceOf(WithSuffix.class);
         }
 
         @Test
@@ -93,7 +97,7 @@ final class MessageSelectorFactoryTest {
         void prefix() {
             String prefix = "io/spine/test/orders_";
             assertThat(inFiles(MessageSelectorFactory.prefix(prefix)))
-                 .isInstanceOf(PrefixSelector.class);
+                    .isInstanceOf(WithPrefix.class);
         }
 
         @Test
@@ -101,7 +105,7 @@ final class MessageSelectorFactoryTest {
         void regex() {
             String regex = ".*test.*";
             assertThat(inFiles(MessageSelectorFactory.regex(regex)))
-                 .isInstanceOf(RegexSelector.class);
+                    .isInstanceOf(ByRegex.class);
         }
     }
 

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/MessageSelectorTest.java
@@ -26,26 +26,36 @@
 
 package io.spine.tools.protoc;
 
-import com.google.common.truth.Truth;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("MessageSelector should")
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("`MessageSelector` should")
 final class MessageSelectorTest {
 
-    @DisplayName("be enabled by default")
     @Test
+    @DisplayName("be enabled by default")
     void beEnabledByDefault() {
-        Truth.assertThat(new MessageSelector().enabled()).isTrue();
+        assertThat(new DefaultSelector().enabled())
+                .isTrue();
     }
 
-    @DisplayName("allow disabling and enabling itself")
     @Test
+    @DisplayName("allow disabling and enabling itself")
     void allowDisablingAndEnablingItself() {
-        MessageSelector selector = new MessageSelector();
+        MessageSelector selector = new DefaultSelector();
         selector.disable();
-        Truth.assertThat(selector.enabled()).isFalse();
+        assertThat(selector.enabled())
+                .isFalse();
         selector.enable();
-        Truth.assertThat(selector.enabled()).isTrue();
+        assertThat(selector.enabled())
+                .isTrue();
+    }
+
+    /**
+     * A test implementation of a {@code MessageSelector}.
+     */
+    private static class DefaultSelector extends MessageSelector {
     }
 }

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/MethodFactoryTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/MethodFactoryTest.java
@@ -43,10 +43,11 @@ import static io.spine.testing.TestValues.nullRef;
 @DisplayName("`MethodFactory` should")
 final class MethodFactoryTest {
 
-    @DisplayName("obey the defined contract")
     @Test
+    @DisplayName("obey the defined contract")
     void obeyTheContract() {
-        assertThat(new TestMethodFactory().generateMethodsFor(nullRef())).isEmpty();
+        assertThat(new TestMethodFactory().generateMethodsFor(nullRef()))
+                .isEmpty();
     }
 
     @Immutable

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/RegexPatternTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/RegexPatternTest.java
@@ -26,18 +26,20 @@
 
 package io.spine.tools.protoc;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-@DisplayName("RegexPattern should")
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("`ByRegex` pattern should")
 final class RegexPatternTest {
 
-    @DisplayName("translate itself to Protobuf counterpart")
     @Test
+    @DisplayName("translate itself to Protobuf counterpart")
     void convertToProtobufCounterpart() {
         String regex = ".*/spine/.*";
-        FilePattern pattern = new RegexSelector(regex).toProto();
-        Assertions.assertEquals(regex, pattern.getRegex());
+        FilePattern pattern = new ByRegex(regex).toProto();
+        assertThat(pattern.getRegex())
+                .isEqualTo(regex);
     }
 }

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/WithPrefixTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/WithPrefixTest.java
@@ -26,19 +26,20 @@
 
 package io.spine.tools.protoc;
 
-import org.checkerframework.checker.regex.qual.Regex;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-/**
- * A selector of proto files whose names end with a certain postfix.
- */
-public final class SuffixSelector extends PatternSelector {
+import static com.google.common.truth.Truth.assertThat;
 
-    public SuffixSelector(@Regex String suffix) {
-        super(suffix);
-    }
+@DisplayName("`WithPrefix` pattern should")
+final class WithPrefixTest {
 
-    @Override
-    FilePattern toProto() {
-        return FilePatterns.fileSuffix(getPattern());
+    @Test
+    @DisplayName("translate itself to Protobuf counterpart")
+    void convertToProtobufCounterpart() {
+        String prefix = "io/spine/test_";
+        FilePattern pattern = new WithPrefix(prefix).toProto();
+        assertThat(pattern.getPrefix())
+                .isEqualTo(prefix);
     }
 }

--- a/tools/tool-base/src/test/java/io/spine/tools/protoc/WithSuffixTest.java
+++ b/tools/tool-base/src/test/java/io/spine/tools/protoc/WithSuffixTest.java
@@ -26,19 +26,20 @@
 
 package io.spine.tools.protoc;
 
-import io.spine.code.java.ClassName;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-/**
- * A selector which signalizes that the configuration should be applied to all UUID messages.
- *
- * <p>A UUID message is a message with a single {@code string} field named {@code uuid}.
- *
- * @see Interfaces#mark(UuidMessage, ClassName)
- * @see Methods#applyFactory(String, UuidMessage)
- */
-public final class UuidMessage extends MessageSelector {
+import static com.google.common.truth.Truth.assertThat;
 
-    UuidMessage() {
-        super();
+@DisplayName("`WithSuffix` pattern should")
+final class WithSuffixTest {
+
+    @Test
+    @DisplayName("translate itself to Protobuf counterpart")
+    void convertToProtobufCounterpart() {
+        String suffix = "test.proto";
+        FilePattern pattern = new WithSuffix(suffix).toProto();
+        assertThat(pattern.getSuffix())
+                .isEqualTo(suffix);
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.34"
+val base = "2.0.0-SNAPSHOT.35"
 
 project.extra.apply {
     this["spineVersion"] = base


### PR DESCRIPTION
This PR fixes issues related to applying and configuring the Model Compiler plugin using Gradle Kotlin DSL.

1. It exposes `:plugin-base` module as `mc-*` plugins `api` dependency.
    
    This is required because Kotlin DSL requires the `Extension` parent class (`GradleExtension`) to be available to the caller.

2. Fixes the visibility of the `EntityState` message selector.
    
    This is required only when `entityState()` selector is used in the model compiler configuration (we'd eventually hit into this issue if the `model-compiler.gradle` default configuration is migrated to Kotlin DSL). Here is an example of the default configuration in Kotlin:
    
    ```kotlin
        
    modelCompiler {
        generateValidation = true
    
        interfaces {
            mark(messages().inFiles(suffix("commands.proto")), asType("io.spine.base.CommandMessage"))
            mark(messages().inFiles(suffix("events.proto")), asType("io.spine.base.EventMessage"))
            mark(
                messages().inFiles(suffix("rejections.proto")),
                asType("io.spine.base.RejectionMessage")
            )
            mark(messages().uuid(), asType("io.spine.base.UuidValue"))
            mark(messages().entityState(), asType("io.spine.base.EntityState"))
        }
    
        methods {
            applyFactory("io.spine.tools.java.code.UuidMethodFactory", messages().uuid())
        }
    
        entityQueries {
            generate(true)
        }
    
        fields {
            generateFor(
                messages().inFiles(suffix("events.proto")),
                markAs("io.spine.base.EventMessageField")
            )
            generateFor(
                messages().inFiles(suffix("rejections.proto")),
                markAs("io.spine.base.EventMessageField")
            )
            generateFor(messages().entityState(), markAs("io.spine.query.EntityStateField"))
        }
    }

    ```