### PR TITLE
Bump version

### DIFF
--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.50"
+val base = "2.0.0-SNAPSHOT.51"
 
 project.extra.apply {
     this["spineVersion"] = base


### PR DESCRIPTION
This PR only bumps version from *.50 to *.51 to trigger publishing failed during [this workflow](https://github.com/SpineEventEngine/base/actions/runs/1184388682).

The reason for failed version increment check will be investigated shortly by @armiol. 