### PR TITLE
Enable Kotlin static code analysis

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -1,0 +1,103 @@
+# This workflow performs a static analysis of your Kotlin source code using
+# Detekt.
+#
+# Scans are triggered:
+# 1. On every push to default and protected branches
+# 2. On every Pull Request targeting the default branch
+# 3. On a weekly schedule
+# 4. Manually, on demand, via the "workflow_dispatch" event
+#
+# The workflow should work with no modifications, but you might like to use a
+# later version of the Detekt CLI by modifing the $DETEKT_RELEASE_TAG
+# environment variable.
+name: Scan with Detekt
+
+on:
+  # Triggers the workflow on push or pull request events but only for default and protected branches
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+     - cron: '20 3 * * 4'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Release tag associated with version of Detekt to be installed
+  # SARIF support (required for this workflow) was introduced in Detekt v1.15.0
+  DETEKT_RELEASE_TAG: v1.15.0
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "scan"
+  scan:
+    name: Scan
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
+    - name: Get Detekt download URL
+      id: detekt_info
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        DETEKT_DOWNLOAD_URL=$( gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
+          query getReleaseAssetDownloadUrl($tagName: String!) {
+            repository(name: "detekt", owner: "detekt") {
+              release(tagName: $tagName) {
+                releaseAssets(name: "detekt", first: 1) {
+                  nodes {
+                    downloadUrl
+                  }
+                }
+              }
+            }
+          }
+        ' | \
+        jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' )
+        echo "::set-output name=download_url::$DETEKT_DOWNLOAD_URL"
+
+    # Sets up the detekt cli
+    - name: Setup Detekt
+      run: |
+        dest=$( mktemp -d )
+        curl --request GET \
+          --url ${{ steps.detekt_info.outputs.download_url }} \
+          --silent \
+          --location \
+          --output $dest/detekt
+        chmod a+x $dest/detekt
+        echo $dest >> $GITHUB_PATH
+
+    # Performs static analysis using Detekt
+    - name: Run Detekt
+      continue-on-error: true
+      run: |
+        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+
+    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
+    # This is so we can easily map results onto their source files
+    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
+    - name: Make artifact location URIs relative
+      continue-on-error: true
+      run: |
+        echo "$(
+          jq \
+            --arg github_workspace ${{ github.workspace }} \
+            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
+            ${{ github.workspace }}/detekt.sarif.json
+        )" > ${{ github.workspace }}/detekt.sarif.json
+
+    # Uploads results to GitHub repository using the upload-sarif action
+    - uses: github/codeql-action/upload-sarif@v1
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: ${{ github.workspace }}/detekt.sarif.json
+        checkout_path: ${{ github.workspace }}

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.17.3"
+    const val version    = "3.18.0"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.util.*
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.findByType
+
+/**
+ * A task that generates a dependency versions `.properties` file.
+ */
+abstract class WriteVersions : DefaultTask() {
+
+    /**
+     * Versions to add to the file.
+     *
+     * The map key is a string in the format of `<group ID>_<artifact name>`, and the value
+     * is the version corresponding to those group ID and artifact name.
+     *
+     * @see WriteVersions.version
+     */
+    @get:Input
+    abstract val versions: MapProperty<String, String>
+
+    /**
+     * The directory that hosts the generated file.
+     */
+    @get:OutputDirectory
+    abstract val versionsFileLocation: DirectoryProperty
+
+    /**
+     * Adds a dependency version to write into the file.
+     *
+     * The given dependency notation is a Gradle artifact string of format:
+     * `"<group ID>:<artifact name>:<version>"`.
+     *
+     * @see WriteVersions.versions
+     * @see WriteVersions.includeOwnVersion
+     */
+    fun version(dependencyNotation: String) {
+        val parts = dependencyNotation.split(":")
+        check(parts.size == 3) { "Invalid dependency notation: `$dependencyNotation`." }
+        versions.put("${parts[0]}_${parts[1]}", parts[2])
+    }
+
+    /**
+     * Enables the versions file to include the version of the project that owns this task.
+     *
+     * @see WriteVersions.version
+     * @see WriteVersions.versions
+     */
+    fun includeOwnVersion() {
+        val groupId = project.group.toString()
+        val name = project.name
+        val version = project.version.toString()
+        versions.put("${groupId}_${name}", version)
+    }
+
+    @TaskAction
+    private fun writeFile() {
+        versions.finalizeValue()
+        versionsFileLocation.finalizeValue()
+
+        val values = versions.get()
+        val properties = Properties()
+        properties.putAll(values)
+        val projectName = project.name
+        val outputDir = versionsFileLocation.get().asFile
+        outputDir.mkdirs()
+        val file = outputDir.resolve("versions-$projectName.properties")
+        file.createNewFile()
+        file.writer().use {
+            properties.store(it, "Dependency versions supplied by the `$path` task.")
+        }
+    }
+}
+
+/**
+ * A plugin that enables storing dependency versions into a resource file.
+ *
+ * Dependency version may be used by Gradle plugins at runtime.
+ *
+ * The plugin adds one task — `writeVersions`, which generates a `.properties` file with some
+ * dependency versions.
+ *
+ * The generated file will be available in classpath of the target project under the name:
+ * `versions-<project name>.properties`, where `<project name>` is the name of the target
+ * Gradle project.
+ */
+@Suppress("unused")
+class VersionWriter : Plugin<Project> {
+
+    override fun apply(target: Project): Unit = with (target.tasks) {
+        val task = register("writeVersions", WriteVersions::class.java) {
+            versionsFileLocation.convention(project.layout.buildDirectory.dir(name))
+            includeOwnVersion()
+            @Suppress("SimpleRedundantLet")
+                // Decrease the number of null-safe calls (`?.`).
+            extensions.findByType<JavaPluginExtension>()?.let {
+                it.sourceSets
+                    .getByName("main")
+                    .resources
+                    .srcDir(versionsFileLocation)
+            }
+        }
+        findByName("processResources")?.dependsOn(task)
+    }
+}

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.17.3"
+    const val version    = "3.18.0"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"

