### PR TITLE
Document validation error message format in `options.proto`

### DIFF
--- a/base/src/main/java/io/spine/validate/option/GoesConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/GoesConstraint.java
@@ -47,8 +47,7 @@ public final class GoesConstraint extends FieldConstraint<GoesOption> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     public String errorMessage(FieldContext field) {
         GoesOption option = optionValue();
         return ViolationText.errorMessage(option, option.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/GoesConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/GoesConstraint.java
@@ -47,6 +47,8 @@ public final class GoesConstraint extends FieldConstraint<GoesOption> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     public String errorMessage(FieldContext field) {
         GoesOption option = optionValue();
         return ViolationText.errorMessage(option, option.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/MaxConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MaxConstraint.java
@@ -56,6 +56,8 @@ public final class MaxConstraint extends RangedConstraint<MaxOption> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     protected String compileErrorMessage(Range<ComparableNumber> range) {
         MaxOption max = optionValue();
         String template = ViolationText.errorMessage(max, max.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/MaxConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MaxConstraint.java
@@ -56,8 +56,7 @@ public final class MaxConstraint extends RangedConstraint<MaxOption> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     protected String compileErrorMessage(Range<ComparableNumber> range) {
         MaxOption max = optionValue();
         String template = ViolationText.errorMessage(max, max.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/MinConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MinConstraint.java
@@ -57,6 +57,8 @@ public final class MinConstraint extends RangedConstraint<MinOption> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     protected String compileErrorMessage(Range<ComparableNumber> range) {
         MinOption min = optionValue();
         String template = ViolationText.errorMessage(min, min.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/MinConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/MinConstraint.java
@@ -57,8 +57,7 @@ public final class MinConstraint extends RangedConstraint<MinOption> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     protected String compileErrorMessage(Range<ComparableNumber> range) {
         MinOption min = optionValue();
         String template = ViolationText.errorMessage(min, min.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/PatternConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/PatternConstraint.java
@@ -51,8 +51,7 @@ public final class PatternConstraint extends FieldConstraint<PatternOption> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     public String errorMessage(FieldContext field) {
         PatternOption option = optionValue();
         return ViolationText.errorMessage(option, option.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/PatternConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/PatternConstraint.java
@@ -51,6 +51,8 @@ public final class PatternConstraint extends FieldConstraint<PatternOption> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     public String errorMessage(FieldContext field) {
         PatternOption option = optionValue();
         return ViolationText.errorMessage(option, option.getMsgFormat());

--- a/base/src/main/java/io/spine/validate/option/RequiredConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/RequiredConstraint.java
@@ -46,6 +46,8 @@ public final class RequiredConstraint extends FieldConstraint<Boolean> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     public String errorMessage(FieldContext field) {
         IfMissing ifMissing = new IfMissing();
         IfMissingOption option = ifMissing.valueOrDefault(field.target());

--- a/base/src/main/java/io/spine/validate/option/RequiredConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/RequiredConstraint.java
@@ -46,8 +46,7 @@ public final class RequiredConstraint extends FieldConstraint<Boolean> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     public String errorMessage(FieldContext field) {
         IfMissing ifMissing = new IfMissing();
         IfMissingOption option = ifMissing.valueOrDefault(field.target());

--- a/base/src/main/java/io/spine/validate/option/ValidateConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/ValidateConstraint.java
@@ -43,8 +43,7 @@ public final class ValidateConstraint extends FieldConstraint<Boolean> {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     public String errorMessage(FieldContext field) {
         IfInvalid option = new IfInvalid();
         IfInvalidOption ifInvalid = option.valueOrDefault(field.target());

--- a/base/src/main/java/io/spine/validate/option/ValidateConstraint.java
+++ b/base/src/main/java/io/spine/validate/option/ValidateConstraint.java
@@ -43,6 +43,8 @@ public final class ValidateConstraint extends FieldConstraint<Boolean> {
     }
 
     @Override
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     public String errorMessage(FieldContext field) {
         IfInvalid option = new IfInvalid();
         IfInvalidOption ifInvalid = option.valueOrDefault(field.target());

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -660,7 +660,7 @@ message PatternOption {
     //
     // The format parameter is the regular expression to which the value must match.
     //
-    option (default_message) = "The string must match the regular expression `{other}`.";
+    option (default_message) = "The string must match the regular expression `%s`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -740,7 +740,8 @@ message PatternOption {
 // Example: Using the `(if_invalid)` option.
 //
 //     message Holder {
-//         MyMessage field = 1 [(validate) = true, (if_invalid).error_msg = "The field is invalid."];
+//         MyMessage field = 1 [(validate) = true,
+//                              (if_invalid).error_msg = "The field is invalid."];
 //    }
 //
 message IfInvalidOption {

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -539,7 +539,7 @@ extend google.protobuf.ServiceOptions {
 //
 //    message Holder {
 //        MyMessage field = 1 [(required) = true,
-//                             (if_missing).msg_format = "This field is required."];
+//                             (if_missing).error_msg = "This field is required."];
 //    }
 //
 message IfMissingOption {
@@ -548,7 +548,13 @@ message IfMissingOption {
     option (default_message) = "A value must be set.";
 
     // A user-defined validation error format message.
-    string msg_format = 1;
+    //
+    // Use `error_msg` instead.
+    //
+    string msg_format = 1 [deprecated = true];
+
+    // A user-defined error message.
+    string error_msg = 2;
 }
 
 // The field value must be greater than or equal to the given minimum number.
@@ -559,7 +565,11 @@ message IfMissingOption {
 // Example: Defining lower boundary for a numeric field.
 //
 //     message KelvinTemperature {
-//         double value = 1 [(min).value = "0.0"];
+//         double value = 1 [(min) = {
+//             value = "0.0"
+//             exclusive = true
+//             error_msg = "Temperature cannot reach {other}K, but provided {value}."
+//         }];
 //     }
 //
 message MinOption {
@@ -582,7 +592,14 @@ message MinOption {
     bool exclusive = 2;
 
     // A user-defined validation error format message.
-    string msg_format = 3;
+    string msg_format = 3 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
+    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 4;
 }
 
 // The field value must be less than or equal to the given maximum number.
@@ -593,7 +610,7 @@ message MinOption {
 // Example: Defining upper boundary for a numeric field.
 //
 //     message Elevation {
-//         double value = 1 [(max).value = "8848.00"];
+//         double value = 1 [(max).value = "8848.86"];
 //     }
 //
 message MaxOption {
@@ -616,7 +633,14 @@ message MaxOption {
     bool exclusive = 2;
 
     // A user-defined validation error format message.
-    string msg_format = 3;
+    string msg_format = 3 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
+    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 4;
 }
 
 // A string field value must match the given regular expression.
@@ -626,7 +650,8 @@ message MaxOption {
 // Example: Using the `(pattern)` option.
 //
 //     message CreateAccount {
-//         string id = 1 [(pattern).regex = "^[A-Za-z0-9+]+$"];
+//         string id = 1 [(pattern).regex = "^[A-Za-z0-9+]+$",
+//                        (pattern).error_msg = "ID must be alphanumerical. Provided: `{value}`."];
 //     }
 //
 message PatternOption {
@@ -635,22 +660,26 @@ message PatternOption {
     //
     // The format parameter is the regular expression to which the value must match.
     //
-    option (default_message) = "The string must match the regular expression `%s`.";
+    option (default_message) = "The string must match the regular expression `{other}`.";
 
     // The regular expression to match.
     string regex = 1;
 
-    // The regex flag.
-    //
-    // Has no effect. Use `modifier` instead.
-    //
-    int32 flag = 2 [deprecated = true];
+    reserved 2;
+    reserved "flag";
 
     // Modifiers for this pattern.
     Modifier modifier = 4;
 
     // A user-defined validation error format message.
-    string msg_format = 3;
+    string msg_format = 3 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
+    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 5;
 
     // Regular expression modifiers.
     //
@@ -711,7 +740,7 @@ message PatternOption {
 // Example: Using the `(if_invalid)` option.
 //
 //     message Holder {
-//         MyMessage field = 1 [(validate) = true, (if_invalid).msg_format = "The field is invalid."];
+//         MyMessage field = 1 [(validate) = true, (if_invalid).error_msg = "The field is invalid."];
 //    }
 //
 message IfInvalidOption {
@@ -720,7 +749,14 @@ message IfInvalidOption {
     option (default_message) = "The message must have valid properties.";
 
     // A user-defined validation error format message.
-    string msg_format = 1;
+    string msg_format = 1 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include the token `{value}` for the actual value of the field. The token will be replaced
+    // at runtime when the error is constructed.
+    //
+    string error_msg = 2;
 }
 
 // Specifies that a message field can be present only if another field is present.
@@ -750,7 +786,14 @@ message GoesOption {
     string with = 1;
 
     // A user-defined validation error format message.
-    string msg_format = 2;
+    string msg_format = 2 [deprecated = true];
+
+    // A user-defined validation error format message.
+    //
+    // May include the token `{value}` for the actual value of the field. The token will be replaced
+    // at runtime when the error is constructed.
+    //
+    string error_msg = 3;
 }
 
 // Defines options of a message representing a state of an entity.

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -294,7 +294,12 @@ extend google.protobuf.MessageOptions {
     // This option extends message types that extend `FieldOptions`
     // The number of parameters and their types are determined by the type of field options.
     //
-    string default_message = 73901;
+    // Usage of this value is deprecated. Along with the old `msg_format`s, it exists to support
+    // the old validation library. The new version of the validation library, which does not lie in
+    // the `base` repository, constructs the default error messages separately when creating
+    // language-agnostic validation rules.
+    //
+    string default_message = 73901 [deprecated = true];
 
     // The constraint to require at least one of the fields or a combination of fields.
     //

--- a/base/src/test/java/io/spine/validate/ErrorMessageTest.java
+++ b/base/src/test/java/io/spine/validate/ErrorMessageTest.java
@@ -97,8 +97,7 @@ class ErrorMessageTest extends ValidationOfConstraintTest {
         assertEquals(expectedMessage, constraintViolation.getMsgFormat());
     }
 
-    @SuppressWarnings("deprecation")
-        // The old validation will not migrate to the new error messages.
+    @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     private static String customErrorMessageFrom(Descriptor descriptor) {
         FieldDescriptor firstFieldDescriptor = descriptor.getFields()
                                                          .get(0);

--- a/base/src/test/java/io/spine/validate/ErrorMessageTest.java
+++ b/base/src/test/java/io/spine/validate/ErrorMessageTest.java
@@ -97,6 +97,8 @@ class ErrorMessageTest extends ValidationOfConstraintTest {
         assertEquals(expectedMessage, constraintViolation.getMsgFormat());
     }
 
+    @SuppressWarnings("deprecation")
+        // The old validation will not migrate to the new error messages.
     private static String customErrorMessageFrom(Descriptor descriptor) {
         FieldDescriptor firstFieldDescriptor = descriptor.getFields()
                                                          .get(0);

--- a/base/src/test/java/io/spine/validate/option/PatternTest.java
+++ b/base/src/test/java/io/spine/validate/option/PatternTest.java
@@ -70,8 +70,7 @@ class PatternTest extends ValidationOfConstraintTest {
     void provideOneValidViolationIfStringDoesNotMatchToRegexPattern() {
         PatternStringFieldValue msg = patternStringFor("invalid email");
         @Regex
-        String regex =
-                "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
+        String regex = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
         String expectedErrMsg = format(MATCH_REGEXP_MSG, regex);
         assertSingleViolation(msg, expectedErrMsg, EMAIL);
     }

--- a/buildSrc/src/main/groovy/slow-tests.gradle
+++ b/buildSrc/src/main/groovy/slow-tests.gradle
@@ -24,6 +24,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+println("`slow-tests.gradle` script is deprecated. " +
+        "Please use `TaskContainer.registerTestTasks()` instead.")
+
 final def slowTag = 'slow' // See io.spine.testing.SlowTest
 
 task fastTest(type: Test) {

--- a/buildSrc/src/main/groovy/test-artifacts.gradle
+++ b/buildSrc/src/main/groovy/test-artifacts.gradle
@@ -29,6 +29,10 @@
 //
 // testCompile project(path: ":projectWithTests", configuration: 'testArtifacts')
 //
+
+println("`test-artifacts.gradle` script is deprecated. " +
+        "Please use the `Project.exposeTestArtifacts()` utility instead.")
+
 configurations {
     testArtifacts.extendsFrom testRuntime
 }

--- a/buildSrc/src/main/groovy/test-output.gradle
+++ b/buildSrc/src/main/groovy/test-output.gradle
@@ -33,6 +33,8 @@
  *    of tests and their results.
  */
 
+println("`test-output.gradle` script is deprecated. Please use `Test.configureLogging()` instead.")
+
 tasks.withType(Test).each {
     it.testLogging {
         showStandardStreams = true

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -43,11 +43,17 @@ object ErrorProne {
     const val testHelpers = "com.google.errorprone:error_prone_test_helpers:${version}"
     const val javacPlugin  = "com.google.errorprone:javac:${javacPluginVersion}"
 
-    /**
-     * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
-     * Thus, when applying the plugin in projects build files, only id should be used.
-     */
+    // https://github.com/tbroyer/gradle-errorprone-plugin/releases
     object GradlePlugin {
         const val id = "net.ltgt.errorprone"
+        /**
+         * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
+         * Thus, when applying the plugin in projects build files, only the [id] should be used.
+         *
+         * When the plugin is used as a library (e.g. in tools), its version and the library
+         * artifacts are of importance.
+         */
+        const val version = "2.0.2"
+        const val lib = "net.ltgt.gradle:gradle-errorprone-plugin:${version}"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/coverage/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/report/coverage/JacocoConfig.kt
@@ -34,7 +34,6 @@ import io.spine.internal.gradle.report.coverage.TaskName.jacocoRootReport
 import io.spine.internal.gradle.report.coverage.TaskName.jacocoTestReport
 import io.spine.internal.gradle.sourceSets
 import java.io.File
-import java.lang.IllegalStateException
 import java.util.*
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -62,6 +61,7 @@ import org.gradle.testing.jacoco.tasks.JacocoReport
  * Therefore, tn case this utility is applied to a single-module Gradle project,
  * an `IllegalStateException` is thrown.
  */
+@Suppress("unused")
 class JacocoConfig(
     private val rootProject: Project,
     private val reportsDir: File,
@@ -112,7 +112,7 @@ class JacocoConfig(
                 } else {
                     throw IllegalStateException(
                         "In a single-module Gradle project, `JacocoConfig` is NOT needed." +
-                                "Please apply `jacoco` plugin instead."
+                                " Please apply `jacoco` plugin instead."
                     )
                 }
             return projects

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Artifacts.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Exposes the test classes of this project as a new `testArtifacts` configuration.
+ *
+ * This allows other Gradle projects to depend on the test classes of some project. It is helpful
+ * in case the dependant projects re-use abstract test suites of some "parent" project.
+ *
+ * Please note that this utility requires Gradle `java` plugin to be applied.
+ * Hence, it is recommended to call this extension method from `java` scope:
+ *
+ * ```
+ * java {
+ *     exposeTestArtifacts()
+ * }
+ * ```
+ *
+ * Here is a snippet which consumes the exposed test classes:
+ *
+ * ```
+ * dependencies {
+ *     testImplementation(project(path = ":projectName", configuration = "testArtifacts"))
+ * }
+ * ```
+ */
+fun Project.exposeTestArtifacts() {
+
+    val testArtifacts = configurations.create("testArtifacts") {
+        extendsFrom(configurations.getAt("testRuntimeClasspath"))
+    }
+
+    val sourceSets = extensions.getByType<JavaPluginExtension>().sourceSets
+    val testJar = tasks.register<Jar>("testJar") {
+        archiveClassifier.set("test")
+        from(sourceSets.getAt("test").output)
+    }
+
+    artifacts.add(testArtifacts.name, testJar)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Logging.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.TestDescriptor
+import org.gradle.api.tasks.testing.TestResult
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.kotlin.dsl.KotlinClosure2
+
+/**
+ * Configures logging of this [Test] task.
+ *
+ * Enables logging of:
+ *  1. Standard `out` and `err` streams;
+ *  2. Thrown exceptions.
+ *
+ *  Additionally, after all the tests are executed, a short summary would be logged. The summary
+ *  consists of the number of tests and their results.
+ *
+ * Usage example:
+ *
+ *```
+ * tasks {
+ *     withType<Test> {
+ *         configureLogging()
+ *     }
+ * }
+ *```
+ */
+fun Test.configureLogging() {
+    testLogging {
+        showStandardStreams = true
+        showExceptions = true
+        exceptionFormat = TestExceptionFormat.FULL
+        showStackTraces = true
+        showCauses = true
+    }
+
+    fun TestResult.summary(): String =
+        """
+        Test summary:
+        >> $testCount tests
+        >> $successfulTestCount succeeded
+        >> $failedTestCount failed
+        >> $skippedTestCount skipped
+        """
+
+    afterSuite(
+
+        // `GroovyInteroperability` is employed as `afterSuite()` has no equivalent in Kotlin DSL.
+        // See issue: https://github.com/gradle/gradle/issues/5431
+
+        KotlinClosure2<TestDescriptor, TestResult, Unit>({ descriptor, result ->
+
+            // If the descriptor has no parent, then it is the root test suite,
+            // i.e. it includes the info about all the run tests.
+
+            if (descriptor.parent == null) {
+                logger.lifecycle(result.summary())
+            }
+        })
+    )
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.testing
+
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Registers [slowTest][SlowTest] and [fastTest][FastTest] tasks in this [TaskContainer].
+ *
+ * Slow tests are registered to run after all fast tests.
+ *
+ * Usage example:
+ *
+ * ```
+ * tasks {
+ *     registerTestTasks()
+ * }
+ * ```
+ */
+@Suppress("unused")
+fun TaskContainer.registerTestTasks() {
+    register<FastTest>("fastTest").let {
+        register<SlowTest>("slowTest") {
+            shouldRunAfter(it)
+        }
+    }
+}
+
+/**
+ * Name of a tag for annotating a test class or method that is known to be slow and
+ * should not normally be run together with the main test suite.
+ *
+ * @see [SlowTest](https://spine.io/base/reference/testlib/io/spine/testing/SlowTest.html)
+ * @see [Tag](https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/Tag.html)
+ */
+private const val SLOW_TAG = "slow"
+
+/**
+ * Executes JUnit tests filtering out the ones tagged as `slow`.
+ */
+private open class FastTest : Test() {
+    init {
+        description = "Executes all JUnit tests but the ones tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            excludeTags(SLOW_TAG)
+        }
+    }
+}
+
+/**
+ * Executes JUnit tests tagged as `slow`.
+ */
+private open class SlowTest : Test() {
+    init {
+        description = "Executes JUnit tests tagged as `slow`."
+        group = "Verification"
+
+        this.useJUnitPlatform {
+            includeTags(SLOW_TAG)
+        }
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -409,12 +409,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 12:02:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:21:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.74`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -871,4 +871,4 @@ This report was generated on **Tue Nov 09 12:02:28 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 12:02:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:21:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.76`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -409,12 +409,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:48:12 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 10:45:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.76`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.75`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -871,4 +871,4 @@ This report was generated on **Tue Nov 09 18:48:12 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:48:13 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 10:45:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -409,7 +409,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 04 23:49:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 12:02:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -871,4 +871,4 @@ This report was generated on **Thu Nov 04 23:49:54 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 04 23:49:54 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 12:02:28 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -409,7 +409,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:28:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:48:12 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -871,4 +871,4 @@ This report was generated on **Tue Nov 09 18:28:31 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:28:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:48:13 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -409,7 +409,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 10:45:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 10:49:32 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -871,4 +871,4 @@ This report was generated on **Wed Nov 10 10:45:25 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Nov 10 10:45:25 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Nov 10 10:49:33 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -409,12 +409,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:21:37 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:28:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.75`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.76`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -871,4 +871,4 @@ This report was generated on **Tue Nov 09 18:21:37 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Nov 09 18:21:39 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Nov 09 18:28:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.75</version>
+<version>2.0.0-SNAPSHOT.76</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.74</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.76</version>
+<version>2.0.0-SNAPSHOT.75</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.75"
+val base = "2.0.0-SNAPSHOT.76"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.74"
+val base = "2.0.0-SNAPSHOT.75"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.76"
+val base = "2.0.0-SNAPSHOT.75"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
As a part of the validation library renovation, we change the format of error messages presented with the constraint violations.

This means replacing the `%s` placeholders with case-specific tokens such as `{value}` and `{other}`.

We also deprecate the old `msg_format` fields and replace them with `error_msg` in order not to confuse the users with the word "format".