--- a/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
+++ b/tests/buildSrc/src/main/kotlin/io/spine/internal/gradle/VersionWriter.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle
+
+import java.util.*
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.findByType
+
+/**
+ * A task that generates a dependency versions `.properties` file.
+ */
+abstract class WriteVersions : DefaultTask() {
+
+    /**
+     * Versions to add to the file.
+     *
+     * The map key is a string in the format of `<group ID>_<artifact name>`, and the value
+     * is the version corresponding to those group ID and artifact name.
+     *
+     * @see WriteVersions.version
+     */
+    @get:Input
+    abstract val versions: MapProperty<String, String>
+
+    /**
+     * The directory that hosts the generated file.
+     */
+    @get:OutputDirectory
+    abstract val versionsFileLocation: DirectoryProperty
+
+    /**
+     * Adds a dependency version to write into the file.
+     *
+     * The given dependency notation is a Gradle artifact string of format:
+     * `"<group ID>:<artifact name>:<version>"`.
+     *
+     * @see WriteVersions.versions
+     * @see WriteVersions.includeOwnVersion
+     */
+    fun version(dependencyNotation: String) {
+        val parts = dependencyNotation.split(":")
+        check(parts.size == 3) { "Invalid dependency notation: `$dependencyNotation`." }
+        versions.put("${parts[0]}_${parts[1]}", parts[2])
+    }
+
+    /**
+     * Enables the versions file to include the version of the project that owns this task.
+     *
+     * @see WriteVersions.version
+     * @see WriteVersions.versions
+     */
+    fun includeOwnVersion() {
+        val groupId = project.group.toString()
+        val name = project.name
+        val version = project.version.toString()
+        versions.put("${groupId}_${name}", version)
+    }
+
+    @TaskAction
+    private fun writeFile() {
+        versions.finalizeValue()
+        versionsFileLocation.finalizeValue()
+
+        val values = versions.get()
+        val properties = Properties()
+        properties.putAll(values)
+        val projectName = project.name
+        val outputDir = versionsFileLocation.get().asFile
+        outputDir.mkdirs()
+        val file = outputDir.resolve("versions-$projectName.properties")
+        file.createNewFile()
+        file.writer().use {
+            properties.store(it, "Dependency versions supplied by the `$path` task.")
+        }
+    }
+}
+
+/**
+ * A plugin that enables storing dependency versions into a resource file.
+ *
+ * Dependency version may be used by Gradle plugins at runtime.
+ *
+ * The plugin adds one task — `writeVersions`, which generates a `.properties` file with some
+ * dependency versions.
+ *
+ * The generated file will be available in classpath of the target project under the name:
+ * `versions-<project name>.properties`, where `<project name>` is the name of the target
+ * Gradle project.
+ */
+@Suppress("unused")
+class VersionWriter : Plugin<Project> {
+
+    override fun apply(target: Project): Unit = with (target.tasks) {
+        val task = register("writeVersions", WriteVersions::class.java) {
+            versionsFileLocation.convention(project.layout.buildDirectory.dir(name))
+            includeOwnVersion()
+            @Suppress("SimpleRedundantLet")
+                // Decrease the number of null-safe calls (`?.`).
+            extensions.findByType<JavaPluginExtension>()?.let {
+                it.sourceSets
+                    .getByName("main")
+                    .resources
+                    .srcDir(versionsFileLocation)
+            }
+        }
+        findByName("processResources")?.dependsOn(task)
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.56"
+val base = "2.0.0-SNAPSHOT.57"
 
 project.extra.apply {
     this["spineVersion"] = base


### PR DESCRIPTION
This PR adds workflow for static analysis of Kotlin code [using Detekt](https://github.com/SpineEventEngine/config/issues/227).