### PR TITLE
Migrate to JDK 11 and Java 11 syntax [part 2]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status][travis-badge]][travis] &nbsp; 
+[![Ubuntu build][ubuntu-build-badge]][gh-actions]
 [![codecov][codecov-badge]][codecov] &nbsp;
 [![license][license-badge]][license]
 
@@ -9,67 +9,20 @@ This repository contains the foundation of the Spine framework which includes th
 * **[`base`](base)** — the framework base data types and utilities for working with them.
 * **[`testlib`](testlib)** - utilities for testing.
 
-* **[`tools/javadoc-style`](tools/javadoc-style)** — a Gradle plugin which processes Javadocs of
-  generated Java files to make them look less ugly.
-* **[`tools/javadoc-filter`](tools/javadoc-filter)** — excludes elements annotated with
-  `io.spine.Internal` from the generated doc.
-  
-  
-* **Model Compiler for Java** which consists of the following sub-modules:
-  * **[`tools/mc-java`](tools/mc-java)** — a Gradle plugin responsible for enabling Java
-    code generation.
-  * **[`tools/mc-java-protoc`](tools/mc-java-protoc)** — plugs-into Google Protobuf compiler for
-    generating framework-specific Java code.
-  *  **[`tools/mc-java-validation`](tools/mc-java-validation)** — `protoc` plugins for generating
-    code for validating attributes of a data model.
-  * **[`tools/mc-java-checks`](tools/mc-java-checks)** — static code analyzers for Spine-based
-  Java projects, implemented as custom Error Prone checks.
+These components are used by [core-java](https://github.com/SpineEventEngine/core-java) and other
+Spine libraries. 
 
-    
-* **[`tools/mc-js`](tools/mc-js)** — **Model Compiler for JS**, a Gradle plug-in that assists Protobuf
-  JS compiler in JavaScript code generation.
+They are not supposed to be used directly by the end user project.
+
+## Java Support
+
+Starting version `2.0.0-SNAPSHOT.78`, the modules in this repository are built with Java 11.
+
+Prior versions, including all `1.x` versions were assembled with Java 8.
 
 
-* **[`tools/mc-dart`](tools/mc-dart)** — **Model Compiler for Dart**, a Gradle plugin for generating
-  Dart code. 
-
-These components are used by [core-java](https://github.com/SpineEventEngine/core-java) and are not
-supposed to be used directly by the end user project.
-
-The repository also contains:
-
-* A [common base](tools/plugin-base) for Spine Gradle plugins.
-  
-
-* [Test utilities](tools/plugin-testlib) for Spine plugins.
-  
-
-* [Integration tests](tests) for all Spine tools.
-
-### Notes on Coverage
-
-The coverage stats (as shown on the Codecov badge above) reflect the hits gathered from
-unit tests. However, Gradle plugins — a significant part of this repository — are covered with
-integration tests. During each of those, a standalone Gradle process is launched.
-
-The limitations of `jacoco` task API do not allow to include 
-the coverage of such tests into the repository coverage report easily.
-Therefore, the coverage percentage shown is significantly lower than a real one.
-So, don't be afraid, this code is tested as the rest of the framework.
-
-### `pull` scripts
-
-In most Spine repositories, we update the `config` submodule by running `./config/pull` (or its
-Batch equivalent). However, in `base` we also need to copy Gradle `buildSrc` directory into included
-builds: `tests` and `base-types`. Thus, here we have `./pull` and `.\pull.bat`
-scripts which do whatever their `config` counterparts do and also copy `buildSrc` into the two
-included build directories.
-
-It is always recommended running `./pull` instead of `./config/pull`.
-
-
-[travis]: https://travis-ci.com/SpineEventEngine/base
-[travis-badge]: https://travis-ci.com/SpineEventEngine/base.svg?branch=master
+[gh-actions]: https://github.com/SpineEventEngine/base/actions
+[ubuntu-build-badge]: https://github.com/SpineEventEngine/base/actions/workflows/build-on-ubuntu.yml/badge.svg
 [codecov]: https://codecov.io/gh/SpineEventEngine/base
 [codecov-badge]: https://codecov.io/gh/SpineEventEngine/base/branch/master/graph/badge.svg
 [license-badge]: https://img.shields.io/badge/license-Apache%20License%202.0-blue.svg?style=flat

--- a/base/src/test/java/io/spine/base/EntityColumnTest.java
+++ b/base/src/test/java/io/spine/base/EntityColumnTest.java
@@ -50,10 +50,10 @@ class EntityColumnTest {
     @Test
     @DisplayName("expose the its attributes")
     void exposeColumnName() {
-        String columnName = "some-column";
-        Class<Timestamp> returningType = Timestamp.class;
-        EntityColumn<FakeEntityState, Timestamp> column =
-                new EntityColumn<>(columnName, returningType, (r) -> Time.currentTime());
+        var columnName = "some-column";
+        var returningType = Timestamp.class;
+        var column = new EntityColumn<FakeEntityState, Timestamp>(columnName, returningType,
+                                                                  (r) -> Time.currentTime());
         assertThat(column.name().value()).isEqualTo(columnName);
         assertThat(column.type()).isEqualTo(returningType);
     }

--- a/base/src/test/java/io/spine/base/ErrorsTest.java
+++ b/base/src/test/java/io/spine/base/ErrorsTest.java
@@ -57,7 +57,7 @@ class ErrorsTest extends UtilityClassTest<Errors> {
 
         @BeforeEach
         void createExceptions() {
-            String causeMessage = randomString();
+            var causeMessage = randomString();
             cause = new RuntimeException(causeMessage);
             throwable = new IllegalStateException(cause);
         }
@@ -65,8 +65,8 @@ class ErrorsTest extends UtilityClassTest<Errors> {
         @Test
         @DisplayName("with error code")
         void withCode() {
-            int errorCode = 404;
-            Error error = causeOf(throwable, errorCode);
+            var errorCode = 404;
+            var error = causeOf(throwable, errorCode);
 
             assertHasCause(error);
             assertThat(error.getCode())
@@ -76,7 +76,7 @@ class ErrorsTest extends UtilityClassTest<Errors> {
         @Test
         @DisplayName("without error code")
         void withoutCode() {
-            Error error = causeOf(throwable);
+            var error = causeOf(throwable);
 
             assertHasCause(error);
         }
@@ -91,10 +91,10 @@ class ErrorsTest extends UtilityClassTest<Errors> {
     @Test
     @DisplayName("convert throwable to `Error`")
     void convertThrowableToError() {
-        String expected = newUuid();
-        RuntimeException throwable = new RuntimeException(expected);
+        var expected = newUuid();
+        var throwable = new RuntimeException(expected);
 
-        Error error = fromThrowable(throwable);
+        var error = fromThrowable(throwable);
 
         assertThat(error.getMessage())
                 .isEqualTo(expected);
@@ -103,9 +103,9 @@ class ErrorsTest extends UtilityClassTest<Errors> {
     @Test
     @DisplayName("convert `ValidationException` into an error with `validation_error`")
     void validation() {
-        ConstraintViolation violation = ConstraintViolation.newBuilder().build();
-        ValidationException exception = new ValidationException(ImmutableList.of(violation));
-        Error error = fromThrowable(exception);
+        var violation = ConstraintViolation.newBuilder().build();
+        var exception = new ValidationException(ImmutableList.of(violation));
+        var error = fromThrowable(exception);
         assertThat(error.getValidationError())
                 .isEqualTo(exception.asValidationError());
     }

--- a/base/src/test/java/io/spine/base/FieldTest.java
+++ b/base/src/test/java/io/spine/base/FieldTest.java
@@ -28,7 +28,6 @@ package io.spine.base;
 
 import com.google.common.testing.NullPointerTester;
 import com.google.common.truth.Truth8;
-import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
@@ -73,8 +72,8 @@ class FieldTest {
         @Test
         @DisplayName("with immediate field name")
         void immediate() {
-            String expected = "val";
-            Field field = Field.parse(expected);
+            var expected = "val";
+            var field = Field.parse(expected);
             assertThat(field.path().getFieldNameList())
                     .containsExactly(expected);
         }
@@ -82,8 +81,8 @@ class FieldTest {
         @Test
         @DisplayName("delimited with dots")
         void nested() {
-            String path = "highway.to.hell";
-            Field field = Field.parse(path);
+            var path = "highway.to.hell";
+            var field = Field.parse(path);
             assertThat(field.toString())
                     .isEqualTo(path);
             assertThat(field.path().getFieldNameList())
@@ -100,7 +99,7 @@ class FieldTest {
     @Test
     @DisplayName("create the instance by the path")
     void byPath() {
-        FieldPath expected = Field.doParse("road_to.mandalay");
+        var expected = Field.doParse("road_to.mandalay");
         assertThat(Field.withPath(expected).path())
                 .isEqualTo(expected);
     }
@@ -112,7 +111,7 @@ class FieldTest {
         @Test
         @DisplayName("accepting non-empty string")
         void byName() {
-            String name = "my_way";
+            var name = "my_way";
             assertThat(Field.named(name).toString())
                     .isEqualTo(name);
         }
@@ -148,9 +147,9 @@ class FieldTest {
 
         @BeforeEach
         void createMessage() {
-            Any value = pack(Time.currentTime());
+            var value = pack(Time.currentTime());
             expectedValue = value.getTypeUrl();
-            AnyHolder anyHolder = AnyHolder
+            var anyHolder = AnyHolder
                     .newBuilder()
                     .setVal(value)
                     .build();
@@ -184,11 +183,10 @@ class FieldTest {
         @Test
         @DisplayName("directly via a simple path")
         void obtainSimple() {
-            StringHolder holder = StringHolder
-                    .newBuilder()
+            var holder = StringHolder.newBuilder()
                     .setVal("foobar")
                     .build();
-            Field field = Field.parse("val");
+            var field = Field.parse("val");
             assertThat(field.valueIn(holder))
                     .isEqualTo(holder.getVal());
         }
@@ -196,25 +194,21 @@ class FieldTest {
         @Test
         @DisplayName("via recursive path")
         void recursivePath() {
-            String value = "42";
-            StringHolder holder0 = StringHolder
-                    .newBuilder()
+            var value = "42";
+            var holder0 = StringHolder.newBuilder()
                     .setVal(value)
                     .build();
-            StringHolderHolder holder1 = StringHolderHolder
-                    .newBuilder()
+            var holder1 = StringHolderHolder.newBuilder()
                     .setHolder(holder0)
                     .build();
-            GenericHolder holder2 = GenericHolder
-                    .newBuilder()
+            var holder2 = GenericHolder.newBuilder()
                     .setHolderHolder(holder1)
                     .build();
-            GenericHolder holder3 = GenericHolder
-                    .newBuilder()
+            var holder3 = GenericHolder.newBuilder()
                     .setGeneric(holder2)
                     .build();
 
-            Field field = Field.parse("generic.holder_holder.holder.val");
+            var field = Field.parse("generic.holder_holder.holder.val");
             assertThat(field.valueIn(holder3))
                     .isEqualTo(value);
         }
@@ -222,12 +216,11 @@ class FieldTest {
         @Test
         @DisplayName("if the value is enum")
         void enumValue() {
-            GenericHolder holder = GenericHolder
-                    .newBuilder()
+            var holder = GenericHolder.newBuilder()
                     .setCount(Count.TWO)
                     .build();
 
-            Field field = Field.parse("count");
+            var field = Field.parse("count");
             assertThat(field.valueIn(holder))
                     .isEqualTo(Count.TWO);
         }
@@ -241,12 +234,11 @@ class FieldTest {
         @Test
         @DisplayName("failing if the path reaches over a primitive value")
         void failOnMissingField() {
-            String value = "primitive value";
-            StringHolder holder = StringHolder
-                    .newBuilder()
+            var value = "primitive value";
+            var holder = StringHolder.newBuilder()
                     .setVal(value)
                     .build();
-            Field wrongPath = parse("val.this_field_is_absent");
+            var wrongPath = parse("val.this_field_is_absent");
             assertIllegalState(() -> wrongPath.valueIn(holder));
         }
     }
@@ -254,16 +246,16 @@ class FieldTest {
     @Test
     @DisplayName("check that the field is present in the message type")
     void checkPresent() {
-        Field field = Field.parse("val");
-        Descriptor message = StringHolder.getDescriptor();
+        var field = Field.parse("val");
+        var message = StringHolder.getDescriptor();
         assertThat(field.presentIn(message)).isTrue();
     }
 
     @Test
     @DisplayName("check that the field is not present in the message type")
     void checkNotPresent() {
-        Field field = Field.parse("some_other_field");
-        Descriptor message = StringHolder.getDescriptor();
+        var field = Field.parse("some_other_field");
+        var message = StringHolder.getDescriptor();
         assertThat(field.presentIn(message)).isFalse();
     }
 
@@ -325,7 +317,7 @@ class FieldTest {
         @Test
         @DisplayName("when the type is recursive")
         void recursiveType() {
-            Field field = Field.parse("generic.generic.generic.generic.generic");
+            var field = Field.parse("generic.generic.generic.generic.generic");
 
             Truth8.assertThat(field.findType(GenericHolder.class))
                   .hasValue(GenericHolder.class);
@@ -341,7 +333,7 @@ class FieldTest {
         @Test
         @DisplayName("returning the short name of the field, if present")
         void nameValue() {
-            String name = Field.nameOf(Timestamp.NANOS_FIELD_NUMBER, message);
+            var name = Field.nameOf(Timestamp.NANOS_FIELD_NUMBER, message);
             assertThat(name).isEqualTo("nanos");
         }
 
@@ -367,19 +359,19 @@ class FieldTest {
     @Test
     @DisplayName("obtain the instance which is a nested field in the current field type")
     void returnNested() {
-        String topLevelField = "top-level-field";
-        Field topLevel = Field.named(topLevelField);
-        String nestedField = "nested-field";
-        Field nested = topLevel.nested(nestedField);
+        var topLevelField = "top-level-field";
+        var topLevel = Field.named(topLevelField);
+        var nestedField = "nested-field";
+        var nested = topLevel.nested(nestedField);
 
-        FieldPath path = nested.path();
+        var path = nested.path();
         assertThat(path.getFieldNameList()).containsExactly(topLevelField, nestedField);
     }
 
     @Test
     @DisplayName("obtain the instance by number in a message type")
     void byNumber() {
-        Field seconds = Field.withNumberIn(1, Timestamp.getDescriptor());
+        var seconds = Field.withNumberIn(1, Timestamp.getDescriptor());
         assertThat((Long) seconds.valueIn(Time.currentTime()))
                 .isGreaterThan(0);
     }
@@ -387,14 +379,14 @@ class FieldTest {
     @Test
     @DisplayName("check that the field is a nested field")
     void checkNested() {
-        Field field = Field.parse("some.nested.field");
+        var field = Field.parse("some.nested.field");
         assertThat(field.isNested()).isTrue();
     }
 
     @Test
     @DisplayName("check that the field is not a nested field")
     void checkTopLevel() {
-        Field field = Field.parse("top_level_field");
+        var field = Field.parse("top_level_field");
         assertThat(field.isNested()).isFalse();
     }
 }

--- a/base/src/test/java/io/spine/base/GeneratedMixinTest.java
+++ b/base/src/test/java/io/spine/base/GeneratedMixinTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.base;
 
-import com.google.common.truth.IterableSubject;
 import io.spine.annotation.GeneratedMixin;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -54,7 +53,7 @@ class GeneratedMixinTest {
     @Test
     @DisplayName("have `TYPE` target")
     void target() {
-        IterableSubject assertTargets = assertThat(annotation(Target.class).value()).asList();
+        var assertTargets = assertThat(annotation(Target.class).value()).asList();
 
         assertTargets.hasSize(1);
         assertTargets.contains(ElementType.TYPE);

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -126,29 +126,29 @@ class IdentifierTest {
     }
 
     @Nested
-    @DisplayName("recognize type by supported Message type")
+    @DisplayName("recognize type by supported `Message` type")
     class RecognizeType {
 
         @Test
-        @DisplayName("INTEGER")
+        @DisplayName("`INTEGER`")
         void ofInteger() {
             assertTrue(INTEGER.matchMessage(toMessage(10)));
         }
 
         @Test
-        @DisplayName("LONG")
+        @DisplayName("`LONG`")
         void ofLong() {
             assertTrue(LONG.matchMessage(toMessage(1020L)));
         }
 
         @Test
-        @DisplayName("STRING")
+        @DisplayName("`STRING`")
         void ofString() {
             assertTrue(STRING.matchMessage(toMessage("")));
         }
 
         @Test
-        @DisplayName("MESSAGE")
+        @DisplayName("`MESSAGE`")
         void ofMessage() {
             assertTrue(MESSAGE.matchMessage(Timestamp.getDefaultInstance()));
 
@@ -209,13 +209,13 @@ class IdentifierTest {
         }
 
         @Test
-        @DisplayName("a Message with a field of Message type, which has the default value")
+        @DisplayName("a `Message` with a field of `Message` type, which has the default value")
         void defaultNestedMessage() {
             assertEmpty(TimestampFieldId.getDefaultInstance());
         }
 
         private void assertEmpty(Object id) {
-            String str = Identifier.toString(id);
+            var str = Identifier.toString(id);
             assertThat(str).isEqualTo(EMPTY_ID);
         }
     }
@@ -293,11 +293,11 @@ class IdentifierTest {
         @Test
         @DisplayName("wrapped `Integer`")
         void ofWrappedInteger() {
-            int value = 1024;
-            Int32Value id = Int32Value.of(value);
-            String expected = Integer.toString(value);
+            var value = 1024;
+            var id = Int32Value.of(value);
+            var expected = Integer.toString(value);
 
-            String actual = Identifier.toString(id);
+            var actual = Identifier.toString(id);
 
             assertEquals(expected, actual);
         }
@@ -305,11 +305,11 @@ class IdentifierTest {
         @Test
         @DisplayName("wrapped `Long`")
         void ofWrappedLong() {
-            long value = 100500L;
-            Int64Value id = Int64Value.of(value);
-            String expected = Long.toString(value);
+            var value = 100500L;
+            var id = Int64Value.of(value);
+            var expected = Long.toString(value);
 
-            String actual = Identifier.toString(id);
+            var actual = Identifier.toString(id);
 
             assertEquals(expected, actual);
         }
@@ -323,9 +323,9 @@ class IdentifierTest {
         @Test
         @DisplayName("wrapped `String`")
         void ofWrappedString() {
-            StringValue id = StringValue.of(TEST_ID);
+            var id = StringValue.of(TEST_ID);
 
-            String result = Identifier.toString(id);
+            var result = Identifier.toString(id);
 
             assertEquals(TEST_ID, result);
         }
@@ -333,9 +333,9 @@ class IdentifierTest {
         @Test
         @DisplayName("`Message` with string field")
         void ofMessage() {
-            StringValue id = StringValue.of(TEST_ID);
+            var id = StringValue.of(TEST_ID);
 
-            String result = Identifier.toString(id);
+            var result = Identifier.toString(id);
 
             assertEquals(TEST_ID, result);
         }
@@ -343,12 +343,12 @@ class IdentifierTest {
         @Test
         @DisplayName("`Message` with nested `Message`")
         void ofNestedMessage() {
-            StringValue value = StringValue.of(TEST_ID);
-            NestedMessageId idToConvert = NestedMessageId.newBuilder()
+            var value = StringValue.of(TEST_ID);
+            var idToConvert = NestedMessageId.newBuilder()
                     .setId(value)
                     .build();
 
-            String result = Identifier.toString(idToConvert);
+            var result = Identifier.toString(idToConvert);
 
             assertEquals(TEST_ID, result);
         }
@@ -356,10 +356,10 @@ class IdentifierTest {
         @Test
         @DisplayName("`Any`")
         void ofAny() {
-            StringValue messageToWrap = StringValue.of(TEST_ID);
-            Any any = AnyPacker.pack(messageToWrap);
+            var messageToWrap = StringValue.of(TEST_ID);
+            var any = AnyPacker.pack(messageToWrap);
 
-            String result = Identifier.toString(any);
+            var result = Identifier.toString(any);
 
             assertEquals(TEST_ID, result);
         }
@@ -368,23 +368,23 @@ class IdentifierTest {
     @Test
     @DisplayName("provide string conversion of messages with several fields")
     void toStringSeveralFields() {
-        String nestedString = "nested_string";
-        String outerString = "outer_string";
-        int number = 256;
+        var nestedString = "nested_string";
+        var outerString = "outer_string";
+        var number = 256;
 
-        StringValue nestedMessageString = StringValue.of(nestedString);
-        SeveralFieldsId idToConvert = SeveralFieldsId.newBuilder()
+        var nestedMessageString = StringValue.of(nestedString);
+        var idToConvert = SeveralFieldsId.newBuilder()
                 .setString(outerString)
                 .setNumber(number)
                 .setMessage(nestedMessageString)
                 .build();
 
-        String expected =
+        var expected =
                 "string=\"" + outerString + '\"' +
                         " number=" + number +
                         " message { value=\"" + nestedString + "\" }";
 
-        String actual = Identifier.toString(idToConvert);
+        var actual = Identifier.toString(idToConvert);
 
         assertEquals(expected, actual);
     }
@@ -418,7 +418,7 @@ class IdentifierTest {
         @Test
         @DisplayName("`String`")
         void stringValue() {
-            String value = getClass().getSimpleName();
+            var value = getClass().getSimpleName();
             assertEquals(value, STRING.fromMessage(toMessage(value)));
         }
     }
@@ -484,9 +484,9 @@ class IdentifierTest {
         @Test
         @DisplayName("Any with StringValue and cast")
         void anyWithStringValue() {
-            StringValue testIdMessage = StringValue.of(TEST_ID);
-            Any any = AnyPacker.pack(testIdMessage);
-            String unpackedId = Identifier.unpack(any, String.class);
+            var testIdMessage = StringValue.of(TEST_ID);
+            var any = AnyPacker.pack(testIdMessage);
+            var unpackedId = Identifier.unpack(any, String.class);
             assertEquals(testIdMessage.getValue(), unpackedId);
         }
 
@@ -541,7 +541,7 @@ class IdentifierTest {
         }
 
         FieldDescriptor field(int index) {
-            FieldDescriptor field =
+            var field =
                     SeveralFieldsId.getDescriptor()
                                    .getFields()
                                    .get(index);
@@ -597,7 +597,7 @@ class IdentifierTest {
     @Test
     @DisplayName("allow event `Empty` as a `Message`-based ID")
     void throwOnUnpacking() {
-        Any packedEmpty = AnyPacker.pack(Empty.getDefaultInstance());
+        var packedEmpty = AnyPacker.pack(Empty.getDefaultInstance());
 
         assertThat(Identifier.unpack(packedEmpty))
                 .isEqualTo(Empty.getDefaultInstance());

--- a/base/src/test/java/io/spine/base/IdentifierTest.java
+++ b/base/src/test/java/io/spine/base/IdentifierTest.java
@@ -379,10 +379,9 @@ class IdentifierTest {
                 .setMessage(nestedMessageString)
                 .build();
 
-        var expected =
-                "string=\"" + outerString + '\"' +
-                        " number=" + number +
-                        " message { value=\"" + nestedString + "\" }";
+        var expected = "string=\"" + outerString + '\"' +
+                " number=" + number +
+                " message { value=\"" + nestedString + "\" }";
 
         var actual = Identifier.toString(idToConvert);
 

--- a/base/src/test/java/io/spine/base/MessageFileTest.java
+++ b/base/src/test/java/io/spine/base/MessageFileTest.java
@@ -36,7 +36,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("MessageFile should")
+@DisplayName("`MessageFile` should")
 class MessageFileTest {
 
     @Nested
@@ -46,15 +46,14 @@ class MessageFileTest {
         @Test
         @DisplayName("accepting the file with matching suffix")
         void acceptingEligibleFile() {
-            FileDescriptor descriptor = MessageFileEventsProto.getDescriptor();
+            var descriptor = MessageFileEventsProto.getDescriptor();
             assertTrue(MessageFile.EVENTS.test(descriptor.toProto()));
         }
 
         @Test
         @DisplayName("rejecting the file with non-matching suffix")
         void rejectingNonEligibleFile() {
-            FileDescriptor descriptor = Any.getDescriptor()
-                                           .getFile();
+            var descriptor = Any.getDescriptor().getFile();
             assertFalse(MessageFile.EVENTS.test(descriptor.toProto()));
         }
     }

--- a/base/src/test/java/io/spine/base/MessageIdToStringTest.java
+++ b/base/src/test/java/io/spine/base/MessageIdToStringTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("MessageIdToString utility class should")
+@DisplayName("`MessageIdToString` utility class should")
 class MessageIdToStringTest extends UtilityClassTest<MessageIdToString> {
 
     MessageIdToStringTest() {
@@ -41,12 +41,12 @@ class MessageIdToStringTest extends UtilityClassTest<MessageIdToString> {
     }
 
     @Test
-    @DisplayName("convert Message to String")
+    @DisplayName("convert `Message` to `String`")
     void convert() {
-        UuidMessage test = UuidMessage.newBuilder()
-                                      .setUuid("0bd2d85f-8a07-4041-a62a-6852654d44e6")
-                                      .build();
-        String value = MessageIdToString.toString(test);
+        var test = UuidMessage.newBuilder()
+                .setUuid("0bd2d85f-8a07-4041-a62a-6852654d44e6")
+                .build();
+        var value = MessageIdToString.toString(test);
 
         assertThat(value).contains(test.getUuid());
     }

--- a/base/src/test/java/io/spine/base/RejectionThrowableTest.java
+++ b/base/src/test/java/io/spine/base/RejectionThrowableTest.java
@@ -25,7 +25,6 @@
  */
 package io.spine.base;
 
-import com.google.common.collect.ImmutableList;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.Any;
 import com.google.protobuf.Descriptors;
@@ -34,13 +33,11 @@ import com.google.protobuf.Message;
 import com.google.protobuf.Parser;
 import com.google.protobuf.UnknownFieldSet;
 import com.google.protobuf.util.Timestamps;
-import io.spine.validate.ConstraintViolation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.Optional;
 
 import static io.spine.testing.Assertions.assertIllegalState;
 import static io.spine.testing.Assertions.assertNpe;
@@ -82,10 +79,10 @@ class RejectionThrowableTest {
         assertFalse(rejectionThrowable.producerId()
                                       .isPresent());
 
-        RejectionThrowable retVal = rejectionThrowable.initProducer(producer);
+        var retVal = rejectionThrowable.initProducer(producer);
 
         assertSame(rejectionThrowable, retVal);
-        Optional<Any> optional = rejectionThrowable.producerId();
+        var optional = rejectionThrowable.producerId();
         assertTrue(optional.isPresent());
         assertEquals(producer, optional.get());
     }
@@ -98,7 +95,7 @@ class RejectionThrowableTest {
     }
 
     @Test
-    @DisplayName("not allow null producer")
+    @DisplayName("not allow `null` producer")
     void prohibitNullProducer() {
         assertNpe(() -> rejectionThrowable.initProducer(nullRef()));
     }
@@ -116,7 +113,7 @@ class RejectionThrowableTest {
 
         private static final long serialVersionUID = 0L;
 
-        private TestRejectionThrowable(@SuppressWarnings("rawtypes") RejectionMessage rejection) {
+        private TestRejectionThrowable(RejectionMessage rejection) {
             super(rejection);
         }
     }
@@ -131,7 +128,7 @@ class RejectionThrowableTest {
      * the Spine Protobuf Compiler plugin. However, in this module we're unable to use the plugin,
      * so this fake implementation is declared.
      */
-    @SuppressWarnings({"ReturnOfNull", "Immutable", "rawtypes"}) // OK for a fake.
+    @SuppressWarnings({"ReturnOfNull", "Immutable"}) // OK for a fake.
     private static class FakeRejectionMessage extends AbstractMessage implements RejectionMessage {
 
         private static final long serialVersionUID = 0L;

--- a/base/src/test/java/io/spine/base/RejectionTypeTest.java
+++ b/base/src/test/java/io/spine/base/RejectionTypeTest.java
@@ -55,7 +55,7 @@ class RejectionTypeTest {
         @Test
         @DisplayName("a throwable class")
         void throwableClass() {
-            ClassName expected =
+            var expected =
                     ClassName.of(type.javaPackage().value() + '.' + type.descriptor().getName());
             assertThat(type.throwableClass())
                     .isEqualTo(expected);
@@ -64,7 +64,7 @@ class RejectionTypeTest {
         @Test
         @DisplayName("a message class")
         void messageClass() {
-            ClassName expected = ClassName.from(DESCRIPTOR);
+            var expected = ClassName.from(DESCRIPTOR);
             assertThat(type.messageClass())
                     .isEqualTo(expected);
         }

--- a/base/src/test/java/io/spine/base/SubscribableFieldTest.java
+++ b/base/src/test/java/io/spine/base/SubscribableFieldTest.java
@@ -49,7 +49,7 @@ class SubscribableFieldTest {
     @Test
     @DisplayName("expose the field reference")
     void exposeColumnName() {
-        Field field = newField();
+        var field = newField();
         SubscribableField subscribableField = new EntityStateField(field);
         assertThat(subscribableField.getField()).isEqualTo(field);
     }

--- a/base/src/test/java/io/spine/base/TimeTest.java
+++ b/base/src/test/java/io/spine/base/TimeTest.java
@@ -63,7 +63,7 @@ class TimeTest {
     @Test
     @DisplayName("accept `TimeProvider`")
     void acceptProvider() {
-        Timestamp fiveMinutesAgo = subtract(currentTime(), DURATION_5_MINUTES);
+        var fiveMinutesAgo = subtract(currentTime(), DURATION_5_MINUTES);
 
         setProvider(new ConstantTimeProvider(fiveMinutesAgo));
 
@@ -77,7 +77,7 @@ class TimeTest {
     @Test
     @DisplayName("reset `TimeProvider` to default value")
     void reset() {
-        Timestamp aMinuteAgo = subtract(systemTime(), DURATION_1_MINUTE);
+        var aMinuteAgo = subtract(systemTime(), DURATION_1_MINUTE);
 
         setProvider(new ConstantTimeProvider(aMinuteAgo));
         resetProvider();
@@ -111,9 +111,9 @@ class TimeTest {
         @DisplayName("which returns incremental emulated values if called several times" +
                 " within a single point of wall-clock time")
         void differentValuesForTheSameTime() {
-            Instant now = Instant.now();
-            long seconds = now.getEpochSecond();
-            int nanos = now.getNano();
+            var now = Instant.now();
+            var seconds = now.getEpochSecond();
+            var nanos = now.getNano();
             assertThat(IncrementalNanos.valueForTime(seconds, nanos))
                     .isLessThan(IncrementalNanos.valueForTime(seconds, nanos));
         }
@@ -122,13 +122,13 @@ class TimeTest {
         @Test
         @DisplayName("which returns zero nanosecond value for each new point in time")
         void resetsNanosForNewInstant() {
-            Instant now = Instant.now();
-            Instant oneMsLater = now.plus(1, ChronoUnit.MILLIS);
+            var now = Instant.now();
+            var oneMsLater = now.plus(1, ChronoUnit.MILLIS);
             IncrementalNanos
                     .valueForTime(now.getEpochSecond(), now.getNano()); // Ignore this value.
-            long oneMsLaterSeconds = oneMsLater.getEpochSecond();
-            int oneMsLaterNanos = oneMsLater.getNano();
-            int value = IncrementalNanos.valueForTime(oneMsLaterSeconds, oneMsLaterNanos);
+            var oneMsLaterSeconds = oneMsLater.getEpochSecond();
+            var oneMsLaterNanos = oneMsLater.getNano();
+            var value = IncrementalNanos.valueForTime(oneMsLaterSeconds, oneMsLaterNanos);
             assertThat(value).isEqualTo(0);
         }
     }
@@ -144,7 +144,7 @@ class TimeTest {
     @Test
     @DisplayName("obtain current time zone")
     void timeZone() {
-        ZoneId zoneId = Time.currentTimeZone();
+        var zoneId = Time.currentTimeZone();
         assertThat(zoneId).isEqualTo(ZoneId.systemDefault());
     }
 

--- a/base/src/test/java/io/spine/base/given/AppEngineStandard.java
+++ b/base/src/test/java/io/spine/base/given/AppEngineStandard.java
@@ -36,7 +36,7 @@ public class AppEngineStandard extends AppEngine {
 
     @Override
     protected boolean enabled() {
-        String propertyValue = System.getProperty(ENV_KEY);
+        var propertyValue = System.getProperty(ENV_KEY);
         return activeValue().equalsIgnoreCase(propertyValue);
     }
 

--- a/base/src/test/java/io/spine/code/java/ClassNameTest.java
+++ b/base/src/test/java/io/spine/code/java/ClassNameTest.java
@@ -27,7 +27,6 @@
 package io.spine.code.java;
 
 import com.google.common.testing.NullPointerTester;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.StringValue;
 import io.spine.test.type.Uri;
 import org.junit.jupiter.api.DisplayName;
@@ -53,7 +52,7 @@ class ClassNameTest {
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void passNullToleranceCheck() {
-        Descriptors.Descriptor descriptor = StringValue.getDescriptor();
+        var descriptor = StringValue.getDescriptor();
         new NullPointerTester()
                 .setDefault(SimpleClassName.class, SimpleClassName.ofMessage(descriptor))
                 .setDefault(PackageName.class, PackageName.resolve(descriptor.getFile()
@@ -64,8 +63,8 @@ class ClassNameTest {
     @Test
     @DisplayName("provide binary name and canonical name")
     void provideBinaryAndCanonical() {
-        Class<Uri.Protocol> cls = Uri.Protocol.class;
-        ClassName className = ClassName.of(cls);
+        var cls = Uri.Protocol.class;
+        var className = ClassName.of(cls);
         assertThat(className.binaryName()).isEqualTo(cls.getName());
         assertThat(className.canonicalName()).isEqualTo(cls.getCanonicalName());
     }
@@ -73,7 +72,7 @@ class ClassNameTest {
     @Test
     @DisplayName("throw ISE when parsing an invalid name")
     void throwOnInvalid() {
-        ClassName className = ClassName.of("NotQualifiedName");
+        var className = ClassName.of("NotQualifiedName");
         assertIllegalState(className::packageName);
     }
 

--- a/base/src/test/java/io/spine/code/java/SimpleClassNameTest.java
+++ b/base/src/test/java/io/spine/code/java/SimpleClassNameTest.java
@@ -37,8 +37,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code base} module, this test uses descriptors copied from the {@code base} stored in
  * resources. That's why the {@code ErrorProto} descriptor is available for these tests.
  */
-@DisplayName("SimpleClassName should")
+@DisplayName("`SimpleClassName` should")
 class SimpleClassNameTest {
 
     private static final FileSet mainSet = FileSet.load();
@@ -60,9 +58,9 @@ class SimpleClassNameTest {
     @SuppressWarnings("OptionalGetWithoutIsPresent") /* The file is present in resources. */
     @BeforeEach
     void setUp() {
-        FileName errorFileName = FileName.from(Error.getDescriptor()
-                                                    .getFile()
-                                                    .toProto());
+        var errorFileName = FileName.from(Error.getDescriptor()
+                                               .getFile()
+                                               .toProto());
         errorProto = mainSet.tryFind(errorFileName)
                             .get();
     }
@@ -77,8 +75,7 @@ class SimpleClassNameTest {
     @Test
     @DisplayName("obtain declared outer class name")
     void obtain_declared_outer_class_name() {
-        Optional<SimpleClassName> className =
-                SimpleClassName.declaredOuterClassName(errorProto);
+        var className = SimpleClassName.declaredOuterClassName(errorProto);
 
         assertTrue(className.isPresent());
         assertEquals(ERROR_PROTO, className.get()

--- a/base/src/test/java/io/spine/code/proto/ColumnOptionTest.java
+++ b/base/src/test/java/io/spine/code/proto/ColumnOptionTest.java
@@ -26,9 +26,7 @@
 
 package io.spine.code.proto;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.testing.NullPointerTester;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.test.code.proto.CoProject;
 import io.spine.test.code.proto.CoTask;
 import io.spine.test.code.proto.CoTaskDescription;
@@ -62,68 +60,68 @@ class ColumnOptionTest {
     @Test
     @DisplayName("determine that message type has no columns")
     void checkHasNoColumns() {
-        MessageType typeWithoutColumns = new MessageType(CoTask.getDescriptor());
+        var typeWithoutColumns = new MessageType(CoTask.getDescriptor());
         assertThat(ColumnOption.hasColumns(typeWithoutColumns)).isFalse();
     }
 
     @Test
     @DisplayName("determine that message type is not eligible for having columns")
     void checkNotEligibleForColumns() {
-        MessageType nonEligible = new MessageType(CoTaskDescription.getDescriptor());
+        var nonEligible = new MessageType(CoTaskDescription.getDescriptor());
         assertThat(ColumnOption.hasColumns(nonEligible)).isFalse();
     }
 
     @Test
     @DisplayName("obtain columns of the entity")
     void obtainColumns() {
-        ImmutableList<FieldDeclaration> columns = ColumnOption.columnsOf(type);
+        var columns = ColumnOption.columnsOf(type);
         assertThat(columns).hasSize(2);
 
-        ImmutableList<String> columnNames = columns.stream()
-                                                   .map(FieldDeclaration::name)
-                                                   .map(StringTypeValue::value)
-                                                   .collect(toImmutableList());
+        var columnNames = columns.stream()
+                .map(FieldDeclaration::name)
+                .map(StringTypeValue::value)
+                .collect(toImmutableList());
         assertThat(columnNames).containsExactly("name", "estimate");
     }
 
     @Test
     @DisplayName("return empty list of columns if the message is not eligible for having ones")
     void obtainEmptyColumns() {
-        MessageType nonEligible = new MessageType(CoTaskDescription.getDescriptor());
-        ImmutableList<FieldDeclaration> list = ColumnOption.columnsOf(nonEligible);
+        var nonEligible = new MessageType(CoTaskDescription.getDescriptor());
+        var list = ColumnOption.columnsOf(nonEligible);
         assertThat(list).isEmpty();
     }
 
     @Test
     @DisplayName("determine that the passed field is a column")
     void checkIsColumn() {
-        FieldDeclaration nameField = fieldByName("name");
-        boolean isColumn = ColumnOption.isColumn(nameField);
+        var nameField = fieldByName("name");
+        var isColumn = ColumnOption.isColumn(nameField);
         assertThat(isColumn).isTrue();
     }
 
     @Test
     @DisplayName("determine that the passed field is not a column")
     void checkIsNotColumn() {
-        FieldDeclaration statusField = fieldByName("status");
-        boolean isColumn = ColumnOption.isColumn(statusField);
+        var statusField = fieldByName("status");
+        var isColumn = ColumnOption.isColumn(statusField);
         assertThat(isColumn).isFalse();
     }
 
     @Test
     @DisplayName("return `false` for fields of type non-eligible for having columns")
     void checkFieldOfNonEligible() {
-        FieldDescriptor descriptor = CoTaskDescription.getDescriptor()
-                                                 .findFieldByName("value");
-        FieldDeclaration field = new FieldDeclaration(descriptor);
-        boolean isColumn = ColumnOption.isColumn(field);
+        var descriptor = CoTaskDescription.getDescriptor()
+                                          .findFieldByName("value");
+        var field = new FieldDeclaration(descriptor);
+        var isColumn = ColumnOption.isColumn(field);
         assertThat(isColumn).isFalse();
     }
 
     private FieldDeclaration fieldByName(String name) {
-        FieldDescriptor field = type.descriptor()
-                                    .findFieldByName(name);
-        FieldDeclaration result = new FieldDeclaration(field);
+        var field = type.descriptor()
+                        .findFieldByName(name);
+        var result = new FieldDeclaration(field);
         return result;
     }
 }

--- a/base/src/test/java/io/spine/code/proto/DescriptorReferenceTest.java
+++ b/base/src/test/java/io/spine/code/proto/DescriptorReferenceTest.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
@@ -57,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("Descriptor reference should")
+@DisplayName("`DescriptorReference` should")
 class DescriptorReferenceTest {
 
     @SuppressWarnings("HardcodedLineSeparator")
@@ -81,15 +80,15 @@ class DescriptorReferenceTest {
     @Test
     @DisplayName("ignore previous content of the `desc.ref` file")
     void ignorePreviousDescRef(@TempDir Path path) {
-        DescriptorReference firstReference = randomRef();
+        var firstReference = randomRef();
         firstReference.writeTo(path);
         assertResourcesLoaded(path, firstReference);
 
-        DescriptorReference secondReference = knownTypesRef();
+        var secondReference = knownTypesRef();
         secondReference.writeTo(path);
         assertResourcesLoaded(path, firstReference, secondReference);
 
-        DescriptorReference thirdReference = smokeTestModelCompilerRef();
+        var thirdReference = smokeTestModelCompilerRef();
         thirdReference.writeTo(path);
         assertResourcesLoaded(path, firstReference, secondReference, thirdReference);
     }
@@ -97,14 +96,13 @@ class DescriptorReferenceTest {
     @Test
     @DisplayName("write a reference with expected content")
     void properContent(@TempDir Path path) throws IOException {
-        DescriptorReference knownTypes = knownTypesRef();
+        var knownTypes = knownTypesRef();
         knownTypes.writeTo(path);
 
-        File descRef = path.resolve(DescriptorReference.FILE_NAME)
-                           .toFile();
-        List<String> linesWritten = Files.readLines(descRef, UTF_8);
+        var descRef = path.resolve(DescriptorReference.FILE_NAME).toFile();
+        var linesWritten = Files.readLines(descRef, UTF_8);
         assertEquals(1, linesWritten.size());
-        String fileName = linesWritten.get(0);
+        var fileName = linesWritten.get(0);
         assertThat(knownTypes.asResource().toString())
                 .contains(fileName);
     }
@@ -112,7 +110,7 @@ class DescriptorReferenceTest {
     private static void assertDescriptorRefsWrittenCorrectly(@TempDir Path path,
                                                              String separator,
                                                              DescriptorReference... descriptors) {
-        for (DescriptorReference descriptor : descriptors) {
+        for (var descriptor : descriptors) {
             descriptor.writeTo(path, separator);
         }
 
@@ -122,31 +120,31 @@ class DescriptorReferenceTest {
     @Test
     @DisplayName("throw if the referenced path points to a file instead of a directory")
     void throwsOnDirectory(@TempDir Path path) {
-        DescriptorReference knownTypes = knownTypesRef();
-        File newFile = createFileUnderPath(path);
+        var knownTypes = knownTypesRef();
+        var newFile = createFileUnderPath(path);
         assertIllegalState(() -> knownTypes.writeTo(newFile.toPath()));
     }
 
     @Test
     @DisplayName("throw if the referenced path is null")
     void throwsOnNull() {
-        DescriptorReference knownTypes = knownTypesRef();
+        var knownTypes = knownTypesRef();
         assertNpe(() -> knownTypes.writeTo(null));
     }
 
     @Test
     @DisplayName("return an empty iterator upon missing `desc.ref` file")
     void onMissingDescRef() {
-        Iterator<Resource> result = DescriptorReference.loadFromResources(emptyList());
+        var result = DescriptorReference.loadFromResources(emptyList());
         assertFalse(result.hasNext());
     }
 
     private static void assertResourcesLoaded(Path path, DescriptorReference... expected) {
-        Path descRef = path.resolve(DescriptorReference.FILE_NAME);
-        Iterator<Resource> existingDescriptors = loadFromResources(asList(descRef));
+        var descRef = path.resolve(DescriptorReference.FILE_NAME);
+        var existingDescriptors = loadFromResources(asList(descRef));
         List<Resource> result = newArrayList(existingDescriptors);
         assertEquals(expected.length, result.size());
-        for (DescriptorReference reference : expected) {
+        for (var reference : expected) {
             assertTrue(result.contains(reference.asResource()));
         }
     }
@@ -165,9 +163,8 @@ class DescriptorReferenceTest {
     // recursive calls should not happen.
     private static File createFileUnderPath(Path path) {
         // Ensures no existing file with such name.
-        String fileName = UUID.randomUUID()
-                              .toString();
-        File result = new File(path.toFile(), fileName);
+        var fileName = UUID.randomUUID().toString();
+        var result = new File(path.toFile(), fileName);
         if (result.exists()) {
             return createFileUnderPath(path);
         }

--- a/base/src/test/java/io/spine/code/proto/EntityStateOptionTest.java
+++ b/base/src/test/java/io/spine/code/proto/EntityStateOptionTest.java
@@ -28,7 +28,6 @@ package io.spine.code.proto;
 
 import com.google.common.truth.Truth8;
 import com.google.protobuf.Descriptors.Descriptor;
-import io.spine.option.EntityOption;
 import io.spine.option.EntityOption.Kind;
 import io.spine.option.EntityOption.Visibility;
 import io.spine.test.code.proto.EsoEntity;
@@ -37,8 +36,6 @@ import io.spine.test.code.proto.EsoSecretAggregate;
 import io.spine.test.code.proto.EsoSubscribablePm;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.option.EntityOption.Kind.AGGREGATE;
@@ -50,29 +47,29 @@ import static io.spine.option.EntityOption.Visibility.NONE;
 import static io.spine.option.EntityOption.Visibility.QUERY;
 import static io.spine.option.EntityOption.Visibility.SUBSCRIBE;
 
-@DisplayName("EntityStateOption should")
+@DisplayName("`EntityStateOption` should")
 class EntityStateOptionTest {
 
     @Test
-    @DisplayName("obtain value for an ENTITY kind")
+    @DisplayName("obtain value for an `ENTITY` kind")
     void entity() {
         assertOption(EsoEntity.getDescriptor(), ENTITY, QUERY);
     }
 
     @Test
-    @DisplayName("obtain value for an AGGREGATE kind")
+    @DisplayName("obtain value for an `AGGREGATE` kind")
     void aggregate() {
         assertOption(EsoSecretAggregate.getDescriptor(), AGGREGATE, NONE);
     }
 
     @Test
-    @DisplayName("obtain value for an PROCESS_MANAGER kind")
+    @DisplayName("obtain value for an `PROCESS_MANAGER` kind")
     void processManager() {
         assertOption(EsoSubscribablePm.getDescriptor(), PROCESS_MANAGER, SUBSCRIBE);
     }
 
     @Test
-    @DisplayName("obtain value for an PROJECTION kind")
+    @DisplayName("obtain value for an `PROJECTION` kind")
     void projection() {
         assertOption(EsoPublicProjection.getDescriptor(), PROJECTION, FULL);
     }
@@ -80,16 +77,16 @@ class EntityStateOptionTest {
     @Test
     @DisplayName("obtain the kind of an entity")
     void obtainEntityKind() {
-        Optional<Kind> kind = EntityStateOption.entityKindOf(EsoPublicProjection.getDescriptor());
+        var kind = EntityStateOption.entityKindOf(EsoPublicProjection.getDescriptor());
         Truth8.assertThat(kind).isPresent();
         assertThat(kind.get()).isEqualTo(PROJECTION);
     }
 
     void assertOption(Descriptor type, Kind kind, Visibility visibility) {
-        Optional<EntityOption> found = EntityStateOption.valueOf(type);
+        var found = EntityStateOption.valueOf(type);
         Truth8.assertThat(found).isPresent();
         @SuppressWarnings("OptionalGetWithoutIsPresent") // checked above.
-        EntityOption option = found.get();
+        var option = found.get();
         assertThat(option.getKind())
                 .isEqualTo(kind);
         assertThat(option.getVisibility())

--- a/base/src/test/java/io/spine/code/proto/FieldDeclarationTest.java
+++ b/base/src/test/java/io/spine/code/proto/FieldDeclarationTest.java
@@ -31,7 +31,6 @@ import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Any;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.BytesValue;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Empty;
 import com.google.protobuf.Int32Value;
@@ -50,14 +49,14 @@ import static io.spine.testing.Assertions.assertIllegalState;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("FieldDeclaration should")
+@DisplayName("`FieldDeclaration` should")
 class FieldDeclarationTest {
 
     @Test
-    @DisplayName("not accept nulls on construction")
+    @DisplayName("not accept `null`s on construction")
     void notAcceptNullsOnCtor() {
-        Descriptor descriptor = Any.getDescriptor();
-        NullPointerTester tester = new NullPointerTester()
+        var descriptor = Any.getDescriptor();
+        var tester = new NullPointerTester()
                 .setDefault(MessageType.class, new MessageType(descriptor))
                 .setDefault(FieldDescriptor.class, descriptor.getFields()
                                                              .get(0));
@@ -65,23 +64,23 @@ class FieldDeclarationTest {
     }
 
     @Test
-    @DisplayName("not accept nulls")
+    @DisplayName("not accept `null`s")
     void notAcceptNulls() {
-        Descriptor descriptor = Any.getDescriptor();
-        FieldDescriptor field = descriptor.getFields()
-                                          .get(0);
+        var descriptor = Any.getDescriptor();
+        var field = descriptor.getFields()
+                              .get(0);
         new NullPointerTester()
                 .testAllPublicInstanceMethods(new FieldDeclaration(field));
     }
 
     @Test
-    @DisplayName("have equals() and hashCode()")
+    @DisplayName("have `equals()` and `hashCode()`")
     void equalsAndHashCode() {
-        Descriptor any = Any.getDescriptor();
-        FieldDescriptor typeUrl = any.getFields()
-                                     .get(0);
-        FieldDescriptor bytes = any.getFields()
-                                   .get(1);
+        var any = Any.getDescriptor();
+        var typeUrl = any.getFields()
+                         .get(0);
+        var bytes = any.getFields()
+                       .get(1);
         new EqualsTester()
                 .addEqualityGroup(new FieldDeclaration(typeUrl),
                                   new FieldDeclaration(typeUrl, new MessageType(any)))
@@ -95,34 +94,34 @@ class FieldDeclarationTest {
     class Defaults {
 
         @Test
-        @DisplayName("int32")
+        @DisplayName("`int32`")
         void anInt32() {
-            FieldDescriptor int32Field = Int32Value.getDescriptor()
-                                                   .getFields()
-                                                   .get(0);
-            FieldDeclaration declaration = new FieldDeclaration(int32Field);
+            var int32Field = Int32Value.getDescriptor()
+                                       .getFields()
+                                       .get(0);
+            var declaration = new FieldDeclaration(int32Field);
             assertTrue(declaration.isDefault(0));
             assertFalse(declaration.isDefault(""));
             assertFalse(declaration.isDefault(0.0));
         }
 
         @Test
-        @DisplayName("string")
+        @DisplayName("`string`")
         void aString() {
-            FieldDescriptor stringField = StringValue.getDescriptor()
-                                                     .getFields()
-                                                     .get(0);
-            FieldDeclaration declaration = new FieldDeclaration(stringField);
+            var stringField = StringValue.getDescriptor()
+                                         .getFields()
+                                         .get(0);
+            var declaration = new FieldDeclaration(stringField);
             assertTrue(declaration.isDefault(""));
             assertFalse(declaration.isDefault(0L));
         }
 
         @Test
-        @DisplayName("message")
+        @DisplayName("`Message`")
         void aMessage() {
-            FieldDescriptor messageField = Uri.getDescriptor()
-                                              .findFieldByName("auth");
-            FieldDeclaration declaration = new FieldDeclaration(messageField);
+            var messageField = Uri.getDescriptor()
+                                  .findFieldByName("auth");
+            var declaration = new FieldDeclaration(messageField);
             assertTrue(declaration.isDefault(Uri.Authorization.getDefaultInstance()));
             assertFalse(declaration.isDefault(0L));
             assertFalse(declaration.isDefault(Empty.getDefaultInstance()));
@@ -134,44 +133,44 @@ class FieldDeclarationTest {
     class TypeName {
 
         @Test
-        @DisplayName("int64")
+        @DisplayName("`int64`")
         void int64() {
-            FieldDescriptor int64Field = Int64Value.getDescriptor()
-                                                   .getFields()
-                                                   .get(0);
-            FieldDeclaration declaration = new FieldDeclaration(int64Field);
-            String typeName = declaration.javaTypeName();
+            var int64Field = Int64Value.getDescriptor()
+                                       .getFields()
+                                       .get(0);
+            var declaration = new FieldDeclaration(int64Field);
+            var typeName = declaration.javaTypeName();
             assertThat(typeName).isEqualTo(long.class.getName());
         }
 
         @Test
         @DisplayName("bytes")
         void bytes() {
-            FieldDescriptor int64Field = BytesValue.getDescriptor()
-                                                   .getFields()
-                                                   .get(0);
-            FieldDeclaration declaration = new FieldDeclaration(int64Field);
-            String typeName = declaration.javaTypeName();
+            var int64Field = BytesValue.getDescriptor()
+                                       .getFields()
+                                       .get(0);
+            var declaration = new FieldDeclaration(int64Field);
+            var typeName = declaration.javaTypeName();
             assertThat(typeName).isEqualTo(ByteString.class.getCanonicalName());
         }
 
         @Test
-        @DisplayName("message")
+        @DisplayName("`Message`")
         void message() {
-            FieldDescriptor messageField = Uri.getDescriptor()
-                                              .findFieldByName("protocol");
-            FieldDeclaration declaration = new FieldDeclaration(messageField);
-            String typeName = declaration.javaTypeName();
+            var messageField = Uri.getDescriptor()
+                                  .findFieldByName("protocol");
+            var declaration = new FieldDeclaration(messageField);
+            var typeName = declaration.javaTypeName();
             assertThat(typeName).isEqualTo(Protocol.class.getCanonicalName());
         }
 
         @Test
-        @DisplayName("enum")
+        @DisplayName("`enum`")
         void anEnum() {
-            FieldDescriptor enumField = Uri.Protocol.getDescriptor()
-                                                    .findFieldByName("schema");
-            FieldDeclaration declaration = new FieldDeclaration(enumField);
-            String typeName = declaration.javaTypeName();
+            var enumField = Uri.Protocol.getDescriptor()
+                                        .findFieldByName("schema");
+            var declaration = new FieldDeclaration(enumField);
+            var typeName = declaration.javaTypeName();
             assertThat(typeName).isEqualTo(Uri.Schema.class.getCanonicalName());
         }
     }
@@ -179,38 +178,36 @@ class FieldDeclarationTest {
     @Test
     @DisplayName("obtain a name of the getter generated for the field by Protobuf Java")
     void obtainJavaGetterName() {
-        FieldDescriptor field = Uri.Authorization.getDescriptor()
-                                                 .findFieldByName("user_name");
-        FieldDeclaration declaration = new FieldDeclaration(field);
-        String javaGetterName = declaration.javaGetterName();
+        var field = Uri.Authorization.getDescriptor()
+                                     .findFieldByName("user_name");
+        var declaration = new FieldDeclaration(field);
+        var javaGetterName = declaration.javaGetterName();
         assertThat(javaGetterName).isEqualTo("getUserName");
     }
 
     @Test
     @DisplayName("obtain the message type of the field")
     void obtainMessageType() {
-        FieldDescriptor field = Uri.getDescriptor()
-                                   .findFieldByName("auth");
-        FieldDeclaration declaration = new FieldDeclaration(field);
-        MessageType authorization = new MessageType(Uri.Authorization.getDescriptor());
+        var field = Uri.getDescriptor()
+                       .findFieldByName("auth");
+        var declaration = new FieldDeclaration(field);
+        var authorization = new MessageType(Uri.Authorization.getDescriptor());
         assertThat(declaration.messageType()).isEqualTo(authorization);
     }
 
     @Test
     @DisplayName("throw an `ISE` if the field is of non-message type")
     void throwOnWrongType() {
-        FieldDescriptor field = getDescriptor()
-                                                 .findFieldByName("user_name");
-        FieldDeclaration declaration = new FieldDeclaration(field);
+        var field = getDescriptor().findFieldByName("user_name");
+        var declaration = new FieldDeclaration(field);
         assertIllegalState(declaration::messageType);
     }
 
     @Test
     @DisplayName("tell if the field is a singular field of a message type")
     void checkSingularMessage() {
-        FieldDescriptor field = Uri.getDescriptor()
-                                   .findFieldByName("auth");
-        FieldDeclaration declaration = new FieldDeclaration(field);
+        var field = Uri.getDescriptor().findFieldByName("auth");
+        var declaration = new FieldDeclaration(field);
         assertThat(declaration.isSingularMessage()).isTrue();
     }
 
@@ -218,15 +215,13 @@ class FieldDeclarationTest {
     @DisplayName("tell if the field is not a singular field of a message type")
     void checkNotSingularMessage() {
         // Check non-singular type.
-        FieldDescriptor query = Uri.getDescriptor()
-                                   .findFieldByName("query");
-        FieldDeclaration nonSingular = new FieldDeclaration(query);
+        var query = Uri.getDescriptor().findFieldByName("query");
+        var nonSingular = new FieldDeclaration(query);
         assertThat(nonSingular.isSingularMessage()).isFalse();
 
         // Check non-`Message` type.
-        FieldDescriptor host = Uri.getDescriptor()
-                                  .findFieldByName("host");
-        FieldDeclaration nonMessage = new FieldDeclaration(host);
+        var host = Uri.getDescriptor().findFieldByName("host");
+        var nonMessage = new FieldDeclaration(host);
         assertThat(nonMessage.isSingularMessage()).isFalse();
     }
 }

--- a/base/src/test/java/io/spine/code/proto/FieldTypesTest.java
+++ b/base/src/test/java/io/spine/code/proto/FieldTypesTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.code.proto;
 
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -90,14 +89,14 @@ class FieldTypesTest extends UtilityClassTest<FieldTypes> {
     @Test
     @DisplayName("get key descriptor for a `Map` field")
     void getKeyDescriptor() {
-        FieldDescriptor key = keyDescriptor(mapField());
+        var key = keyDescriptor(mapField());
         assertEquals(INT64, key.getType());
     }
 
     @Test
     @DisplayName("get value descriptor for a `Map` field")
     void getValueDescriptor() {
-        FieldDescriptor value = valueDescriptor(mapField());
+        var value = valueDescriptor(mapField());
         assertEquals(STRING, value.getType());
     }
 

--- a/base/src/test/java/io/spine/code/proto/FileNameTest.java
+++ b/base/src/test/java/io/spine/code/proto/FileNameTest.java
@@ -32,8 +32,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static io.spine.testing.Assertions.assertIllegalArgument;
 import static io.spine.testing.DisplayNames.NOT_ACCEPT_NULLS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,7 +60,7 @@ class FileNameTest {
     @Test
     @DisplayName("return words")
     void returnWords() {
-        List<String> words = FileName.of("some_file_name.proto").words();
+        var words = FileName.of("some_file_name.proto").words();
 
         assertEquals(ImmutableList.of("some", "file", "name"), words);
     }
@@ -101,8 +99,8 @@ class FileNameTest {
         }
 
         private void assertConversion(String expected, String fileName) {
-            String calculated = FileName.of(fileName)
-                                        .nameOnlyCamelCase();
+            var calculated = FileName.of(fileName)
+                                     .nameOnlyCamelCase();
             assertEquals(expected, calculated);
         }
     }
@@ -117,7 +115,7 @@ class FileNameTest {
     @Test
     @DisplayName("tell commands file kind")
     void commandsFile() {
-        FileName commandsFile = FileName.of("my_commands.proto");
+        var commandsFile = FileName.of("my_commands.proto");
 
         assertTrue(commandsFile.isCommands());
         assertFalse(commandsFile.isEvents());
@@ -127,7 +125,7 @@ class FileNameTest {
     @Test
     @DisplayName("tell events file kind")
     void eventsFile() {
-        FileName eventsFile = FileName.of("project_events.proto");
+        var eventsFile = FileName.of("project_events.proto");
 
         assertTrue(eventsFile.isEvents());
         assertFalse(eventsFile.isCommands());
@@ -137,7 +135,7 @@ class FileNameTest {
     @Test
     @DisplayName("tell rejection file kind")
     void rejectionsFile() {
-        FileName rejectionsFile = FileName.of("rejections.proto");
+        var rejectionsFile = FileName.of("rejections.proto");
 
         assertTrue(rejectionsFile.isRejections());
         assertFalse(rejectionsFile.isCommands());
@@ -147,7 +145,7 @@ class FileNameTest {
     @Test
     @DisplayName("return file name with extension")
     void returnFileNameWithExtension(){
-        FileName fileName = FileName.of("io/spine/test/test_protos.proto");
+        var fileName = FileName.of("io/spine/test/test_protos.proto");
 
         assertEquals("test_protos.proto", fileName.nameWithExtension());
     }

--- a/base/src/test/java/io/spine/code/proto/FileSetTest.java
+++ b/base/src/test/java/io/spine/code/proto/FileSetTest.java
@@ -33,7 +33,6 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Empty;
 import io.spine.test.code.proto.MessageDecl;
-import io.spine.type.MessageType;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -44,7 +43,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -75,21 +73,21 @@ class FileSetTest {
     @Test
     @DisplayName("return all declared top-level messages")
     void returnTopLevelMessages() {
-        ImmutableSet<FileName> fileNames =
+        var fileNames =
                 ImmutableSet.of(FileName.of("spine/test/code/proto/file_set_test.proto"));
-        FileSet set = fileSet.find(fileNames);
-        List<MessageType> types = set.topLevelMessages();
+        var set = fileSet.find(fileNames);
+        var types = set.topLevelMessages();
         assertThat(types).hasSize(1);
 
-        MessageType onlyElement = types.get(0);
+        var onlyElement = types.get(0);
         assertThat(onlyElement.javaClass()).isEqualTo(MessageDecl.class);
     }
 
     @Test
     @DisplayName("filter message type by predicate")
     void findType() {
-        String nameFragment = "Field";
-        List<MessageType> types =
+        var nameFragment = "Field";
+        var types =
                 fileSet.findMessageTypes((d) -> d.getName()
                                                  .contains(nameFragment));
         types.forEach(
@@ -100,10 +98,10 @@ class FileSetTest {
     @Test
     @DisplayName("load from known types")
     void loadFromKnownTypes() throws IOException {
-        File file = writeToFile(Empty.getDescriptor()
-                                     .getFile()
-                                     .toProto());
-        FileSet set = FileSet.parseAsKnownFiles(file);
+        var file = writeToFile(Empty.getDescriptor()
+                                    .getFile()
+                                    .toProto());
+        var set = FileSet.parseAsKnownFiles(file);
         assertThat(set.files())
                 .comparingElementsUsing(fileNames)
                 .containsExactly("google/protobuf/empty.proto");
@@ -112,24 +110,22 @@ class FileSetTest {
     @Test
     @DisplayName("load from known types and ignore unknown")
     void ignoreUnknown() throws IOException {
-        FileDescriptorProto unknownFile = FileDescriptorProto
-                .newBuilder()
+        var unknownFile = FileDescriptorProto.newBuilder()
                 .setName("example/definition/unknown_file.proto")
                 .build();
-        File file = writeToFile(unknownFile);
-        FileSet set = FileSet.parseAsKnownFiles(file);
+        var file = writeToFile(unknownFile);
+        var set = FileSet.parseAsKnownFiles(file);
         assertThat(set.files())
                 .isEmpty();
     }
 
     private File writeToFile(FileDescriptorProto fileDescriptor) throws IOException {
-        FileDescriptorSet descriptorSet = FileDescriptorSet
-                .newBuilder()
+        var descriptorSet = FileDescriptorSet.newBuilder()
                 .addFile(fileDescriptor)
                 .build();
-        File file = new File(tempDir.toString(), "temp.desc");
+        var file = new File(tempDir.toString(), "temp.desc");
         file.createNewFile();
-        try (FileOutputStream output = new FileOutputStream(file)) {
+        try (var output = new FileOutputStream(file)) {
             descriptorSet.writeTo(output);
         }
         return file;

--- a/base/src/test/java/io/spine/code/proto/LinkerTest.java
+++ b/base/src/test/java/io/spine/code/proto/LinkerTest.java
@@ -55,7 +55,7 @@ class LinkerTest {
     @Test
     @DisplayName("resolve files")
     void resolveFiles() {
-        FileSet resolved = linker.resolved();
+        var resolved = linker.resolved();
         assertTrue(resolved.size() > 0);
         assertTrue(resolved.containsAll(ImmutableList.of(
                 FileName.of("google/protobuf/any.proto"),

--- a/base/src/test/java/io/spine/code/proto/LocationPathTest.java
+++ b/base/src/test/java/io/spine/code/proto/LocationPathTest.java
@@ -27,7 +27,6 @@
 package io.spine.code.proto;
 
 import com.google.common.testing.EqualsTester;
-import com.google.common.truth.StringSubject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -56,7 +55,7 @@ class LocationPathTest {
     @Test
     @DisplayName("print the path to string")
     void text() {
-        StringSubject assertString = assertThat(new LocationPath(6, 17, 10, 20).toString());
+        var assertString = assertThat(new LocationPath(6, 17, 10, 20).toString());
         assertString.contains("6");
         assertString.contains("17");
         assertString.contains("10");

--- a/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
+++ b/base/src/test/java/io/spine/code/proto/MessageTypeTest.java
@@ -32,8 +32,6 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Timestamp;
-import io.spine.test.type.Uri;
-import io.spine.test.type.Url;
 import io.spine.option.EntityOption;
 import io.spine.option.GoesOption;
 import io.spine.option.MinOption;
@@ -42,6 +40,8 @@ import io.spine.test.code.proto.event.MttProjectStarted;
 import io.spine.test.code.proto.rejections.TestRejections;
 import io.spine.test.code.proto.uuid.MttEntityState;
 import io.spine.test.code.proto.uuid.MttUuidMessage;
+import io.spine.test.type.Uri;
+import io.spine.test.type.Url;
 import io.spine.type.MessageType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -74,8 +74,8 @@ final class MessageTypeTest {
          * Tests a certain boolean method of {@code MessageType} created on the passed descriptor.
          */
         void assertQuality(Predicate<MessageType> method, Descriptor descriptor) {
-            MessageType type = new MessageType(descriptor);
-            boolean result = method.test(type);
+            var type = new MessageType(descriptor);
+            var result = method.test(type);
             assertTrue(result);
         }
 
@@ -135,6 +135,7 @@ final class MessageTypeTest {
 
             @Nested
             @DisplayName("not")
+            @SuppressWarnings("InnerClassTooDeeplyNested")
             class NotA {
 
                 @Test
@@ -176,6 +177,7 @@ final class MessageTypeTest {
 
             @Nested
             @DisplayName("a non-Google or a Spine options type")
+            @SuppressWarnings("InnerClassTooDeeplyNested")
             final class Custom {
 
                 @Test
@@ -207,7 +209,7 @@ final class MessageTypeTest {
     }
 
     @Nested
-    @DisplayName("Obtain path for")
+    @DisplayName("obtain path for")
     final class Path {
 
         @Test
@@ -218,10 +220,10 @@ final class MessageTypeTest {
 
         @CanIgnoreReturnValue
         private IterableSubject assertPath(Descriptor descriptor) {
-            MessageType type = new MessageType(descriptor);
-            LocationPath path = type.path();
+            var type = new MessageType(descriptor);
+            var path = type.path();
 
-            IterableSubject assertPath = assertThat(path.toList());
+            var assertPath = assertThat(path.toList());
             assertPath.contains(FileDescriptorProto.MESSAGE_TYPE_FIELD_NUMBER);
             assertPath.contains(descriptor.getIndex());
 
@@ -231,7 +233,7 @@ final class MessageTypeTest {
         @Test
         @DisplayName("second-level message")
         void secondLevel() {
-            IterableSubject assertPath = assertPath(Uri.Protocol.getDescriptor());
+            var assertPath = assertPath(Uri.Protocol.getDescriptor());
             assertPath.contains(Uri.getDescriptor()
                                    .getIndex());
         }

--- a/base/src/test/java/io/spine/code/proto/OneofDeclarationTest.java
+++ b/base/src/test/java/io/spine/code/proto/OneofDeclarationTest.java
@@ -36,11 +36,11 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("OneofDeclaration should")
+@DisplayName("`OneofDeclaration` should")
 class OneofDeclarationTest {
 
     @Test
-    @DisplayName("not accept nulls")
+    @DisplayName("not accept `null`s")
     void nonNull() {
         new NullPointerTester()
                 .setDefault(MessageType.class, new MessageType(Empty.getDescriptor()))
@@ -53,13 +53,11 @@ class OneofDeclarationTest {
     @Test
     @DisplayName("obtain name")
     void obtainName() {
-        Descriptors.Descriptor declaringType = Transmission.getDescriptor();
-        Descriptors.OneofDescriptor protocolOneof = declaringType
-                .getOneofs()
-                .get(0);
-        MessageType declaringMessageType = new MessageType(declaringType);
-        OneofDeclaration declaration = new OneofDeclaration(protocolOneof, declaringMessageType);
-        FieldName name = declaration.name();
+        var declaringType = Transmission.getDescriptor();
+        var protocolOneof = declaringType.getOneofs().get(0);
+        var declaringMessageType = new MessageType(declaringType);
+        var declaration = new OneofDeclaration(protocolOneof, declaringMessageType);
+        var name = declaration.name();
         assertThat(name.javaCase()).isEqualTo("type");
     }
 }

--- a/base/src/test/java/io/spine/code/proto/PackageNameTest.java
+++ b/base/src/test/java/io/spine/code/proto/PackageNameTest.java
@@ -45,7 +45,7 @@ class PackageNameTest {
     @Test
     @DisplayName("create a new instance by value")
     void newInstance() {
-        String packageName = "some.pack.age";
+        var packageName = "some.pack.age";
         assertThat(PackageName.of(packageName)
                               .value()).isEqualTo(packageName);
     }
@@ -74,13 +74,13 @@ class PackageNameTest {
         }
 
         void assertIsInner(String inner, String outer) {
-            BooleanSubject assertInner = assertInner(inner, outer);
+            var assertInner = assertInner(inner, outer);
             assertInner.isTrue();
         }
 
         private BooleanSubject assertInner(String inner, String outer) {
-            PackageName innerPackage = PackageName.of(inner);
-            PackageName outerPackage = PackageName.of(outer);
+            var innerPackage = PackageName.of(inner);
+            var outerPackage = PackageName.of(outer);
             return assertThat(innerPackage.isInnerOf(outerPackage));
         }
     }

--- a/base/src/test/java/io/spine/code/proto/RejectionsFileTest.java
+++ b/base/src/test/java/io/spine/code/proto/RejectionsFileTest.java
@@ -50,9 +50,9 @@ class RejectionsFileTest {
     @Test
     @DisplayName("accept only files ending with `rejections.proto`")
     void checkFileName() {
-        SourceFile sourceFile = SourceFile.from(EmptyProto.getDescriptor());
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          () -> RejectionsFile.from(sourceFile));
+        var sourceFile = SourceFile.from(EmptyProto.getDescriptor());
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     () -> RejectionsFile.from(sourceFile));
         assertThat(exception)
                 .hasMessageThat()
                 .contains("`rejections.proto`");
@@ -61,9 +61,9 @@ class RejectionsFileTest {
     @Test
     @DisplayName("accept only files with `Rejections` outer class name")
     void checkOuterClassName() {
-        SourceFile sourceFile = SourceFile.from(FakeRejectionsProto.getDescriptor());
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          () -> RejectionsFile.from(sourceFile));
+        var sourceFile = SourceFile.from(FakeRejectionsProto.getDescriptor());
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     () -> RejectionsFile.from(sourceFile));
         assertThat(exception)
                 .hasMessageThat()
                 .contains("`Rejections`");
@@ -72,9 +72,9 @@ class RejectionsFileTest {
     @Test
     @DisplayName("accept only files with `java_multiple_files = false`")
     void checkMultipleFiles() {
-        SourceFile sourceFile = SourceFile.from(MoreFakeRejections.getDescriptor());
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                                                          () -> RejectionsFile.from(sourceFile));
+        var sourceFile = SourceFile.from(MoreFakeRejections.getDescriptor());
+        var exception = assertThrows(IllegalArgumentException.class,
+                                     () -> RejectionsFile.from(sourceFile));
         assertThat(exception)
                 .hasMessageThat()
                 .contains("`java_multiple_files`");

--- a/base/src/test/java/io/spine/code/proto/SourceFileTest.java
+++ b/base/src/test/java/io/spine/code/proto/SourceFileTest.java
@@ -27,7 +27,6 @@
 package io.spine.code.proto;
 
 import com.google.protobuf.DescriptorProtos.DescriptorProto;
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import io.spine.test.compiler.message.Top;
 import io.spine.type.MessageType;
@@ -42,7 +41,7 @@ import java.util.function.Predicate;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("SourceFile should")
+@DisplayName("`SourceFile` should")
 class SourceFileTest {
 
     private static final FileDescriptor TEST_FILE_DESCRIPTOR = Top.getDescriptor()
@@ -57,10 +56,10 @@ class SourceFileTest {
     @Test
     @DisplayName("search nested declarations recursively")
     void search_nested_declarations_recursively() {
-        Descriptor nestedForNested = Top.NestedForTop.NestedForNested.getDescriptor();
-        String expectedTypeName = nestedForNested.getFullName();
-        String simpleTypeName = nestedForNested.getName();
-        MessageType result = findDeclaration(simpleTypeName);
+        var nestedForNested = Top.NestedForTop.NestedForNested.getDescriptor();
+        var expectedTypeName = nestedForNested.getFullName();
+        var simpleTypeName = nestedForNested.getName();
+        var result = findDeclaration(simpleTypeName);
         assertEquals(expectedTypeName, result.name()
                                              .value());
     }
@@ -87,7 +86,7 @@ class SourceFileTest {
         @Override
         public boolean test(@Nullable DescriptorProto input) {
             checkNotNull(input);
-            String messageName = input.getName();
+            var messageName = input.getName();
             return messageName.equals(name);
         }
     }

--- a/base/src/test/java/io/spine/code/proto/TypeSetTest.java
+++ b/base/src/test/java/io/spine/code/proto/TypeSetTest.java
@@ -27,14 +27,13 @@
 package io.spine.code.proto;
 
 import com.google.protobuf.DescriptorProtos.FileDescriptorSet;
-import com.google.protobuf.Descriptors.FileDescriptor;
 import io.spine.type.TypeName;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("TypeSet should")
+@DisplayName("`TypeSet` should")
 class TypeSetTest {
 
     private static final FileSet fileSet = FileSet.load();
@@ -43,9 +42,8 @@ class TypeSetTest {
     @DisplayName("obtain messages and enums from a file")
     void fromFile() {
         @SuppressWarnings("OptionalGetWithoutIsPresent") /* The file is present in resources. */
-        FileDescriptor file = fileSet.tryFind(FileName.of("google/protobuf/descriptor.proto"))
-                                     .get();
-        TypeSet typeSet = TypeSet.from(file);
+        var file = fileSet.tryFind(FileName.of("google/protobuf/descriptor.proto")).get();
+        var typeSet = TypeSet.from(file);
         assertNotEmpty(typeSet);
         assertThat(typeSet.contains(TypeName.from(FileDescriptorSet.getDescriptor())))
                 .isTrue();
@@ -54,7 +52,7 @@ class TypeSetTest {
     @Test
     @DisplayName("obtain message and enums")
     void fromSet() {
-        TypeSet typeSet = TypeSet.from(fileSet);
+        var typeSet = TypeSet.from(fileSet);
         assertNotEmpty(typeSet);
         // We have a number of test service declarations for testing annotations.
         assertThat(typeSet.serviceTypes())

--- a/base/src/test/java/io/spine/code/proto/given/DescriptorReferenceTestEnv.java
+++ b/base/src/test/java/io/spine/code/proto/given/DescriptorReferenceTestEnv.java
@@ -44,15 +44,14 @@ public class DescriptorReferenceTestEnv {
 
     /** Returns a reference to a {@code "smoke-test-model-compiler.desc"} file. */
     public static DescriptorReference smokeTestModelCompilerRef() {
-        String reference = "smoke_tests_model-compiler_tests_unspecified.desc";
+        var reference = "smoke_tests_model-compiler_tests_unspecified.desc";
         return DescriptorReference.toOneFile(new File(reference));
     }
 
     /** Returns a reference to a {@code "known_types.desc"} file. */
     public static DescriptorReference knownTypesRef() {
-        String asFile = Resources.getResource(FileDescriptors.KNOWN_TYPES)
-                                 .getFile();
-        File result = new File(asFile);
+        var asFile = Resources.getResource(FileDescriptors.KNOWN_TYPES).getFile();
+        var result = new File(asFile);
         return DescriptorReference.toOneFile(result);
     }
 
@@ -61,9 +60,8 @@ public class DescriptorReferenceTestEnv {
      * exist.
      */
     public static DescriptorReference randomRef() {
-        String reference = UUID.randomUUID()
-                               .toString();
-        File result = new File(reference);
+        var reference = UUID.randomUUID().toString();
+        var result = new File(reference);
         return DescriptorReference.toOneFile(result);
     }
 }

--- a/base/src/test/java/io/spine/code/proto/given/Given.java
+++ b/base/src/test/java/io/spine/code/proto/given/Given.java
@@ -26,11 +26,8 @@
 
 package io.spine.code.proto.given;
 
-import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.test.code.proto.FieldContainer;
-
-import java.util.List;
 
 public final class Given {
 
@@ -63,9 +60,9 @@ public final class Given {
     }
 
     private static FieldDescriptor fieldWithIndex(int index) {
-        Descriptor fieldContainer = FieldContainer.getDescriptor();
-        List<FieldDescriptor> fields = fieldContainer.getFields();
-        FieldDescriptor field = fields.get(index);
+        var fieldContainer = FieldContainer.getDescriptor();
+        var fields = fieldContainer.getFields();
+        var field = fields.get(index);
         return field;
     }
 }

--- a/base/src/test/java/io/spine/environment/EnvironmentTest.java
+++ b/base/src/test/java/io/spine/environment/EnvironmentTest.java
@@ -43,7 +43,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.environment.TestsProperty.TESTS_VALUES;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@DisplayName("Environment should")
+@DisplayName("`Environment` should")
 @SuppressWarnings("AccessOfSystemProperties")
 class EnvironmentTest {
 
@@ -242,9 +242,9 @@ class EnvironmentTest {
     @Test
     @DisplayName("cache the `Tests` environment type")
     void cacheTests() throws InterruptedException {
-        AtomicBoolean envCached = new AtomicBoolean(false);
+        var envCached = new AtomicBoolean(false);
         assertThat(environment.is(Tests.class));
-        Thread thread = new Thread(() -> {
+        var thread = new Thread(() -> {
             TestsProperty.clear();
             assertThat(environment.is(Tests.class)).isTrue();
             assertThat(Tests.type().enabled()).isFalse();

--- a/base/src/test/java/io/spine/io/EnsureTest.java
+++ b/base/src/test/java/io/spine/io/EnsureTest.java
@@ -62,9 +62,9 @@ class EnsureTest extends UtilityClassTest<Ensure> {
 
         @BeforeEach
         void createFile(@TempDir Path tempDir) {
-            File testFolder = tempDir.toFile();
+            var testFolder = tempDir.toFile();
 
-            String fileName = "ensure/exists/file" + randomString() + ".txt";
+            var fileName = "ensure/exists/file" + randomString() + ".txt";
             file = new File(testFolder.getAbsolutePath(), fileName);
         }
 
@@ -81,7 +81,7 @@ class EnsureTest extends UtilityClassTest<Ensure> {
         @Test
         @DisplayName("`Path` argument")
         void pathArg() {
-            Path path = file.toPath();
+            var path = file.toPath();
             Object returnedValue = ensureFile(path);
 
             assertThat(file.exists())
@@ -105,8 +105,8 @@ class EnsureTest extends UtilityClassTest<Ensure> {
         @Test
         @DisplayName("if it does not exist")
         void notExisting() {
-            Path subDir = Paths.get("sub-1-" + randomString(), "sub-2-" + randomString());
-            Path newDir = tempDir.resolve(subDir);
+            var subDir = Paths.get("sub-1-" + randomString(), "sub-2-" + randomString());
+            var newDir = tempDir.resolve(subDir);
 
             // See that the directory does not exist.
             assertFalse(newDir.toFile().exists());
@@ -119,7 +119,7 @@ class EnsureTest extends UtilityClassTest<Ensure> {
         @Test
         @DisplayName("if it exists")
         void existing() {
-            Path existingDir = tempDir.resolve(randomString());
+            var existingDir = tempDir.resolve(randomString());
             ensureDirectory(existingDir);
 
             // Now as we know that the directory exists, let's try it again.
@@ -131,8 +131,8 @@ class EnsureTest extends UtilityClassTest<Ensure> {
         @Test
         @DisplayName("rejecting existing file")
         void rejectFile() {
-            Path filePath = tempDir.resolve("file" + randomString());
-            File file = filePath.toFile();
+            var filePath = tempDir.resolve("file" + randomString());
+            var file = filePath.toFile();
             ensureFile(file);
 
             assertThrows(IllegalStateException.class, () -> ensureDirectory(filePath));

--- a/base/src/test/java/io/spine/io/Files2Test.java
+++ b/base/src/test/java/io/spine/io/Files2Test.java
@@ -40,11 +40,8 @@ import java.io.PrintWriter;
 import java.nio.file.Path;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.spine.io.Ensure.ensureFile;
 import static io.spine.io.Files2.existsNonEmpty;
 import static java.nio.charset.Charset.defaultCharset;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DisplayName("`Files2` utility class should")
 class Files2Test extends UtilityClassTest<Files2> {
@@ -67,7 +64,7 @@ class Files2Test extends UtilityClassTest<Files2> {
         @Test
         @DisplayName("returning `false` when existing file is empty")
         void whenNonEmpty() {
-            File emptyFile = testFolder.toPath().resolve("empty file").toFile();
+            var emptyFile = testFolder.toPath().resolve("empty file").toFile();
 
             assertThat(existsNonEmpty(emptyFile)).isFalse();
         }
@@ -75,7 +72,7 @@ class Files2Test extends UtilityClassTest<Files2> {
         @Test
         @DisplayName("returning `false` when a file does not exist")
         void doesNotExist() {
-            File doesNotExist = new File(TestValues.randomString());
+            var doesNotExist = new File(TestValues.randomString());
 
             assertThat(existsNonEmpty(doesNotExist)).isFalse();
         }
@@ -83,10 +80,10 @@ class Files2Test extends UtilityClassTest<Files2> {
         @Test
         @DisplayName("returning `true` if the existing file is not empty")
         void notEmpty() throws IOException {
-            File nonEmptyFile = testFolder.toPath().resolve("non-empty file").toFile();
-            String path = nonEmptyFile.getAbsolutePath();
-            String charsetName = defaultCharset().name();
-            try (PrintWriter out = new PrintWriter(path, charsetName)) {
+            var nonEmptyFile = testFolder.toPath().resolve("non-empty file").toFile();
+            var path = nonEmptyFile.getAbsolutePath();
+            var charsetName = defaultCharset().name();
+            try (var out = new PrintWriter(path, charsetName)) {
                 out.println(TestValues.randomString());
             }
 

--- a/base/src/test/java/io/spine/json/JsonTest.java
+++ b/base/src/test/java/io/spine/json/JsonTest.java
@@ -29,12 +29,10 @@ package io.spine.json;
 import com.google.common.collect.Lists;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.StringValue;
-import com.google.protobuf.TypeRegistry;
 import io.spine.json.given.Node;
 import io.spine.json.given.WrappedString;
 import io.spine.testing.UtilityClassTest;
 import io.spine.type.KnownTypes;
-import io.spine.type.TypeUrl;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisplayName("Json utility class should")
+@DisplayName("`Json` utility class should")
 class JsonTest extends UtilityClassTest<Json> {
 
     JsonTest() {
@@ -61,13 +59,12 @@ class JsonTest extends UtilityClassTest<Json> {
     @Test
     @DisplayName("build JsonFormat registry for known types")
     void knownTypes() {
-        TypeRegistry typeRegistry = Json.typeRegistry();
+        var typeRegistry = Json.typeRegistry();
 
         List<Descriptor> found = Lists.newLinkedList();
-        for (TypeUrl typeUrl : KnownTypes.instance()
-                                         .allUrls()) {
-            Descriptor descriptor = typeRegistry.find(typeUrl.toTypeName()
-                                                             .value());
+        for (var typeUrl : KnownTypes.instance().allUrls()) {
+            var descriptor = typeRegistry.find(typeUrl.toTypeName()
+                                                      .value());
             if (descriptor != null) {
                 found.add(descriptor);
             }
@@ -85,19 +82,19 @@ class JsonTest extends UtilityClassTest<Json> {
     @Test
     @DisplayName("print to JSON")
     void print() {
-        StringValue value = StringValue.of("print_to_json");
+        var value = StringValue.of("print_to_json");
         assertFalse(toJson(value).isEmpty());
     }
 
     @Test
     @DisplayName("print to compact JSON")
     void printCompact() {
-        String idValue = newUuid();
-        Node node = Node.newBuilder()
-                        .setName(idValue)
-                        .setRight(Node.getDefaultInstance())
-                        .build();
-        String result = toCompactJson(node);
+        var idValue = newUuid();
+        var node = Node.newBuilder()
+                .setName(idValue)
+                .setRight(Node.getDefaultInstance())
+                .build();
+        var result = toCompactJson(node);
         assertFalse(result.isEmpty());
         assertFalse(result.contains(System.lineSeparator()));
     }
@@ -105,9 +102,9 @@ class JsonTest extends UtilityClassTest<Json> {
     @Test
     @DisplayName("parse from JSON")
     void parse() {
-        String idValue = newUuid();
-        String jsonMessage = format("{\"value\": \"%s\"}", idValue);
-        WrappedString parsedValue = fromJson(jsonMessage, WrappedString.class);
+        var idValue = newUuid();
+        var jsonMessage = format("{\"value\": \"%s\"}", idValue);
+        var parsedValue = fromJson(jsonMessage, WrappedString.class);
         assertNotNull(parsedValue);
         assertEquals(idValue, parsedValue.getValue());
     }
@@ -115,9 +112,9 @@ class JsonTest extends UtilityClassTest<Json> {
     @Test
     @DisplayName("parse from JSON with unknown values")
     void parseUnknown() {
-        String idValue = newUuid();
-        String jsonMessage = format("{\"value\": \"%s\", \"newField\": \"newValue\"}", idValue);
-        WrappedString parsedValue = fromJson(jsonMessage, WrappedString.class);
+        var idValue = newUuid();
+        var jsonMessage = format("{\"value\": \"%s\", \"newField\": \"newValue\"}", idValue);
+        var parsedValue = fromJson(jsonMessage, WrappedString.class);
         assertNotNull(parsedValue);
         assertEquals(idValue, parsedValue.getValue());
     }

--- a/base/src/test/java/io/spine/logging/LoggingHierarchyTest.java
+++ b/base/src/test/java/io/spine/logging/LoggingHierarchyTest.java
@@ -41,15 +41,15 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 /**
  * Tests that classes in a hierarchy have own logs.
  */
-@DisplayName("Logging interface should work in a class hierarchy")
+@DisplayName("`Logging` interface should work in a class hierarchy")
 class LoggingHierarchyTest {
 
     @Test
     @DisplayName("create a logger for each class in hierarchy")
     void classHierarchyFlogger() {
-        FluentLogger baseLogger = new Base().logger();
-        FluentLogger childOneLogger = new ChildOne().logger();
-        FluentLogger childTwoLogger = new ChildTwo().logger();
+        var baseLogger = new Base().logger();
+        var childOneLogger = new ChildOne().logger();
+        var childTwoLogger = new ChildTwo().logger();
 
         assertNotSame(baseLogger, childOneLogger);
         assertNotSame(baseLogger, childTwoLogger);
@@ -67,7 +67,7 @@ class LoggingHierarchyTest {
     private static void assertLogger(FluentLogger logger, Class<?> cls) {
         @SuppressWarnings("FloggerSplitLogStatement")
         // See: https://github.com/SpineEventEngine/base/issues/612
-        LogContext<?, ?> context = (LogContext<?, ?>) logger.atSevere();
+        var context = (LogContext<?, ?>) logger.atSevere();
         assertThat(context.getLoggerName())
                 .isEqualTo(cls.getName());
     }

--- a/base/src/test/java/io/spine/logging/LoggingTest.java
+++ b/base/src/test/java/io/spine/logging/LoggingTest.java
@@ -29,7 +29,6 @@ package io.spine.logging;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.flogger.LogContext;
 import com.google.common.flogger.backend.LogData;
-import com.google.common.truth.Subject;
 import io.spine.logging.given.LoggingObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,7 +41,7 @@ import java.util.logging.Logger;
 
 import static io.spine.testing.logging.LogTruth.assertThat;
 
-@DisplayName("Logging interface should")
+@DisplayName("`Logging` interface should")
 class LoggingTest {
 
     @Test
@@ -64,7 +63,7 @@ class LoggingTest {
     void fluentLogger() {
         Logging object = new LoggingObject();
 
-        FluentLogger logger = object.logger();
+        var logger = object.logger();
 
         assertThat(object.logger())
              .isSameInstanceAs(logger);
@@ -75,8 +74,8 @@ class LoggingTest {
     @Test
     @DisplayName("provide a static API to obtain a logger for a class")
     void staticApi() {
-        FluentLogger logger = Logging.loggerFor(LoggingObject.class);
-        Subject assertLogger = assertThat(logger);
+        var logger = Logging.loggerFor(LoggingObject.class);
+        var assertLogger = assertThat(logger);
         assertLogger.isNotNull();
         assertLogger.isSameInstanceAs(new LoggingObject().logger());
     }
@@ -118,7 +117,7 @@ class LoggingTest {
             julLogger.setLevel(expectedLevel);
             @SuppressWarnings("FloggerSplitLogStatement")
             // See: https://github.com/SpineEventEngine/base/issues/612
-            FluentLogger.Api api = method.get();
+            var api = method.get();
             assertThat(api)
                     .isInstanceOf(LogContext.class);
             assertThat(((LogData) api).getLevel())

--- a/base/src/test/java/io/spine/protobuf/AnyPackerTest.java
+++ b/base/src/test/java/io/spine/protobuf/AnyPackerTest.java
@@ -39,13 +39,9 @@ import io.spine.testing.TestValues;
 import io.spine.testing.UtilityClassTest;
 import io.spine.type.TypeUrl;
 import io.spine.type.UnexpectedTypeException;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.util.Iterator;
-import java.util.function.Function;
 
 import static com.google.common.truth.extensions.proto.ProtoTruth.assertThat;
 import static io.spine.base.Identifier.newUuid;
@@ -86,8 +82,8 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("pack Spine message to Any")
     void packSpineMessageToAny() {
-        Any actual = pack(spineMsg);
-        TypeUrl typeUrl = TypeUrl.of(spineMsg);
+        var actual = pack(spineMsg);
+        var typeUrl = TypeUrl.of(spineMsg);
 
         assertEquals(Any.pack(spineMsg)
                         .getValue(), actual.getValue());
@@ -97,9 +93,9 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("unpack Spine message from Any")
     void unpackSpineMessageFromAny() {
-        Any any = pack(spineMsg);
+        var any = pack(spineMsg);
 
-        MessageToPack actual = (MessageToPack) unpack(any);
+        var actual = (MessageToPack) unpack(any);
 
         assertEquals(spineMsg, actual);
     }
@@ -107,9 +103,9 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("pack Google message to Any")
     void packGoogleMessageToAny() {
-        Any expected = Any.pack(googleMsg);
+        var expected = Any.pack(googleMsg);
 
-        Any actual = pack(googleMsg);
+        var actual = pack(googleMsg);
 
         assertEquals(expected, actual);
     }
@@ -117,9 +113,9 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("unpack Google message from Any")
     void unpackGoogleMessageFromAny() {
-        Any any = Any.pack(googleMsg);
+        var any = Any.pack(googleMsg);
 
-        StringValue actual = (StringValue) unpack(any);
+        var actual = (StringValue) unpack(any);
 
         assertEquals(googleMsg, actual);
     }
@@ -127,7 +123,7 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("return Any if it is passes to pack")
     void returnAnyIfItIsPassedToPack() {
-        Any any = Any.pack(googleMsg);
+        var any = Any.pack(googleMsg);
 
         assertSame(any, pack(any));
     }
@@ -147,9 +143,9 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("create packing iterator")
     void createPackingIterator() {
-        StringValue value = newUuidValue();
-        Iterator<Message> iterator = Lists.<Message>newArrayList(value).iterator();
-        Iterator<Any> packingIterator = pack(iterator);
+        var value = newUuidValue();
+        var iterator = Lists.<Message>newArrayList(value).iterator();
+        var packingIterator = pack(iterator);
         assertThat(ImmutableList.copyOf(packingIterator))
              .containsExactly(pack(value));
     }
@@ -163,7 +159,7 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("provide unpacking function")
     void unpackingFunc() {
-        StringValue value = newUuidValue();
+        var value = newUuidValue();
         assertThat(unpackFunc().apply(Any.pack(value)))
                 .isEqualTo(value);
     }
@@ -171,9 +167,9 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("provide typed unpacking function")
     void typedUnpackingFunc() {
-        StringValue value = newUuidValue();
-        Function<Any, StringValue> function = unpackFunc(StringValue.class);
-        StringValue unpacked = function.apply(Any.pack(value));
+        var value = newUuidValue();
+        var function = unpackFunc(StringValue.class);
+        var unpacked = function.apply(Any.pack(value));
         assertThat(unpacked)
                   .isEqualTo(value);
     }
@@ -185,23 +181,22 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
         @Test
         @DisplayName("type URL and class do not match")
         void type() {
-            Any any = Any.pack(spineMsg);
+            var any = Any.pack(spineMsg);
             assertThrows(UnexpectedTypeException.class, () -> unpack(any, Empty.class));
         }
 
         @Test
         @DisplayName("type URL and the predefined class do not match")
         void typeInFunction() {
-            Any any = Any.pack(spineMsg);
-            Function<@Nullable Any, @Nullable Empty> fun = unpackFunc(Empty.class);
+            var any = Any.pack(spineMsg);
+            var fun = unpackFunc(Empty.class);
             assertThrows(UnexpectedTypeException.class, () -> fun.apply(any));
         }
 
         @Test
         @DisplayName("bytes don't match the type URL")
         void malformed() {
-            Any malformed = Any
-                    .newBuilder()
+            var malformed = Any.newBuilder()
                     .setTypeUrl(TypeUrl.of(Empty.class).value())
                     .setValue(ByteString.copyFromUtf8("malformed bytes"))
                     .build();
@@ -211,12 +206,11 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
         @Test
         @DisplayName("bytes don't match the function's predefined class")
         void malformedInFunction() {
-            Any malformed = Any
-                    .newBuilder()
+            var malformed = Any.newBuilder()
                     .setTypeUrl(TypeUrl.of(Empty.class).value())
                     .setValue(ByteString.copyFromUtf8("malformed bytes"))
                     .build();
-            Function<@Nullable Any, @Nullable Empty> fun = unpackFunc(Empty.class);
+            var fun = unpackFunc(Empty.class);
             assertThrows(UnexpectedTypeException.class, () -> fun.apply(malformed));
         }
     }
@@ -224,7 +218,7 @@ class AnyPackerTest extends UtilityClassTest<AnyPacker> {
     @Test
     @DisplayName("throw UnexpectedTypeException on a type URL and class mismatch")
     void unexpectedTypeInFunction() {
-        Any any = Any.pack(spineMsg);
+        var any = Any.pack(spineMsg);
         assertThrows(UnexpectedTypeException.class, () -> unpack(any, Empty.class));
     }
 }

--- a/base/src/test/java/io/spine/protobuf/MessageFieldExceptionTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessageFieldExceptionTest.java
@@ -27,8 +27,6 @@
 package io.spine.protobuf;
 
 import com.google.protobuf.Empty;
-import com.google.protobuf.StringValue;
-import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,17 +43,16 @@ class MessageFieldExceptionTest {
     @Test
     @DisplayName("construct an instance with a formatted message")
     void instanceWithFormattedMessage() {
-        String param1 = "Букварь";
-        String param2 = "blue";
-        String param3 = String.valueOf(3);
-        StringValue protobufMessage = newUuidValue();
-        MessageFieldException exception =
-                new MessageFieldException(protobufMessage,
-                                          "Reading log is: %s %s %s",
-                                          param1, param2, param3);
+        var param1 = "Букварь";
+        var param2 = "blue";
+        var param3 = String.valueOf(3);
+        var protobufMessage = newUuidValue();
+        var exception = new MessageFieldException(protobufMessage,
+                                                  "Reading log is: %s %s %s",
+                                                  param1, param2, param3);
 
         assertEquals(protobufMessage, exception.getProtobufMessage());
-        String exceptionMessage = exception.getMessage();
+        var exceptionMessage = exception.getMessage();
         assertTrue(exceptionMessage.contains(param1));
         assertTrue(exceptionMessage.contains(param2));
         assertTrue(exceptionMessage.contains(param3));
@@ -64,8 +61,8 @@ class MessageFieldExceptionTest {
     @Test
     @DisplayName("contain an instance without text")
     void instanceWithoutText() {
-        Timestamp protobufMessage = Time.currentTime();
-        MessageFieldException exception = new MessageFieldException(protobufMessage);
+        var protobufMessage = Time.currentTime();
+        var exception = new MessageFieldException(protobufMessage);
 
         assertEquals(protobufMessage, exception.getProtobufMessage());
         assertTrue(exception.getMessage()

--- a/base/src/test/java/io/spine/protobuf/MessagesTest.java
+++ b/base/src/test/java/io/spine/protobuf/MessagesTest.java
@@ -25,10 +25,8 @@
  */
 package io.spine.protobuf;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
-import com.google.protobuf.Timestamp;
 import io.spine.base.Time;
 import io.spine.test.messages.MessageWithStringValue;
 import io.spine.testing.TestValues;
@@ -62,23 +60,23 @@ class MessagesTest extends UtilityClassTest<Messages> {
     }
 
     @Test
-    @DisplayName("return the same any from toAny")
+    @DisplayName("return the same `Any` from `toAny()`")
     void sameAny() {
-        Any any = toAny(getClass().getSimpleName());
+        var any = toAny(getClass().getSimpleName());
         assertSame(any, AnyPacker.pack(any));
     }
 
     @Test
     @DisplayName("pack to `Any`")
     void packToAny() {
-        Timestamp timestamp = Time.currentTime();
+        var timestamp = Time.currentTime();
         assertEquals(timestamp, unpack(AnyPacker.pack(timestamp)));
     }
 
     @Test
     @DisplayName("return builder for the message")
     void builderForMessage() {
-        Message.Builder messageBuilder = builderFor(MessageWithStringValue.class);
+        var messageBuilder = builderFor(MessageWithStringValue.class);
         assertNotNull(messageBuilder);
         assertEquals(MessageWithStringValue.class,
                      messageBuilder.build()
@@ -86,7 +84,7 @@ class MessagesTest extends UtilityClassTest<Messages> {
     }
 
     @Test
-    @DisplayName("throw when try to get builder for a not generated message")
+    @DisplayName("throw when try to get builder for a non-generated message")
     void failGettingNonGeneratedBuilder() {
         assertIllegalArgument(() -> builderFor(Message.class));
     }
@@ -94,7 +92,7 @@ class MessagesTest extends UtilityClassTest<Messages> {
     @Test
     @DisplayName("ensure `Message`")
     void ensureMessageInstance() {
-        StringValue value = TestValues.newUuidValue();
+        var value = TestValues.newUuidValue();
         assertEquals(value, ensureMessage(AnyPacker.pack(value)));
         assertSame(value, ensureMessage(value));
     }
@@ -106,7 +104,7 @@ class MessagesTest extends UtilityClassTest<Messages> {
         @Test
         @DisplayName("a message is not in the default state")
         void messageIsNotInDefaultState() {
-            Message msg = toMessage("check_if_message_is_not_in_default_state");
+            var msg = toMessage("check_if_message_is_not_in_default_state");
 
             assertTrue(isNotDefault(msg));
             assertFalse(isNotDefault(StringValue.getDefaultInstance()));

--- a/base/src/test/java/io/spine/protobuf/PackingIteratorTest.java
+++ b/base/src/test/java/io/spine/protobuf/PackingIteratorTest.java
@@ -43,7 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("PackingIterator should")
+@DisplayName("`PackingIterator` should")
 class PackingIteratorTest {
 
     private List<Message> list;
@@ -73,7 +73,7 @@ class PackingIteratorTest {
     @DisplayName("implement next()")
     void implement_next() {
         while (packer.hasNext()) {
-            Any packed = packer.next();
+            var packed = packer.next();
             assertNotNull(packed);
             assertFalse(isDefault(unpack(packed)));
         }

--- a/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
+++ b/base/src/test/java/io/spine/protobuf/TypeConverterTest.java
@@ -85,7 +85,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`Int32Value` to `int`")
         void int32ValueToInt() {
-            int rawValue = 42;
+            var rawValue = 42;
             Message value = Int32Value.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -101,7 +101,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`FloatValue` to `float`")
         void floatValueToFloat() {
-            float rawValue = 42.0f;
+            var rawValue = 42.0f;
             Message value = FloatValue.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -109,7 +109,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`DoubleValue` to `double`")
         void doubleValueToDouble() {
-            double rawValue = 42.0;
+            var rawValue = 42.0;
             Message value = DoubleValue.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -117,7 +117,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`BoolValue` to `boolean`")
         void boolValueToBoolean() {
-            boolean rawValue = true;
+            var rawValue = true;
             Message value = BoolValue.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -125,7 +125,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`StringValue` to `String`")
         void stringValueToString() {
-            String rawValue = "Hello";
+            var rawValue = "Hello";
             Message value = StringValue.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -133,7 +133,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`BytesValue` to `ByteString`")
         void bytesValueToByteString() {
-            ByteString rawValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
+            var rawValue = ByteString.copyFrom("Hello!", Charsets.UTF_8);
             Message value = BytesValue.of(rawValue);
             checkMapping(rawValue, value);
         }
@@ -141,9 +141,9 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`UInt32` to `int`")
         void uint32ToInt() {
-            int value = 42;
-            UInt32Value wrapped = UInt32Value.of(value);
-            Any packed = AnyPacker.pack(wrapped);
+            var value = 42;
+            var wrapped = UInt32Value.of(value);
+            var packed = AnyPacker.pack(wrapped);
             int mapped = TypeConverter.toObject(packed, Integer.class);
             assertEquals(value, mapped);
         }
@@ -151,19 +151,19 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("`UInt64` to `int`")
         void uint64ToLong() {
-            long value = 42L;
-            UInt64Value wrapped = UInt64Value.of(value);
-            Any packed = AnyPacker.pack(wrapped);
+            var value = 42L;
+            var wrapped = UInt64Value.of(value);
+            var packed = AnyPacker.pack(wrapped);
             long mapped = TypeConverter.toObject(packed, Long.class);
             assertEquals(value, mapped);
         }
 
         private void checkMapping(Object javaObject, Message protoObject) {
-            Any wrapped = AnyPacker.pack(protoObject);
-            Object mappedJavaObject = TypeConverter.toObject(wrapped, javaObject.getClass());
+            var wrapped = AnyPacker.pack(protoObject);
+            var mappedJavaObject = TypeConverter.toObject(wrapped, javaObject.getClass());
             assertEquals(javaObject, mappedJavaObject);
-            Any restoredWrapped = TypeConverter.toAny(mappedJavaObject);
-            Message restored = AnyPacker.unpack(restoredWrapped);
+            var restoredWrapped = TypeConverter.toAny(mappedJavaObject);
+            var restored = AnyPacker.unpack(restoredWrapped);
             assertEquals(protoObject, restored);
         }
     }
@@ -175,8 +175,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("if the `EnumValue` has a constant name specified")
         void ifHasName() {
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var value = EnumValue.newBuilder()
                     .setName(SUCCESS.name())
                     .build();
             checkConverts(value, SUCCESS);
@@ -185,8 +184,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("if the `EnumValue` has a constant number specified")
         void ifHasNumber() {
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var value = EnumValue.newBuilder()
                     .setNumber(EXECUTING.getNumber())
                     .build();
             checkConverts(value, EXECUTING);
@@ -195,8 +193,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("with `UNRECOGNIZED` value by name")
         void unrecognizedByName() {
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var value = EnumValue.newBuilder()
                     .setName(UNRECOGNIZED.name())
                     .build();
             checkConverts(value, UNRECOGNIZED);
@@ -205,8 +202,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("with `UNRECOGNIZED` value by number `-1`")
         void unrecognizedByNumber() {
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var value = EnumValue.newBuilder()
                     .setNumber(-1)
                     .build();
             checkConverts(value, UNRECOGNIZED);
@@ -216,8 +212,7 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @DisplayName("using the constant name if both the name and the number are specified")
         void preferringConversionWithName() {
             // Set the different name and number just for the sake of test.
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var value = EnumValue.newBuilder()
                     .setName(SUCCESS.name())
                     .setNumber(FAILED.getNumber())
                     .build();
@@ -225,9 +220,8 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         }
 
         private void checkConverts(EnumValue enumValue, Enum<?> expected) {
-            Any wrapped = AnyPacker.pack(enumValue);
-            Object mappedJavaObject =
-                    TypeConverter.toObject(wrapped, expected.getDeclaringClass());
+            var wrapped = AnyPacker.pack(enumValue);
+            var mappedJavaObject = TypeConverter.toObject(wrapped, expected.getDeclaringClass());
             assertEquals(expected, mappedJavaObject);
         }
     }
@@ -240,35 +234,32 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("the `EnumValue` with an unknown name is passed")
         void unknownName() {
-            String unknownName = "some_name";
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var unknownName = "some_name";
+            var value = EnumValue.newBuilder()
                     .setName(unknownName)
                     .build();
-            Any wrapped = pack(value);
+            var wrapped = pack(value);
             assertIllegalArgument(() -> toObject(wrapped, TaskStatus.class));
         }
 
         @Test
         @DisplayName("the `EnumValue` with an unknown number is passed")
         void unknownNumber() {
-            int unknownValue = 156;
-            EnumValue value = EnumValue
-                    .newBuilder()
+            var unknownValue = 156;
+            var value = EnumValue.newBuilder()
                     .setNumber(unknownValue)
                     .build();
-            Any wrapped = pack(value);
+            var wrapped = pack(value);
             assertIllegalArgument(() -> toObject(wrapped, TaskStatus.class));
         }
 
         @Test
         @DisplayName("converting a non-`EnumValue` object to a `Enum`")
         void rawValuesForEnum() {
-            Int32Value enumNumber = Int32Value
-                    .newBuilder()
+            var enumNumber = Int32Value.newBuilder()
                     .setValue(SUCCESS.getNumber())
                     .build();
-            Any packed = pack(enumNumber);
+            var packed = pack(enumNumber);
             assertIllegalArgument(() -> toObject(packed, TaskStatus.class));
         }
     }
@@ -276,10 +267,9 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
     @Test
     @DisplayName("convert `Enum` to `EnumValue`")
     void convertEnumToEnumValue() {
-        Any restoredWrapped = TypeConverter.toAny(SUCCESS);
-        Message restored = AnyPacker.unpack(restoredWrapped);
-        EnumValue expected = EnumValue
-                .newBuilder()
+        var restoredWrapped = TypeConverter.toAny(SUCCESS);
+        var restored = AnyPacker.unpack(restoredWrapped);
+        var expected = EnumValue.newBuilder()
                 .setName(SUCCESS.name())
                 .setNumber(SUCCESS.getNumber())
                 .build();
@@ -293,8 +283,8 @@ class TypeConverterTest extends UtilityClassTest<TypeConverter> {
         @Test
         @DisplayName("a value to a particular message")
         void valueToParticularMessage() {
-            String stringValue = "a string value";
-            StringValue convertedValue = toMessage(stringValue, StringValue.class);
+            var stringValue = "a string value";
+            var convertedValue = toMessage(stringValue, StringValue.class);
             assertEquals(stringValue, convertedValue.getValue());
         }
     }

--- a/base/src/test/java/io/spine/query/ColumnNameTest.java
+++ b/base/src/test/java/io/spine/query/ColumnNameTest.java
@@ -27,7 +27,6 @@
 package io.spine.query;
 
 import com.google.common.testing.NullPointerTester;
-import com.google.protobuf.Descriptors;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.test.code.proto.CoProject;
 import org.junit.jupiter.api.DisplayName;
@@ -50,16 +49,16 @@ class ColumnNameTest {
     @Test
     @DisplayName("be constructed from string value")
     void initFromString() {
-        String columnName = "the-column-name";
-        ColumnName name = ColumnName.of(columnName);
+        var columnName = "the-column-name";
+        var name = ColumnName.of(columnName);
 
         assertThat(name.value()).isEqualTo(columnName);
     }
 
-    @SuppressWarnings({"CheckReturnValue", "ResultOfMethodCallIgnored"})
-    // Called to throw exception.
     @Test
     @DisplayName("not be constructed from empty string")
+    @SuppressWarnings({"CheckReturnValue",
+            "ResultOfMethodCallIgnored" /* Called to trigger the exception. */ })
     void notInitFromEmpty() {
         assertThrows(IllegalArgumentException.class, () -> ColumnName.of(""));
     }
@@ -67,11 +66,11 @@ class ColumnNameTest {
     @Test
     @DisplayName("be constructed from `FieldDeclaration`")
     void initFromFieldDeclaration() {
-        Descriptors.FieldDescriptor field = CoProject.getDescriptor()
-                                                     .getFields()
-                                                     .get(0);
-        FieldDeclaration fieldDeclaration = new FieldDeclaration(field);
-        ColumnName columnName = ColumnName.of(fieldDeclaration);
+        var field = CoProject.getDescriptor()
+                             .getFields()
+                             .get(0);
+        var fieldDeclaration = new FieldDeclaration(field);
+        var columnName = ColumnName.of(fieldDeclaration);
 
         assertThat(columnName.value()).isEqualTo(field.getName());
     }

--- a/base/src/test/java/io/spine/query/ColumnsTest.java
+++ b/base/src/test/java/io/spine/query/ColumnsTest.java
@@ -26,13 +26,13 @@
 
 package io.spine.query;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.common.testing.NullPointerTester;
 import com.google.errorprone.annotations.Immutable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.truth.Truth.assertThat;
@@ -52,12 +52,10 @@ class ColumnsTest {
     @Test
     @DisplayName("be immutable")
     void beImmutable() {
-        Annotation[] declaredAnnotations = Columns.class.getDeclaredAnnotations();
-        ImmutableSet<Class<? extends Annotation>> annotationTypes =
-                ImmutableSet.copyOf(declaredAnnotations)
-                            .stream()
-                            .map(Annotation::annotationType)
-                            .collect(toImmutableSet());
+        var declaredAnnotations = Columns.class.getDeclaredAnnotations();
+        var annotationTypes = Stream.of(declaredAnnotations)
+                                    .map(Annotation::annotationType)
+                                    .collect(toImmutableSet());
         assertThat(annotationTypes)
                 .contains(Immutable.class);
     }
@@ -65,7 +63,7 @@ class ColumnsTest {
     @Test
     @DisplayName("create new instances from the passed `RecordColumn`s")
     void createNewInstances() {
-        Columns<Manufacturer> columns = Columns.of(is_traded, isin, stock_count);
+        var columns = Columns.of(is_traded, isin, stock_count);
         assertThat(columns)
                 .containsExactly(is_traded, isin, stock_count);
     }

--- a/base/src/test/java/io/spine/query/ComparisonOperatorTest.java
+++ b/base/src/test/java/io/spine/query/ComparisonOperatorTest.java
@@ -154,7 +154,7 @@ class ComparisonOperatorTest {
         void notSame() {
             Object left = Timestamp.getDefaultInstance();
             Object right = 0;
-            for (ComparisonOperator operator : orderingOperators) {
+            for (var operator : orderingOperators) {
                 assertThrows(IllegalArgumentException.class,
                              () -> operator.eval(left, right));
             }
@@ -166,7 +166,7 @@ class ComparisonOperatorTest {
         void unsupported() {
             Object left = Any.getDefaultInstance();
             Object right = Any.getDefaultInstance();
-            for (ComparisonOperator operator : orderingOperators) {
+            for (var operator : orderingOperators) {
                 assertThrows(UnsupportedOperationException.class,
                              () -> operator.eval(left, right));
             }
@@ -177,8 +177,8 @@ class ComparisonOperatorTest {
     @DisplayName("return `false` in `>`, `>=`, `<` and `<=` if any of the operands is `null`")
     void orderingOperatorsReturnFalseForTwoNulls() {
         Timestamp nullOperand = nullRef();
-        Timestamp anotherOperand = Timestamp.getDefaultInstance();
-        for (ComparisonOperator operator : orderingOperators) {
+        var anotherOperand = Timestamp.getDefaultInstance();
+        for (var operator : orderingOperators) {
             assertThat(operator.eval(nullOperand, anotherOperand)).isFalse();
             assertThat(operator.eval(anotherOperand, nullOperand)).isFalse();
         }

--- a/base/src/test/java/io/spine/query/QueryPredicateTest.java
+++ b/base/src/test/java/io/spine/query/QueryPredicateTest.java
@@ -73,30 +73,25 @@ class QueryPredicateTest {
     @DisplayName("allow copying and joining predicates with some logical operator")
     void allowToCopyAndJoinPredicates() {
 
-        QueryPredicate<Manufacturer> notTraded =
-                firstPredicateOf(queryManufacturer().where(is_traded)
-                                                    .is(false));
+        var notTraded =
+                firstPredicateOf(queryManufacturer().where(is_traded).is(false));
 
-        QueryPredicate<Manufacturer> specificIsin =
-                firstPredicateOf(queryManufacturer().where(isin)
-                                                    .is("A194N"));
+        var specificIsin =
+                firstPredicateOf(queryManufacturer().where(isin).is("A194N"));
 
-        QueryPredicate<Manufacturer> foundedAfterEpoch =
-                firstPredicateOf(queryManufacturer().where(when_founded)
-                                                    .isGreaterThan(Timestamps.fromSeconds(0)));
+        var epoch = Timestamps.fromSeconds(0);
+        var foundedAfterEpoch =
+                firstPredicateOf(queryManufacturer().where(when_founded).isGreaterThan(epoch));
 
-        ImmutableList<QueryPredicate<Manufacturer>> predicatesToJoin =
-                ImmutableList.of(notTraded, specificIsin, foundedAfterEpoch);
+        var predicatesToJoin = ImmutableList.of(notTraded, specificIsin, foundedAfterEpoch);
 
-        LogicalOperator expectedOperator = OR;
-        QueryPredicate<Manufacturer> joinResult =
-                QueryPredicate.merge(predicatesToJoin, expectedOperator);
+        var expectedOperator = OR;
+        var joinResult = QueryPredicate.merge(predicatesToJoin, expectedOperator);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> expectedParameters =
-                predicatesToJoin.stream()
-                                .flatMap(p -> p.allParams()
-                                               .stream())
-                                .collect(toImmutableList());
+        var expectedParameters = predicatesToJoin.stream()
+                .flatMap(p -> p.allParams()
+                        .stream())
+                .collect(toImmutableList());
 
         assertThat(joinResult).isNotNull();
         assertThat(joinResult.allParams()).containsExactlyElementsIn(expectedParameters);
@@ -106,30 +101,26 @@ class QueryPredicateTest {
     @Test
     @DisplayName("when transforming a flat predicate into its DNF, return it as-is")
     void returnFlatPredicateAsIs() {
-        RecordQuery<ManufacturerId, Manufacturer> query =
-                queryManufacturer()
-                        .where(is_traded).is(IS_TRADED)
-                        .where(when_founded).isLessThan(NOW)
-                        .build();
-        QueryPredicate<Manufacturer> original = query.subject()
-                                                      .predicate();
-        QueryPredicate<Manufacturer> transformed = original.toDnf();
+        var query = queryManufacturer()
+                .where(is_traded).is(IS_TRADED)
+                .where(when_founded).isLessThan(NOW)
+                .build();
+        var original = query.subject().predicate();
+        var transformed = original.toDnf();
         assertThat(transformed).isEqualTo(original);
     }
 
     @Test
     @DisplayName("when transforming a predicate that is already in DNF, return it as-is")
     void returnDnfPredicateAsIs() {
-        RecordQuery<ManufacturerId, Manufacturer> query =
-                queryManufacturer()
-                        .either(r -> r.where(stock_count).is(TEN_STOCKS)
-                                      .where(isin).is(FIRST_ISIN),
-                                r -> r.where(stock_count).is(HUNDRED_STOCKS)
-                                      .where(isin).is(SECOND_ISIN))
-                        .build();
-        QueryPredicate<Manufacturer> original = query.subject()
-                                                     .predicate();
-        QueryPredicate<Manufacturer> transformed = original.toDnf();
+        var query = queryManufacturer()
+                .either(r -> r.where(stock_count).is(TEN_STOCKS)
+                              .where(isin).is(FIRST_ISIN),
+                        r -> r.where(stock_count).is(HUNDRED_STOCKS)
+                              .where(isin).is(SECOND_ISIN))
+                .build();
+        var original = query.subject().predicate();
+        var transformed = original.toDnf();
         assertThat(transformed).isEqualTo(original);
     }
 
@@ -167,23 +158,21 @@ class QueryPredicateTest {
                         .where(when_founded).isLessThan(IN_BETWEEN)                         /* E */
                         .either(childEither1, childEither2);                                /* G */
 
-        RecordQuery<ManufacturerId, Manufacturer> query =
-                queryManufacturer()
-                        .where(is_traded).is(IS_TRADED)                                     /* A */
-                        .either(firstEither, secondEither)
-                        .build();
-        QueryPredicate<Manufacturer> rootPredicate = query.subject()
-                                                          .predicate();
-        QueryPredicate<Manufacturer> dnfPredicate = rootPredicate.toDnf();
+        var query = queryManufacturer()
+                .where(is_traded).is(IS_TRADED)                                     /* A */
+                .either(firstEither, secondEither)
+                .build();
+        var rootPredicate = query.subject().predicate();
+        var dnfPredicate = rootPredicate.toDnf();
         assertThat(dnfPredicate).isNotNull();
 
-        LogicalOperator rootOperator = dnfPredicate.operator();
+        var rootOperator = dnfPredicate.operator();
         assertThat(rootOperator).isEqualTo(OR);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> allParams = dnfPredicate.allParams();
+        var allParams = dnfPredicate.allParams();
         assertThat(allParams).isEmpty();
 
-        ImmutableList<QueryPredicate<Manufacturer>> children = dnfPredicate.children();
+        var children = dnfPredicate.children();
         assertThat(children).hasSize(4);
 
         assertFirstChild(children);
@@ -196,20 +185,20 @@ class QueryPredicateTest {
      * Expects the first child of the passed collection to be {@code A && B && C}.
      */
     private static void assertFirstChild(ImmutableList<QueryPredicate<Manufacturer>> children) {
-        QueryPredicate<Manufacturer> first = children.get(0);
+        var first = children.get(0);
         assertThat(first.children()).isEmpty();
         assertThat(first.operator()).isEqualTo(AND);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> allParams = first.allParams();
+        var allParams = first.allParams();
         assertThat(allParams).hasSize(3);
 
-        SubjectParameter<?, ?, ?> actualA = allParams.get(0);
+        var actualA = allParams.get(0);
         assertParamA(actualA);
 
-        SubjectParameter<?, ?, ?> actualB = allParams.get(1);
+        var actualB = allParams.get(1);
         assertParam(actualB, isin, EQUALS, FIRST_ISIN);
 
-        SubjectParameter<?, ?, ?> actualC = allParams.get(2);
+        var actualC = allParams.get(2);
         assertParam(actualC, when_founded, GREATER_THAN, IN_BETWEEN);
     }
 
@@ -217,23 +206,23 @@ class QueryPredicateTest {
      * Expects the second child of the passed collection to be {@code A && D && E && F}.
      */
     private static void assertSecondChild(ImmutableList<QueryPredicate<Manufacturer>> children) {
-        QueryPredicate<Manufacturer> second = children.get(1);
+        var second = children.get(1);
         assertThat(second.children()).isEmpty();
         assertThat(second.operator()).isEqualTo(AND);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> allParams = second.allParams();
+        var allParams = second.allParams();
         assertThat(allParams).hasSize(4);
 
-        SubjectParameter<?, ?, ?> actualA = allParams.get(0);
+        var actualA = allParams.get(0);
         assertParamA(actualA);
 
-        SubjectParameter<?, ?, ?> actualD = allParams.get(1);
+        var actualD = allParams.get(1);
         assertParamD(actualD);
 
-        SubjectParameter<?, ?, ?> actualE = allParams.get(2);
+        var actualE = allParams.get(2);
         assertParamE(actualE);
 
-        SubjectParameter<?, ?, ?> actualF = allParams.get(3);
+        var actualF = allParams.get(3);
         assertParam(actualF, stock_count, LESS_THAN, TEN_STOCKS);
     }
 
@@ -241,26 +230,26 @@ class QueryPredicateTest {
      * Expects the third child of the passed collection to be {@code A && D && E && G && H}.
      */
     private static void assertThirdChild(ImmutableList<QueryPredicate<Manufacturer>> children) {
-        QueryPredicate<Manufacturer> third = children.get(2);
+        var third = children.get(2);
         assertThat(third.children()).isEmpty();
         assertThat(third.operator()).isEqualTo(AND);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> allParams = third.allParams();
+        var allParams = third.allParams();
         assertThat(allParams).hasSize(5);
 
-        SubjectParameter<?, ?, ?> actualA = allParams.get(0);
+        var actualA = allParams.get(0);
         assertParamA(actualA);
 
-        SubjectParameter<?, ?, ?> actualD = allParams.get(1);
+        var actualD = allParams.get(1);
         assertParamD(actualD);
 
-        SubjectParameter<?, ?, ?> actualE = allParams.get(2);
+        var actualE = allParams.get(2);
         assertParamE(actualE);
 
-        SubjectParameter<?, ?, ?> actualG = allParams.get(3);
+        var actualG = allParams.get(3);
         assertParamG(actualG);
 
-        SubjectParameter<?, ?, ?> actualH = allParams.get(4);
+        var actualH = allParams.get(4);
         assertParam(actualH, when_founded, EQUALS, DEFAULT_TIME);
     }
 
@@ -268,26 +257,26 @@ class QueryPredicateTest {
      * Expects the fourth child of the passed collection to be {@code A && D && E && G && J}.
      */
     private static void assertFourthChild(ImmutableList<QueryPredicate<Manufacturer>> children) {
-        QueryPredicate<Manufacturer> fourth = children.get(3);
+        var fourth = children.get(3);
         assertThat(fourth.children()).isEmpty();
         assertThat(fourth.operator()).isEqualTo(AND);
 
-        ImmutableList<SubjectParameter<?, ?, ?>> allParams = fourth.allParams();
+        var allParams = fourth.allParams();
         assertThat(allParams).hasSize(5);
 
-        SubjectParameter<?, ?, ?> actualA = allParams.get(0);
+        var actualA = allParams.get(0);
         assertParamA(actualA);
 
-        SubjectParameter<?, ?, ?> actualD = allParams.get(1);
+        var actualD = allParams.get(1);
         assertParamD(actualD);
 
-        SubjectParameter<?, ?, ?> actualE = allParams.get(2);
+        var actualE = allParams.get(2);
         assertParamE(actualE);
 
-        SubjectParameter<?, ?, ?> actualG = allParams.get(3);
+        var actualG = allParams.get(3);
         assertParamG(actualG);
 
-        SubjectParameter<?, ?, ?> actualJ = allParams.get(4);
+        var actualJ = allParams.get(4);
         assertParam(actualJ, when_founded, LESS_THAN, NOW);
     }
 

--- a/base/src/test/java/io/spine/query/RecordColumnTest.java
+++ b/base/src/test/java/io/spine/query/RecordColumnTest.java
@@ -41,10 +41,9 @@ class RecordColumnTest {
     @Test
     @DisplayName("allow creating new instances")
     void allowCreation() {
-        String name = "description";
-        String description = "some description";
-        RecordColumn<Manufacturer, String> column =
-                new RecordColumn<>(name, String.class, (r) -> description);
+        var name = "description";
+        var description = "some description";
+        var column = new RecordColumn<Manufacturer, String>(name, String.class, (r) -> description);
 
         assertThat(column).isNotNull();
         assertThat(column.name().value()).isEqualTo(name);

--- a/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
+++ b/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
@@ -27,7 +27,6 @@
 package io.spine.query;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Timestamps;
@@ -35,8 +34,6 @@ import io.spine.query.given.RecordQueryBuilderTestEnv;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
@@ -75,8 +72,8 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("with no parameters")
         void empty() {
-            RecordQuery<ManufacturerId, Manufacturer> actual = queryManufacturer().build();
-            Subject<ManufacturerId, Manufacturer> subject = subjectWithNoParameters(actual);
+            var actual = queryManufacturer().build();
+            var subject = subjectWithNoParameters(actual);
             assertThat(subject.id()
                               .values()).isEmpty();
             RecordQueryBuilderTestEnv.assertNoSortingMaskLimit(actual);
@@ -85,8 +82,8 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("which hold the type of the queried record and the type of its ID")
         void withRecordType() {
-            RecordQuery<ManufacturerId, Manufacturer> query = queryManufacturer().build();
-            Subject<ManufacturerId, Manufacturer> subject = query.subject();
+            var query = queryManufacturer().build();
+            var subject = query.subject();
             assertThat(subject.recordType()).isEqualTo(Manufacturer.class);
             assertThat(subject.idType()).isEqualTo(ManufacturerId.class);
         }
@@ -94,49 +91,46 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("by a single identifier value")
         void byId() {
-            ManufacturerId expectedId = manufacturerId();
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer()
-                            .id().is(expectedId)
-                            .build();
-            Subject<ManufacturerId, Manufacturer> subject = subjectWithNoParameters(query);
+            var expectedId = manufacturerId();
+            var query = queryManufacturer()
+                    .id().is(expectedId)
+                    .build();
+            var subject = subjectWithNoParameters(query);
 
-            IdParameter<ManufacturerId> actualIdParam = subject.id();
+            var actualIdParam = subject.id();
             assertThat(actualIdParam.values()).containsExactly(expectedId);
         }
 
         @Test
         @DisplayName("by several identifier values")
         void bySeveralIds() {
-            ImmutableSet<ManufacturerId> expectedValues = generateIds(24);
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer()
-                            .id().in(expectedValues)
-                            .build();
-            Subject<ManufacturerId, Manufacturer> subject = subjectWithNoParameters(query);
+            var expectedValues = generateIds(24);
+            var query = queryManufacturer()
+                    .id().in(expectedValues)
+                    .build();
+            var subject = subjectWithNoParameters(query);
 
-            IdParameter<ManufacturerId> actualIdParam = subject.id();
+            var actualIdParam = subject.id();
             assertThat(actualIdParam.values()).isEqualTo(expectedValues);
         }
 
         @Test
         @DisplayName("by the values of several columns")
         void byColumnValues() {
-            boolean stocksAreTraded = true;
-            String isinValue = "JP 3633400001";
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer().where(isin).is(isinValue)
-                                       .where(when_founded).isLessOrEqualTo(THURSDAY)
-                                       .where(is_traded).is(stocksAreTraded)
-                                       .build();
+            var stocksAreTraded = true;
+            var isinValue = "JP 3633400001";
+            var query = queryManufacturer()
+                    .where(isin).is(isinValue)
+                    .where(when_founded).isLessOrEqualTo(THURSDAY)
+                    .where(is_traded).is(stocksAreTraded)
+                    .build();
 
-            QueryPredicate<Manufacturer> rootPredicate = query.subject()
-                                                           .predicate();
+            var rootPredicate = query.subject().predicate();
             assertThat(rootPredicate.operator()).isEqualTo(AND);
             assertThat(rootPredicate.children()).isEmpty();
             assertThat(rootPredicate.customParameters()).isEmpty();
 
-            ImmutableList<SubjectParameter<Manufacturer, ?, ?>> params = rootPredicate.parameters();
+            var params = rootPredicate.parameters();
             assertThat(params).hasSize(3);
             assertHasParamValue(params, isin, EQUALS, isinValue);
             assertHasParamValue(params, when_founded, LESS_OR_EQUALS, THURSDAY);
@@ -147,28 +141,26 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("by the value of either of the columns")
         void byEitherColumn() {
-            String isinValue = "JP 3899800001";
-            boolean stocksAreTraded = true;
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer()
-                            .where(when_founded).isLessThan(THURSDAY)
-                            .either((r) -> r.where(isin).is(isinValue),
-                                    (r) -> r.where(is_traded).is(stocksAreTraded))
-                            .build();
-            QueryPredicate<Manufacturer> rootPredicate = query.subject().predicate();
+            var isinValue = "JP 3899800001";
+            var stocksAreTraded = true;
+            var query = queryManufacturer()
+                    .where(when_founded).isLessThan(THURSDAY)
+                    .either((r) -> r.where(isin).is(isinValue),
+                            (r) -> r.where(is_traded).is(stocksAreTraded))
+                    .build();
+            var rootPredicate = query.subject().predicate();
             assertThat(rootPredicate.operator()).isEqualTo(AND);
 
-            ImmutableList<SubjectParameter<Manufacturer, ?, ?>> parameters =
-                    rootPredicate.parameters();
+            var parameters =rootPredicate.parameters();
             assertThat(parameters.size()).isEqualTo(1);
             assertHasParamValue(parameters, when_founded, LESS_THAN, THURSDAY);
 
-            ImmutableList<QueryPredicate<Manufacturer>> children = rootPredicate.children();
+            var children = rootPredicate.children();
             assertThat(children.size()).isEqualTo(1);
-            QueryPredicate<Manufacturer> either = children.get(0);
+            var either = children.get(0);
             assertThat(either.operator()).isEqualTo(OR);
             assertThat(either.customParameters()).hasSize(0);
-            ImmutableList<SubjectParameter<Manufacturer, ?, ?>> params = either.parameters();
+            var params = either.parameters();
             assertThat(params).hasSize(2);
 
             assertHasParamValue(params, isin, EQUALS, isinValue);
@@ -179,26 +171,25 @@ class RecordQueryBuilderTest {
         @DisplayName("removing unnecessary top-level `AND` predicate, " +
                 "if there is just a single `OR` child predicate.")
         void removeUnnecessaryTopLevelAnd() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer()
-                            .either(r -> r.where(stock_count).is(42)
+            var query = queryManufacturer()
+                    .either(r -> r.where(stock_count).is(42)
                                           .where(isin).is("some value"),
-                                    r -> r.where(stock_count).is(7)
-                                          .where(isin).is("another value"))
-                            .build();
-            LogicalOperator topLevelOperator = query.subject()
-                                                    .predicate()
-                                                    .operator();
+                            r -> r.where(stock_count).is(7)
+                                  .where(isin).is("another value"))
+                    .build();
+            var topLevelOperator = query.subject()
+                                        .predicate()
+                                        .operator();
             assertThat(topLevelOperator).isEqualTo(OR);
         }
 
         @Test
         @DisplayName("with the field mask")
         void withFieldMask() {
-            FieldMask mask = fieldMaskWith(is_traded);
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer().withMask(mask)
-                                       .build();
+            var mask = fieldMaskWith(is_traded);
+            var query = queryManufacturer()
+                    .withMask(mask)
+                    .build();
 
             assertThat(query.mask()).isEqualTo(mask);
         }
@@ -207,28 +198,28 @@ class RecordQueryBuilderTest {
         @DisplayName("with the field mask defined by the paths")
         @SuppressWarnings("DuplicateStringLiteralInspection")   /* Field names just for tests. */
         void withMaskPaths() {
-            String isin = "isin";
-            String whenFounded = "when_founded";
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer().withMask(isin, whenFounded)
-                                       .build();
-            FieldMask expected = FieldMask.newBuilder()
-                                          .addPaths(isin)
-                                          .addPaths(whenFounded)
-                                          .build();
+            var isin = "isin";
+            var whenFounded = "when_founded";
+            var query = queryManufacturer()
+                    .withMask(isin, whenFounded)
+                    .build();
+            var expected = FieldMask.newBuilder()
+                    .addPaths(isin)
+                    .addPaths(whenFounded)
+                    .build();
             assertThat(query.mask()).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("sorted by the values of several columns")
         void withSorting() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer().sortAscendingBy(when_founded)
-                                       .sortAscendingBy(isin)
-                                       .sortDescendingBy(is_traded)
-                                       .build();
+            var query = queryManufacturer()
+                    .sortAscendingBy(when_founded)
+                    .sortAscendingBy(isin)
+                    .sortDescendingBy(is_traded)
+                    .build();
 
-            ImmutableList<SortBy<?, Manufacturer>> sorting = query.sorting();
+            var sorting = query.sorting();
             assertThat(sorting).hasSize(3);
             assertThat(sorting.get(0)).isEqualTo(new SortBy<>(when_founded, ASC));
             assertThat(sorting.get(1)).isEqualTo(new SortBy<>(isin, ASC));
@@ -238,13 +229,13 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("sorted by the values of several columns with the record limit")
         void withLimitAndSorting() {
-            int tenRecords = 10;
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    queryManufacturer().sortDescendingBy(isin)
-                                       .sortAscendingBy(when_founded)
-                                       .limit(tenRecords)
-                                       .build();
-            ImmutableList<SortBy<?, Manufacturer>> sorting = query.sorting();
+            var tenRecords = 10;
+            var query = queryManufacturer()
+                    .sortDescendingBy(isin)
+                    .sortAscendingBy(when_founded)
+                    .limit(tenRecords)
+                    .build();
+            var sorting = query.sorting();
             assertThat(sorting.get(0)).isEqualTo(new SortBy<>(isin, DESC));
             assertThat(sorting.get(1)).isEqualTo(new SortBy<>(when_founded, ASC));
             assertThat(query.limit()).isEqualTo(tenRecords);
@@ -253,13 +244,13 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("which return the same `Builder` instance if asked")
         void returnSameBuilder() {
-            RecordQueryBuilder<ManufacturerId, Manufacturer> builder =
-                    queryManufacturer().where(when_founded).isGreaterThan(THURSDAY)
-                                       .where(isin).is("JP 49869009911")
-                                       .sortAscendingBy(when_founded)
-                                       .limit(150);
-            RecordQuery<ManufacturerId, Manufacturer> query = builder.build();
-            RecordQueryBuilder<ManufacturerId, Manufacturer> actualBuilder = query.toBuilder();
+            var builder = queryManufacturer()
+                    .where(when_founded).isGreaterThan(THURSDAY)
+                    .where(isin).is("JP 49869009911")
+                    .sortAscendingBy(when_founded)
+                    .limit(150);
+            var query = builder.build();
+            var actualBuilder = query.toBuilder();
             assertThat(actualBuilder).isSameInstanceAs(builder);
         }
     }
@@ -285,7 +276,7 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("of a single ID parameter")
         void ofId() {
-            ManufacturerId value = manufacturerId();
+            var value = manufacturerId();
             assertThat(queryManufacturer().id().is(value)
                                           .whichIds()
                                           .values()).containsExactly(value);
@@ -294,7 +285,7 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("of several IDs")
         void ofSeveralIds() {
-            ImmutableSet<ManufacturerId> ids = generateIds(3);
+            var ids = generateIds(3);
             assertThat(queryManufacturer().id().in(ids)
                                           .whichIds()
                                           .values()).isEqualTo(ids);
@@ -303,15 +294,15 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("of parameters")
         void ofParameterValues() {
-            String isinValue = "JP 3496600002";
-            QueryPredicate<Manufacturer> predicate =
-                    queryManufacturer().where(isin).is(isinValue)
-                                       .where(when_founded).isGreaterOrEqualTo(THURSDAY)
-                                       .predicate();
+            var isinValue = "JP 3496600002";
+            var predicate = queryManufacturer()
+                    .where(isin).is(isinValue)
+                    .where(when_founded).isGreaterOrEqualTo(THURSDAY)
+                    .predicate();
             assertThat(predicate.children()).isEmpty();
             assertThat(predicate.operator()).isEqualTo(AND);
 
-            ImmutableList<SubjectParameter<Manufacturer, ?, ?>> parameters = predicate.parameters();
+            var parameters = predicate.parameters();
             assertHasParamValue(parameters, isin, EQUALS, isinValue);
             assertHasParamValue(parameters, when_founded, GREATER_OR_EQUALS, THURSDAY);
         }
@@ -319,9 +310,8 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("of a field mask")
         void ofFieldMask() {
-            FieldMask mask = fieldMaskWith(isin);
-            Optional<FieldMask> maybeMask = queryManufacturer().withMask(mask)
-                                                               .whichMask();
+            var mask = fieldMaskWith(isin);
+            var maybeMask = queryManufacturer().withMask(mask).whichMask();
             assertThat(maybeMask).isPresent();
             assertThat(maybeMask.get()).isEqualTo(mask);
         }
@@ -329,7 +319,7 @@ class RecordQueryBuilderTest {
         @Test
         @DisplayName("of a record limit")
         void ofLimit() {
-            int limit = 55;
+            var limit = 55;
             assertThat(queryManufacturer().limit(limit)
                                           .whichLimit()).isEqualTo(limit);
 

--- a/base/src/test/java/io/spine/query/RecordQueryTest.java
+++ b/base/src/test/java/io/spine/query/RecordQueryTest.java
@@ -60,111 +60,96 @@ class RecordQueryTest {
         @Test
         @DisplayName("in conjunction with conjunctive predicates, if this query is disjunctive")
         void disjunctiveAndConjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    disjunctiveBuilder(either1(), either2()).build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
+            var query = disjunctiveBuilder(either1(), either2()).build();
+            var expected =
                     conjunctivePredicates().apply(disjunctiveBuilder(either1(), either2())).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual = query.and(conjunctivePredicates());
+            var actual = query.and(conjunctivePredicates());
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in conjunction with disjunctive predicates, if this query is disjunctive")
         void disjunctiveAndDisjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    disjunctiveBuilder(either1(), either2()).build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
+            var query = disjunctiveBuilder(either1(), either2()).build();
+            var expected =
                     disjunctiveBuilder(either1(), either2())
                             .either(r -> either3().apply(r),
                                     r -> either4().apply(r))
                             .build();
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.and(disjunctivePredicates(either3(), either4()));
+            var actual = query.and(disjunctivePredicates(either3(), either4()));
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in disjunction with disjunctive predicates, if this query is disjunctive")
         void disjunctiveEitherDisjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    disjunctiveBuilder(either1(), either2()).build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
-                    disjunctiveBuilder(either1(), either2(), either3(), either4()).build();
+            var query = disjunctiveBuilder(either1(), either2()).build();
+            var expected = disjunctiveBuilder(either1(), either2(), either3(), either4()).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.either(disjunctivePredicates(either3(), either4()));
+            var actual = query.either(disjunctivePredicates(either3(), either4()));
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in disjunction with conjunctive predicates, if this query is disjunctive")
         void disjunctiveEitherConjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query =
-                    disjunctiveBuilder(either1(), either2()).build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
+            var query = disjunctiveBuilder(either1(), either2()).build();
+            var expected =
                     disjunctiveBuilder(either1(), either2(), r -> conjunctivePredicates().apply(r))
                             .build();
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.either(conjunctivePredicates());
+            var actual = query.either(conjunctivePredicates());
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in conjunction with conjunctive predicates, if this query is conjunctive")
         void conjunctiveAndConjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query = conjunctiveBuilder().build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
-                    conjunctivePredicates().apply(conjunctiveBuilder()).build();
+            var query = conjunctiveBuilder().build();
+            var expected = conjunctivePredicates().apply(conjunctiveBuilder()).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.and(conjunctivePredicates());
+            var actual = query.and(conjunctivePredicates());
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in conjunction with disjunctive predicates, if this query is conjunctive")
         void conjunctiveAndDisjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query = conjunctiveBuilder().build();
-            RecordQuery<ManufacturerId, Manufacturer> expected =
-                    disjunctivePredicates().apply(conjunctiveBuilder()).build();
+            var query = conjunctiveBuilder().build();
+            var expected = disjunctivePredicates().apply(conjunctiveBuilder()).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual = query.and(disjunctivePredicates());
+            var actual = query.and(disjunctivePredicates());
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in disjunction with conjunctive predicates, if this query is conjunctive")
         void conjunctiveEitherConjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query = conjunctiveBuilder().build();
-            RecordQueryBuilder<ManufacturerId, Manufacturer> almostAsExpected =
-                    queryManufacturer().either(
+            var query = conjunctiveBuilder().build();
+            var almostAsExpected = queryManufacturer()
+                    .either(
                             r -> conjunctivePredicates().apply(r),
                             r -> moreConjunctivePredicates().apply(r)
                     );
-            RecordQuery<ManufacturerId, Manufacturer> expected =
-                    withMaskSortingAndLimit(almostAsExpected).build();
+            var expected = withMaskSortingAndLimit(almostAsExpected).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.either(moreConjunctivePredicates());
+            var actual = query.either(moreConjunctivePredicates());
             assertThat(actual).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("in disjunction with disjunctive predicates, if this query is conjunctive")
         void conjunctiveEitherDisjunction() {
-            RecordQuery<ManufacturerId, Manufacturer> query = conjunctiveBuilder().build();
-            RecordQueryBuilder<ManufacturerId, Manufacturer> almostAsExpected =
-                    queryManufacturer().either(
+            var query = conjunctiveBuilder().build();
+            var almostAsExpected = queryManufacturer()
+                    .either(
                             r -> conjunctivePredicates().apply(r),
                             r -> either1().apply(r),
                             r -> either2().apply(r)
                     );
-            RecordQuery<ManufacturerId, Manufacturer> expected =
-                    withMaskSortingAndLimit(almostAsExpected).build();
+            var expected = withMaskSortingAndLimit(almostAsExpected).build();
 
-            RecordQuery<ManufacturerId, Manufacturer> actual =
-                    query.either(disjunctivePredicates(either1(), either2()));
+            var actual = query.either(disjunctivePredicates(either1(), either2()));
             assertThat(actual).isEqualTo(expected);
         }
     }

--- a/base/src/test/java/io/spine/query/given/ComparisonOperatorTestEnv.java
+++ b/base/src/test/java/io/spine/query/given/ComparisonOperatorTestEnv.java
@@ -26,7 +26,6 @@
 
 package io.spine.query.given;
 
-import com.google.protobuf.Any;
 import com.google.protobuf.FieldMask;
 import com.google.protobuf.StringValue;
 import com.google.protobuf.util.Timestamps;
@@ -41,6 +40,7 @@ import static io.spine.protobuf.AnyPacker.pack;
 /**
  * Test values used in comparison tests of a {@link io.spine.query.ComparisonOperator}.
  */
+@SuppressWarnings("unused") /* Serve as method sources */
 public final class ComparisonOperatorTestEnv {
 
     private ComparisonOperatorTestEnv() {
@@ -75,8 +75,8 @@ public final class ComparisonOperatorTestEnv {
     }
 
     private static Arguments equalMessages() {
-        Any message = pack(FieldMask.getDefaultInstance());
-        Any anotherMessage = pack(FieldMask.getDefaultInstance());
+        var message = pack(FieldMask.getDefaultInstance());
+        var anotherMessage = pack(FieldMask.getDefaultInstance());
         return Arguments.of(message, anotherMessage);
     }
 

--- a/base/src/test/java/io/spine/query/given/RecordQueryBuilderTestEnv.java
+++ b/base/src/test/java/io/spine/query/given/RecordQueryBuilderTestEnv.java
@@ -68,8 +68,8 @@ public final class RecordQueryBuilderTestEnv {
      */
     public static ManufacturerId manufacturerId() {
         return ManufacturerId.newBuilder()
-                             .setUuid(randomString())
-                             .build();
+                .setUuid(randomString())
+                .build();
     }
 
     /**
@@ -96,7 +96,7 @@ public final class RecordQueryBuilderTestEnv {
     public static Subject<ManufacturerId, Manufacturer>
     subjectWithNoParameters(RecordQuery<ManufacturerId, Manufacturer> query) {
         assertThat(query).isNotNull();
-        Subject<ManufacturerId, Manufacturer> subject = query.subject();
+        var subject = query.subject();
         assertThat(subject.predicate().parameters()).isEmpty();
         return subject;
     }
@@ -119,12 +119,12 @@ public final class RecordQueryBuilderTestEnv {
                                            RecordColumn<Manufacturer, ?> column,
                                            ComparisonOperator operator,
                                            Object value) {
-        boolean parameterFound = false;
-        for (SubjectParameter<Manufacturer, ?, ?> parameter : list) {
+        var parameterFound = false;
+        for (var parameter : list) {
             if (parameter.column()
                          .equals(column)) {
-                ComparisonOperator actualOperator = parameter.operator();
-                Object actualValue = parameter.value();
+                var actualOperator = parameter.operator();
+                var actualValue = parameter.value();
                 if (actualOperator == operator && value.equals(actualValue)) {
                     parameterFound = true;
                 }

--- a/base/src/test/java/io/spine/query/given/RecordQueryTestEnv.java
+++ b/base/src/test/java/io/spine/query/given/RecordQueryTestEnv.java
@@ -97,8 +97,7 @@ public final class RecordQueryTestEnv {
     }
 
     public static RecordQueryBuilder<ManufacturerId, Manufacturer> conjunctiveBuilder() {
-        RecordQueryBuilder<ManufacturerId, Manufacturer> withPredicates =
-                conjunctivePredicates().apply(queryManufacturer());
+        var withPredicates = conjunctivePredicates().apply(queryManufacturer());
         return withMaskSortingAndLimit(withPredicates);
 
     }

--- a/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
+++ b/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
@@ -31,13 +31,13 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("GenericTypeIndex should")
+@DisplayName("`GenericTypeIndex` should")
 class GenericTypeIndexTest {
 
     @Test
     @DisplayName("obtain generic argument assuming generic superclass")
     void obtain_generic_argument_assuming_generic_superclass() {
-        Parametrized<Long, String> val = new Parametrized<Long, String>() {};
+        var val = new Parametrized<Long, String>() {};
         assertEquals(Long.class, Types.argumentIn(val.getClass(), Base.class, 0));
         assertEquals(String.class, Types.argumentIn(val.getClass(), Base.class, 1));
     }

--- a/base/src/test/java/io/spine/reflect/InvokablesTest.java
+++ b/base/src/test/java/io/spine/reflect/InvokablesTest.java
@@ -38,7 +38,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 
@@ -89,8 +88,8 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("set accessible and invoke successfully")
         void allowToSetAccessibleAndInvoke() {
-            ClassWithPrivateMethod target = new ClassWithPrivateMethod();
-            Object result = setAccessibleAndInvoke(privateMethod, target);
+            var target = new ClassWithPrivateMethod();
+            var result = setAccessibleAndInvoke(privateMethod, target);
 
             assertThat(result).isEqualTo(METHOD_RESULT);
         }
@@ -99,7 +98,7 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("throw `IAE` if the given target is not a valid invocation target")
         void throwOnInvalidTarget() {
-            Object wrongTarget = new Object();
+            var wrongTarget = new Object();
 
             assertIllegalState(() -> setAccessibleAndInvoke(privateMethod, wrongTarget));
         }
@@ -108,8 +107,8 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("throw `ISE` if an exception is thrown during invocation")
         void throwOnInvocationError() throws NoSuchMethodException {
-            Method method = ClassWithPrivateMethod.class.getDeclaredMethod("throwingMethod");
-            ClassWithPrivateMethod target = new ClassWithPrivateMethod();
+            var method = ClassWithPrivateMethod.class.getDeclaredMethod("throwingMethod");
+            var target = new ClassWithPrivateMethod();
 
             assertIllegalState(() -> setAccessibleAndInvoke(method, target));
         }
@@ -117,12 +116,12 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("convert a visible method to a handle")
         void convertToHandle() throws Throwable {
-            Method method = ClassWithPrivateMethod.class.getMethod("publicMethod");
-            MethodHandle handle = asHandle(method);
+            var method = ClassWithPrivateMethod.class.getMethod("publicMethod");
+            var handle = asHandle(method);
             assertThat(handle).isNotNull();
 
-            Object invocationResult = handle.bindTo(new ClassWithPrivateMethod())
-                                            .invoke();
+            var invocationResult = handle.bindTo(new ClassWithPrivateMethod())
+                                         .invoke();
             assertThat(invocationResult)
                     .isEqualTo(METHOD_RESULT);
         }
@@ -130,11 +129,11 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("convert an invisible method to a handle")
         void convertInvisibleToHandle() throws Throwable {
-            MethodHandle handle = asHandle(privateMethod);
+            var handle = asHandle(privateMethod);
             assertThat(handle).isNotNull();
             assertAccessible().isFalse();
 
-            Object invocationResult = handle.invoke(new ClassWithPrivateMethod());
+            var invocationResult = handle.invoke(new ClassWithPrivateMethod());
             assertThat(invocationResult)
                     .isEqualTo(METHOD_RESULT);
         }
@@ -143,11 +142,11 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @DisplayName("convert an accessible method to a handle")
         void convertAccessibleToHandle() throws Throwable {
             privateMethod.setAccessible(true);
-            MethodHandle handle = asHandle(privateMethod);
+            var handle = asHandle(privateMethod);
             assertAccessible().isTrue();
             assertThat(handle).isNotNull();
 
-            Object invocationResult = handle.invoke(new ClassWithPrivateMethod());
+            var invocationResult = handle.invoke(new ClassWithPrivateMethod());
             assertThat(invocationResult)
                     .isEqualTo(METHOD_RESULT);
         }
@@ -165,21 +164,20 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("instantiate a class using a parameterless constructor")
         void instantiate() {
-            Cat cat = callParameterlessCtor(Cat.class);
+            var cat = callParameterlessCtor(Cat.class);
             assertThat(cat.greet()).contains(MISSING);
         }
 
         @Test
         @DisplayName("fail to instantiate an abstract class")
         void notInstantiateAbstractClass() {
-            assertIllegalState(() -> callParameterlessCtor(
-                    Animal.class));
+            assertIllegalState(() -> callParameterlessCtor(Animal.class));
         }
 
         @Test
         @DisplayName("instantiate using a default ctor")
         void defaultCtor() {
-            ClassWithDefaultCtor instance = callParameterlessCtor(ClassWithDefaultCtor.class);
+            var instance = callParameterlessCtor(ClassWithDefaultCtor.class);
             assertThat(instance.instantiated()).isTrue();
         }
 
@@ -198,7 +196,7 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
         @Test
         @DisplayName("instantiate a private class")
         void instantiatePrivate() {
-            ClassWithPrivateCtor instance = callParameterlessCtor(
+            var instance = callParameterlessCtor(
                     ClassWithPrivateCtor.class);
             assertThat(instance.instantiated()).isTrue();
         }
@@ -218,11 +216,10 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
             @Test
             @DisplayName("if the instantiation succeeded")
             void success() throws NoSuchMethodException {
-                Class<ClassWithPrivateCtor> privateCtorClass = ClassWithPrivateCtor.class;
+                var privateCtorClass = ClassWithPrivateCtor.class;
 
                 ctor = ClassWithPrivateCtor.class.getDeclaredConstructor();
-                ClassWithPrivateCtor instance =
-                        callParameterlessCtor(privateCtorClass);
+                var instance = callParameterlessCtor(privateCtorClass);
                 assertThat(instance.instantiated()).isTrue();
 
                 assertConstructorAccessible().isFalse();
@@ -231,7 +228,7 @@ class InvokablesTest extends UtilityClassTest<Invokables> {
             @Test
             @DisplayName("if the instantiation failed")
             void failure() throws NoSuchMethodException {
-                Class<ThrowingConstructor> throwingCtorClass = ThrowingConstructor.class;
+                var throwingCtorClass = ThrowingConstructor.class;
 
                 ctor = ThrowingConstructor.class.getDeclaredConstructor();
 

--- a/base/src/test/java/io/spine/reflect/IsDirectParentTest.java
+++ b/base/src/test/java/io/spine/reflect/IsDirectParentTest.java
@@ -38,7 +38,7 @@ import java.util.function.Predicate;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("IsDirectParent predicate should")
+@DisplayName("`IsDirectParent` predicate should")
 class IsDirectParentTest {
 
     private static void assertDirectParent(Package parentCandidate, Package child) {
@@ -54,32 +54,32 @@ class IsDirectParentTest {
     @Test
     @DisplayName("accept direct parent package")
     void directParent() {
-        Package javaUtilFunction = Predicate.class.getPackage();
-        Package javaUtil = Collection.class.getPackage();
+        var javaUtilFunction = Predicate.class.getPackage();
+        var javaUtil = Collection.class.getPackage();
         assertDirectParent(javaUtil, javaUtilFunction);
     }
 
     @Test
     @DisplayName("reject indirect parent package")
     void rejectIndirectParent() {
-        Package javaUtilConcurrentLocks = Lock.class.getPackage();
-        Package javaUtil = Collection.class.getPackage();
+        var javaUtilConcurrentLocks = Lock.class.getPackage();
+        var javaUtil = Collection.class.getPackage();
         assertNotDirectParent(javaUtil, javaUtilConcurrentLocks);
     }
 
     @Test
     @DisplayName("reject sibling package")
     void rejectSibling() {
-        Package javaUtilFunction = Predicate.class.getPackage();
-        Package javaUtilConcurrent = Callable.class.getPackage();
+        var javaUtilFunction = Predicate.class.getPackage();
+        var javaUtilConcurrent = Callable.class.getPackage();
         assertNotDirectParent(javaUtilConcurrent, javaUtilFunction);
     }
 
     @Test
     @DisplayName("reject cousin package")
     void rejectCousins() {
-        Package javaLangAnnotation = Annotation.class.getPackage();
-        Package javaUtilFunction = Predicate.class.getPackage();
+        var javaLangAnnotation = Annotation.class.getPackage();
+        var javaUtilFunction = Predicate.class.getPackage();
         assertNotDirectParent(javaUtilFunction, javaLangAnnotation);
     }
 }

--- a/base/src/test/java/io/spine/reflect/J2KtTest.java
+++ b/base/src/test/java/io/spine/reflect/J2KtTest.java
@@ -28,34 +28,28 @@ package io.spine.reflect;
 
 import io.spine.reflect.given.MethodHolder;
 import io.spine.reflect.given.ObjMethodHolder;
-import kotlin.reflect.KCallable;
-import kotlin.reflect.KParameter;
 import kotlin.reflect.KParameter.Kind;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Method;
-import java.util.List;
-import java.util.Optional;
-
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
-@DisplayName("`J2Kt` should")
+@DisplayName("``J2Kt`` should")
 class J2KtTest {
 
     @Test
     @DisplayName("find a static method in a class")
     void findStatic() throws NoSuchMethodException {
-        String name = "staticMethod";
-        Method method = MethodHolder.class.getDeclaredMethod(name, int.class);
-        Optional<KCallable<?>> found = J2Kt.findKotlinMethod(method);
+        var name = "staticMethod";
+        var method = MethodHolder.class.getDeclaredMethod(name, int.class);
+        var found = J2Kt.findKotlinMethod(method);
         assertThat(found)
                 .isPresent();
-        KCallable<?> ktMethod = found.get();
+        var ktMethod = found.get();
         assertThat(ktMethod.getName())
                 .isEqualTo(name);
-        List<KParameter> params = ktMethod.getParameters();
+        var params = ktMethod.getParameters();
         assertThat(params)
                 .hasSize(2);
         assertThat(params.get(0).getKind())
@@ -67,15 +61,15 @@ class J2KtTest {
     @Test
     @DisplayName("find a instance method a single argument in a class")
     void findInstance() throws NoSuchMethodException {
-        String name = "instanceMethod";
-        Method method = MethodHolder.class.getDeclaredMethod(name, String.class);
-        Optional<KCallable<?>> found = J2Kt.findKotlinMethod(method);
+        var name = "instanceMethod";
+        var method = MethodHolder.class.getDeclaredMethod(name, String.class);
+        var found = J2Kt.findKotlinMethod(method);
         assertThat(found)
                 .isPresent();
-        KCallable<?> ktMethod = found.get();
+        var ktMethod = found.get();
         assertThat(ktMethod.getName())
                 .isEqualTo(name);
-        List<KParameter> params = ktMethod.getParameters();
+        var params = ktMethod.getParameters();
         assertThat(params)
                 .hasSize(2);
         assertThat(params.get(0).getKind())
@@ -87,15 +81,15 @@ class J2KtTest {
     @Test
     @DisplayName("find a instance method with no arguments in a class")
     void findInstanceNoArg() throws NoSuchMethodException {
-        String name = "noParamMethod";
-        Method method = MethodHolder.class.getDeclaredMethod(name);
-        Optional<KCallable<?>> found = J2Kt.findKotlinMethod(method);
+        var name = "noParamMethod";
+        var method = MethodHolder.class.getDeclaredMethod(name);
+        var found = J2Kt.findKotlinMethod(method);
         assertThat(found)
                 .isPresent();
-        KCallable<?> ktMethod = found.get();
+        var ktMethod = found.get();
         assertThat(ktMethod.getName())
                 .isEqualTo(name);
-        List<KParameter> params = ktMethod.getParameters();
+        var params = ktMethod.getParameters();
         assertThat(params)
                 .hasSize(1);
         assertThat(params.get(0).getKind())
@@ -105,15 +99,15 @@ class J2KtTest {
     @Test
     @DisplayName("find a static method in an object")
     void findStaticInObj() throws NoSuchMethodException {
-        String name = "staticObjMethod";
-        Method method = ObjMethodHolder.class.getDeclaredMethod(name);
-        Optional<KCallable<?>> found = J2Kt.findKotlinMethod(method);
+        var name = "staticObjMethod";
+        var method = ObjMethodHolder.class.getDeclaredMethod(name);
+        var found = J2Kt.findKotlinMethod(method);
         assertThat(found)
                 .isPresent();
-        KCallable<?> ktMethod = found.get();
+        var ktMethod = found.get();
         assertThat(ktMethod.getName())
                 .isEqualTo(name);
-        List<KParameter> params = ktMethod.getParameters();
+        var params = ktMethod.getParameters();
         assertThat(params)
                 .hasSize(1);
         assertThat(params.get(0).getKind())
@@ -123,15 +117,15 @@ class J2KtTest {
     @Test
     @DisplayName("find a instance method in an object")
     void findInstanceInObj() throws NoSuchMethodException {
-        String name = "instanceObjMethod";
-        Method method = ObjMethodHolder.class.getDeclaredMethod(name);
-        Optional<KCallable<?>> found = J2Kt.findKotlinMethod(method);
+        var name = "instanceObjMethod";
+        var method = ObjMethodHolder.class.getDeclaredMethod(name);
+        var found = J2Kt.findKotlinMethod(method);
         assertThat(found)
                 .isPresent();
-        KCallable<?> ktMethod = found.get();
+        var ktMethod = found.get();
         assertThat(ktMethod.getName())
                 .isEqualTo(name);
-        List<KParameter> params = ktMethod.getParameters();
+        var params = ktMethod.getParameters();
         assertThat(params)
                 .hasSize(1);
         assertThat(params.get(0).getKind())

--- a/base/src/test/java/io/spine/reflect/PackageGraphTest.java
+++ b/base/src/test/java/io/spine/reflect/PackageGraphTest.java
@@ -50,7 +50,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("PackageGraph should")
+@DisplayName("`PackageGraph` should")
 class PackageGraphTest {
 
     private final PackageGraph graph = PackageGraph.newInstance();
@@ -67,13 +67,13 @@ class PackageGraphTest {
     }
 
     @Nested
-    @DisplayName("Create instance with packages")
+    @DisplayName("create instance with packages")
     class Create {
 
         @Test
-        @DisplayName("all known to the caller's ClassLoader")
+        @DisplayName("all known to the caller's `ClassLoader`")
         void allKnown() {
-            PackageGraph graph = PackageGraph.newInstance();
+            var graph = PackageGraph.newInstance();
             assertContainsPackageOf(graph, String.class);
             assertContainsPackageOf(graph, Predicate.class);
             assertContainsPackageOf(graph, Test.class);
@@ -82,7 +82,7 @@ class PackageGraphTest {
         @Test
         @DisplayName("having common name prefix")
         void commonPrefix() {
-            PackageGraph graph = PackageGraph.containing("org.junit");
+            var graph = PackageGraph.containing("org.junit");
             assertNotContainsPackageOf(graph, String.class);
             assertNotContainsPackageOf(graph, Predicate.class);
             assertContainsPackageOf(graph, Test.class);
@@ -90,15 +90,14 @@ class PackageGraphTest {
         }
 
         @Test
-        @DisplayName("accepted by a Filter")
+        @DisplayName("accepted by a `Filter`")
         void filtered() {
-            PackageGraph.Filter filter =
-                    PackageGraph.newFilter()
-                                .exclude("java")
-                                .include("java.lang.annotation")
-                                .include("java.util.function");
+            var filter = PackageGraph.newFilter()
+                                     .exclude("java")
+                                     .include("java.lang.annotation")
+                                     .include("java.util.function");
 
-            PackageGraph graph = PackageGraph.matching(filter);
+            var graph = PackageGraph.matching(filter);
 
             assertContainsPackageOf(graph, Annotation.class);
             assertContainsPackageOf(graph, Predicate.class);
@@ -117,7 +116,7 @@ class PackageGraphTest {
         }
     }
 
-    @DisplayName("Implement Graph interface")
+    @DisplayName("implement `Graph` interface")
     @Nested
     class GraphApi {
 
@@ -149,7 +148,7 @@ class PackageGraphTest {
         @Test
         @DisplayName("returning adjacent nodes")
         void adjacentNodes() {
-            Set<PackageInfo> nodes = graph.adjacentNodes(javaUtil);
+            var nodes = graph.adjacentNodes(javaUtil);
             assertContainsPackageOf(nodes, Callable.class);
             assertContainsPackageOf(nodes, Function.class);
             assertContainsPackageOf(nodes, Logger.class);
@@ -158,7 +157,7 @@ class PackageGraphTest {
         @Test
         @DisplayName("obtaining predecessors")
         void predecessors() {
-            Set<PackageInfo> predecessors = graph.predecessors(javaUtilConcurrent);
+            var predecessors = graph.predecessors(javaUtilConcurrent);
 
             assertContainsPackageOf(predecessors, AtomicBoolean.class);
             assertContainsPackageOf(predecessors, Lock.class);
@@ -167,7 +166,7 @@ class PackageGraphTest {
         @Test
         @DisplayName("obtaining successors")
         void successors() {
-            Set<PackageInfo> successors = graph.successors(javaUtilConcurrent);
+            var successors = graph.successors(javaUtilConcurrent);
 
             assertEquals(1, successors.size());
             assertContainsPackageOf(successors, Collection.class);
@@ -180,20 +179,18 @@ class PackageGraphTest {
         @Test
         @DisplayName("obtaining incident edges")
         void incidentEdges() {
-            Set<EndpointPair<PackageInfo>> edges = graph.incidentEdges(javaUtilConcurrent);
+            var edges = graph.incidentEdges(javaUtilConcurrent);
             // The primary purpose of these checks is to demonstrate how the edges work.
             // They do not test our code since we simply redirect to Guava's Graph.
-            for (EndpointPair<PackageInfo> edge : edges) {
-                boolean isSource = edge.source()
-                                       .equals(javaUtilConcurrent);
-                boolean isTarget = edge.target()
-                                       .equals(javaUtilConcurrent);
+            for (var edge : edges) {
+                var isSource = edge.source().equals(javaUtilConcurrent);
+                var isTarget = edge.target().equals(javaUtilConcurrent);
                 assertTrue(isSource || isTarget);
             }
         }
 
         @Nested
-        @DisplayName("Return degree")
+        @DisplayName("return degree")
         class Degree {
 
             @Test
@@ -226,7 +223,7 @@ class PackageGraphTest {
         }
 
         @Nested
-        @DisplayName("Check edge")
+        @DisplayName("check edge")
         class Edge {
 
             @Test
@@ -263,13 +260,13 @@ class PackageGraphTest {
         }
 
         static void nodes(Collection<PackageInfo> nodes) {
-            for (PackageInfo node : nodes) {
+            for (var node : nodes) {
                 System.out.println(node);
             }
         }
 
         static void edges(Collection<EndpointPair<PackageInfo>> edges) {
-            for (EndpointPair<PackageInfo> edge : edges) {
+            for (var edge : edges) {
                 System.out.println(edge);
             }
         }

--- a/base/src/test/java/io/spine/reflect/PackageInfoTest.java
+++ b/base/src/test/java/io/spine/reflect/PackageInfoTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.concurrent.Callable;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -46,14 +45,14 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("PackageInfo should")
+@DisplayName("`PackageInfo` should")
 class PackageInfoTest {
 
     private final PackageInfo javaUtil = PackageInfo.of(Collection.class.getPackage());
     private final PackageInfo javaUtilConcurrent = PackageInfo.of(Callable.class.getPackage());
 
     @Test
-    @DisplayName("return package name in toString()")
+    @DisplayName("return package name in `toString()`")
     void stringify() {
         assertEquals(javaUtil.getValue()
                              .getName(),
@@ -61,7 +60,7 @@ class PackageInfoTest {
     }
 
     @Test
-    @DisplayName("have equals() and hashCode()")
+    @DisplayName("have `equals()` and `hashCode()`")
     void hashCodeAndEquals() {
         new EqualsTester()
                 .addEqualityGroup(javaUtil, PackageInfo.of(Collection.class.getPackage()))
@@ -70,17 +69,17 @@ class PackageInfoTest {
     }
 
     @Nested
-    @DisplayName("Obtain Annotation")
+    @DisplayName("obtain `Annotation`")
     class FindAnnotation {
 
         @Test
         @DisplayName("present directly in the package")
         void presentDirectly() {
-            Package pkg = Sub1Class.class.getPackage();
-            ValueAnnotation annotation = assertAnnotated(pkg);
+            var pkg = Sub1Class.class.getPackage();
+            var annotation = assertAnnotated(pkg);
 
-            PackageInfo packageInfo = PackageInfo.of(pkg);
-            Optional<ValueAnnotation> optional = packageInfo.findAnnotation(ValueAnnotation.class);
+            var packageInfo = PackageInfo.of(pkg);
+            var optional = packageInfo.findAnnotation(ValueAnnotation.class);
             assertTrue(optional.isPresent());
             assertEquals(annotation, optional.get());
         }
@@ -88,7 +87,7 @@ class PackageInfoTest {
         @Test
         @DisplayName("present in immediate parent package")
         void fromImmediateParent() {
-            Package pkg = Sub2Class.class.getPackage();
+            var pkg = Sub2Class.class.getPackage();
             assertNotAnnotated(pkg);
             assertFound(pkg);
         }
@@ -96,19 +95,19 @@ class PackageInfoTest {
         @Test
         @DisplayName("present in a parent above")
         void fromParentAbove() {
-            Package pkg = Sub3Class.class.getPackage();
+            var pkg = Sub3Class.class.getPackage();
             assertNotAnnotated(pkg);
             assertFound(pkg);
         }
 
         private void assertFound(Package pkg) {
-            PackageInfo packageInfo = PackageInfo.of(pkg);
-            Optional<ValueAnnotation> optional = packageInfo.findAnnotation(ValueAnnotation.class);
+            var packageInfo = PackageInfo.of(pkg);
+            var optional = packageInfo.findAnnotation(ValueAnnotation.class);
             assertTrue(optional.isPresent());
         }
 
         private ValueAnnotation assertAnnotated(Package pkg) {
-            ValueAnnotation annotation = pkg.getAnnotation(ValueAnnotation.class);
+            var annotation = pkg.getAnnotation(ValueAnnotation.class);
             // Make sure that the package is annotated in the test environment.
             assertNotNull(annotation);
             return annotation;
@@ -119,7 +118,7 @@ class PackageInfoTest {
     @Test
     @DisplayName("tell if there is not annotation")
     void notFound() {
-        Package pkg = LastVisitor.class.getPackage();
+        var pkg = LastVisitor.class.getPackage();
         assertNotAnnotated(pkg);
         assertFalse(PackageInfo.of(pkg)
                                .findAnnotation(ValueAnnotation.class)
@@ -127,7 +126,7 @@ class PackageInfoTest {
     }
 
     private static void assertNotAnnotated(Package pkg) {
-        ValueAnnotation annotation = pkg.getAnnotation(ValueAnnotation.class);
+        var annotation = pkg.getAnnotation(ValueAnnotation.class);
         // Make sure that the package is NOT annotated in the test environment.
         assertNull(annotation);
     }

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.reflect;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.reflect.TypeToken;
 import com.google.common.testing.NullPointerTester;
 import com.google.protobuf.Message;
@@ -37,7 +36,6 @@ import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -53,7 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SuppressWarnings({"SerializableNonStaticInnerClassWithoutSerialVersionUID",
         "SerializableInnerClassWithNonSerializableOuterClass"}) // OK when using TypeToken.
-@DisplayName("Types utility class should")
+@DisplayName("`Types` utility class should")
 class TypesTest extends UtilityClassTest<Types> {
 
     TypesTest() {
@@ -63,16 +61,16 @@ class TypesTest extends UtilityClassTest<Types> {
     @Test
     @DisplayName("create a map type")
     void createMapType() {
-        Type type = mapTypeOf(String.class, Integer.class);
-        Type expectedType = new TypeToken<Map<String, Integer>>(){}.getType();
+        var type = mapTypeOf(String.class, Integer.class);
+        var expectedType = new TypeToken<Map<String, Integer>>(){}.getType();
         assertEquals(expectedType, type);
     }
 
     @Test
     @DisplayName("create a list type")
     void createListType() {
-        Type type = listTypeOf(String.class);
-        Type expectedType = new TypeToken<List<String>>(){}.getType();
+        var type = listTypeOf(String.class);
+        var expectedType = new TypeToken<List<String>>(){}.getType();
         assertEquals(expectedType, type);
     }
 
@@ -99,23 +97,23 @@ class TypesTest extends UtilityClassTest<Types> {
     @Test
     @DisplayName("resolve params of a generic type")
     void resolveTypeParams() {
-        Type type = new TypeToken<Function<String, StringValue>>() {}.getType();
-        ImmutableList<Type> types = resolveArguments(type);
+        var type = new TypeToken<Function<String, StringValue>>() {}.getType();
+        var types = resolveArguments(type);
         assertThat(types).containsExactly(String.class, StringValue.class);
     }
 
     @Test
     @DisplayName("return an empty list when resolving params of a non-parameterized type")
     void resolveRawTypeParams() {
-        Type type = new TypeToken<String>() {}.getType();
-        ImmutableList<Type> types = resolveArguments(type);
+        var type = new TypeToken<String>() {}.getType();
+        var types = resolveArguments(type);
         assertThat(types).isEmpty();
     }
 
     @Test
     @DisplayName("obtain a type argument value from the inheritance chain")
     void getTypeArgument() {
-        Class<?> argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
+        var argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
         assertEquals(argument, Message.class);
     }
 

--- a/base/src/test/java/io/spine/security/InvocationGuardTest.java
+++ b/base/src/test/java/io/spine/security/InvocationGuardTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.function.Executable;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@DisplayName("InvocationGuard should")
+@DisplayName("`InvocationGuard` should")
 class InvocationGuardTest extends UtilityClassTest<InvocationGuard> {
 
     InvocationGuardTest() {
@@ -43,7 +43,7 @@ class InvocationGuardTest extends UtilityClassTest<InvocationGuard> {
     }
 
     @Nested
-    @DisplayName("throw SecurityException")
+    @DisplayName("throw `SecurityException`")
     class Throwing {
 
         @Test
@@ -71,9 +71,9 @@ class InvocationGuardTest extends UtilityClassTest<InvocationGuard> {
     @Test
     @DisplayName("do not throw on allowed class")
     void pass() {
-        String callingClass = CallerProvider.instance()
-                                            .callerClass()
-                                            .getName();
+        var callingClass = CallerProvider.instance()
+                                         .callerClass()
+                                         .getName();
         try {
             InvocationGuard.allowOnly(callingClass);
         } catch (Exception e) {

--- a/base/src/test/java/io/spine/string/AbstractStringifierTest.java
+++ b/base/src/test/java/io/spine/string/AbstractStringifierTest.java
@@ -27,25 +27,21 @@
 package io.spine.string;
 
 import com.google.common.base.Converter;
-import com.google.common.truth.Truth;
 import com.google.common.truth.Truth8;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.Optional;
 
 import static com.google.common.testing.SerializableTester.reserializeAndAssert;
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.Assertions.assertHasPrivateParameterlessCtor;
 import static io.spine.testing.Assertions.assertIllegalArgument;
 import static java.lang.reflect.Modifier.isFinal;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * The abstract base for stringifier tests.
  *
- * @param <T> the type of stringifier objects
+ * @param <T>
+ *         the type of stringifier objects
  */
 abstract class AbstractStringifierTest<T> {
 
@@ -80,10 +76,10 @@ abstract class AbstractStringifierTest<T> {
     @Test
     @DisplayName("convert forward and backward")
     void convert() {
-        T obj = createObject();
+        var obj = createObject();
 
-        final String str = stringifier.convert(obj);
-        final T convertedBack = parser().convert(str);
+        final var str = stringifier.convert(obj);
+        final var convertedBack = parser().convert(str);
 
         assertThat(convertedBack).isEqualTo(obj);
     }
@@ -97,8 +93,8 @@ abstract class AbstractStringifierTest<T> {
     @Test
     @DisplayName("serialize")
     void serialize() {
-        Stringifier<T> expected = stringifier();
-        Stringifier<T> stringifier = reserializeAndAssert(expected);
+        var expected = stringifier();
+        var stringifier = reserializeAndAssert(expected);
         assertThat(stringifier)
                 .isSameInstanceAs(expected);
     }
@@ -106,12 +102,12 @@ abstract class AbstractStringifierTest<T> {
     @Test
     @DisplayName("be registered")
     void isRegistered() {
-        Optional<Stringifier<Object>> found = registry().find(dataClass);
+        var found = registry().find(dataClass);
         Truth8.assertThat(found).isPresent();
     }
 
     @Test
-    @DisplayName("have final class")
+    @DisplayName("be a `final` class")
     void isFinalClass() {
         Class<?> stringifierClass = stringifier.getClass();
         assertThat(isFinal(stringifierClass.getModifiers()))

--- a/base/src/test/java/io/spine/string/DiagsTest.java
+++ b/base/src/test/java/io/spine/string/DiagsTest.java
@@ -52,9 +52,9 @@ class DiagsTest extends UtilityClassTest<Diags> {
     @DisplayName("backtick string representation of an object")
     void backticks() {
         Object anObject = getClass();
-        String backticked = backtick(anObject);
+        var backticked = backtick(anObject);
 
-        StringSubject assertOutput = assertThat(backticked);
+        var assertOutput = assertThat(backticked);
         assertOutput.startsWith("`");
         assertOutput.endsWith("`");
         assertOutput.contains(anObject.toString());
@@ -68,9 +68,9 @@ class DiagsTest extends UtilityClassTest<Diags> {
         @DisplayName("`Iterable`")
         void iterable() {
             List<String> items = ImmutableList.of("one", "two", "tree");
-            String joined = Diags.join(items);
+            var joined = Diags.join(items);
 
-            StringSubject assertOutput = assertThat(joined);
+            var assertOutput = assertThat(joined);
             assertOutput.contains(COMMA_AND_SPACE);
             items.forEach(assertOutput::contains);
         }
@@ -78,9 +78,9 @@ class DiagsTest extends UtilityClassTest<Diags> {
         @Test
         @DisplayName("vararg")
         void varArg() {
-            String joined = Diags.join("uno", "dos", "tres");
+            var joined = Diags.join("uno", "dos", "tres");
 
-            StringSubject assertOutput = assertThat(joined);
+            var assertOutput = assertThat(joined);
             ImmutableList.of("uno", "dos", "tres")
                          .forEach(assertOutput::contains);
         }
@@ -88,9 +88,9 @@ class DiagsTest extends UtilityClassTest<Diags> {
         @Test
         @DisplayName("separating with comma followed by space char")
         void commaThenSpace() {
-            String joined = Diags.join(100, 200, 300);
+            var joined = Diags.join(100, 200, 300);
 
-            StringSubject assertOutput = assertThat(joined);
+            var assertOutput = assertThat(joined);
             assertOutput.contains(COMMA_AND_SPACE);
             ImmutableList.of(100, 200, 300)
                          .forEach(item -> assertOutput.contains(item.toString()));
@@ -107,8 +107,8 @@ class DiagsTest extends UtilityClassTest<Diags> {
         @Test
         @DisplayName("with items")
         void stringEnumeration() {
-            String output = list.stream()
-                                .collect(toEnumeration());
+            var output = list.stream()
+                    .collect(toEnumeration());
 
             assertOutput = assertThat(output);
 
@@ -119,8 +119,8 @@ class DiagsTest extends UtilityClassTest<Diags> {
         @Test
         @DisplayName("with backticked items")
         void backtickedEnumeration() {
-            String output = list.stream()
-                                .collect(toEnumerationBackticked());
+            var output = list.stream()
+                    .collect(toEnumerationBackticked());
 
             assertOutput = assertThat(output);
 

--- a/base/src/test/java/io/spine/string/DurationStringifierTest.java
+++ b/base/src/test/java/io/spine/string/DurationStringifierTest.java
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.protobuf.Durations2.hoursAndMinutes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("DurationStringifier should")
+@DisplayName("`DurationStringifier` should")
 class DurationStringifierTest extends AbstractStringifierTest<Duration> {
 
     DurationStringifierTest() {
@@ -46,10 +46,10 @@ class DurationStringifierTest extends AbstractStringifierTest<Duration> {
     }
 
     @Test
-    @DisplayName("Convert negative duration")
+    @DisplayName("convert negative duration")
     void convertNegativeDuration() {
-        Stringifier<Duration> stringifier = stringifier();
-        Duration negative = hoursAndMinutes(-4, -31);
+        var stringifier = stringifier();
+        var negative = hoursAndMinutes(-4, -31);
         assertEquals(negative, parser().convert(stringifier.convert(negative)));
     }
 }

--- a/base/src/test/java/io/spine/string/Durations2Test.java
+++ b/base/src/test/java/io/spine/string/Durations2Test.java
@@ -80,9 +80,9 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     @Test
     @DisplayName("parse a string")
     void toFromString() {
-        Duration expected = randomDuration();
-        String str = Durations.toString(expected);
-        Duration converted = Durations2.parse(str);
+        var expected = randomDuration();
+        var str = Durations.toString(expected);
+        var converted = Durations2.parse(str);
         assertThat(converted).isEqualTo(expected);
     }
 
@@ -93,16 +93,14 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     @Test
     @DisplayName("convert to Java Time and back")
     void toFromJavaTime() {
-        Duration original = randomDuration();
-        java.time.Duration converted =
-                converter.reverse()
-                         .convert(original);
-        Duration back = converter.convert(converted);
+        var original = randomDuration();
+        var converted = converter.reverse().convert(original);
+        var back = converter.convert(converted);
         assertThat(back).isEqualTo(original);
     }
 
     @Test
-    @DisplayName("have ZERO constant")
+    @DisplayName("have `ZERO` constant")
     void zeroConstant() {
         assertThat(toNanos(ZERO)).isEqualTo(0);
     }
@@ -150,10 +148,10 @@ class Durations2Test extends UtilityClassTest<Durations2> {
         void hoursMinutesSeconds() {
             long hours = 3;
             long minutes = 25;
-            long secondsTotal = hoursToSeconds(hours) + minutesToSeconds(minutes);
-            Duration expected = seconds(secondsTotal);
+            var secondsTotal = hoursToSeconds(hours) + minutesToSeconds(minutes);
+            var expected = seconds(secondsTotal);
 
-            Duration actual = hoursAndMinutes(hours, minutes);
+            var actual = hoursAndMinutes(hours, minutes);
 
             assertEquals(expected, actual);
         }
@@ -168,12 +166,12 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     }
 
     @Nested
-    @DisplayName("Convert a number of hours")
+    @DisplayName("convert a number of hours")
     class HourConversion {
 
         private void test(long hours) {
-            Duration expected = seconds(hoursToSeconds(hours));
-            Duration actual = hours(hours);
+            var expected = seconds(hoursToSeconds(hours));
+            var actual = hours(hours);
             assertThat(actual).isEqualTo(expected);
         }
 
@@ -197,7 +195,7 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     }
 
     @Nested
-    @DisplayName("Fail if")
+    @DisplayName("fail if")
     class MathError {
 
         @Test
@@ -220,7 +218,7 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     }
 
     @Nested
-    @DisplayName("Add")
+    @DisplayName("add")
     class Add {
 
         @Test
@@ -232,7 +230,7 @@ class Durations2Test extends UtilityClassTest<Durations2> {
         @Test
         @DisplayName("`null` returning same instance")
         void sameWithNull() {
-            Duration duration = seconds(525);
+            var duration = seconds(525);
             assertThat(add(duration, null))
                     .isSameInstanceAs(duration);
             assertThat(add(null, duration))
@@ -261,9 +259,9 @@ class Durations2Test extends UtilityClassTest<Durations2> {
         }
 
         private void testAddSeconds(long seconds1, long seconds2) {
-            long secondsTotal = seconds1 + seconds2;
-            Duration sumExpected = seconds(secondsTotal);
-            Duration sumActual = add(seconds(seconds1), seconds(seconds2));
+            var secondsTotal = seconds1 + seconds2;
+            var sumExpected = seconds(secondsTotal);
+            var sumActual = add(seconds(seconds1), seconds(seconds2));
 
             assertThat(sumActual).isEqualTo(sumExpected);
         }
@@ -281,7 +279,7 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     }
 
     @Nested
-    @DisplayName("Verify if `Duration` is")
+    @DisplayName("verify if `Duration` is")
     class Verify {
 
         @Test
@@ -318,7 +316,7 @@ class Durations2Test extends UtilityClassTest<Durations2> {
     }
 
     @Nested
-    @DisplayName("Tell if `Duration` is")
+    @DisplayName("tell if `Duration` is")
     class Compare {
 
         @Test

--- a/base/src/test/java/io/spine/string/EnumStringifierTest.java
+++ b/base/src/test/java/io/spine/string/EnumStringifierTest.java
@@ -26,24 +26,23 @@
 
 package io.spine.string;
 
-import com.google.common.base.Converter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("EnumStringifier should")
+@DisplayName("`EnumStringifier` should")
 class EnumStringifierTest {
 
     @Test
     @DisplayName("convert values to String and back")
     void convert() {
-        EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
-        Converter<String, DayOfWeek> reverse = stringifier.reverse();
+        var stringifier = new EnumStringifier<>(DayOfWeek.class);
+        var reverse = stringifier.reverse();
 
-        for (DayOfWeek value : DayOfWeek.values()) {
-            String str = stringifier.convert(value);
+        for (var value : DayOfWeek.values()) {
+            var str = stringifier.convert(value);
             assertEquals(value, reverse.convert(str));
         }
     }
@@ -51,10 +50,10 @@ class EnumStringifierTest {
     @Test
     @DisplayName("have an identity tied to the name of a processed class")
     void provideDefaultIdentity() {
-        EnumStringifier<DayOfWeek> stringifier = new EnumStringifier<>(DayOfWeek.class);
-        String identity = stringifier.toString();
+        var stringifier = new EnumStringifier<>(DayOfWeek.class);
+        var identity = stringifier.toString();
 
-        String expected = EnumStringifier.identity(DayOfWeek.class);
+        var expected = EnumStringifier.identity(DayOfWeek.class);
         assertThat(identity).isEqualTo(expected);
     }
 

--- a/base/src/test/java/io/spine/string/StringifiersTest.java
+++ b/base/src/test/java/io/spine/string/StringifiersTest.java
@@ -28,8 +28,6 @@ package io.spine.string;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.reflect.TypeToken;
-import com.google.common.truth.StringSubject;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Timestamp;
 import com.google.protobuf.util.Durations;
@@ -43,9 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
@@ -85,7 +81,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("a `String`")
         void aString() {
-            String theString = "some-string";
+            var theString = "some-string";
 
             checkStringifies(theString, theString);
         }
@@ -93,8 +89,8 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("a `Timestamp`")
         void aTimestamp() {
-            Timestamp timestamp = Timestamp.getDefaultInstance();
-            String expected = Timestamps.toString(timestamp);
+            var timestamp = Timestamp.getDefaultInstance();
+            var expected = Timestamps.toString(timestamp);
 
             checkStringifies(timestamp, expected);
         }
@@ -102,8 +98,8 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("a `Duration`")
         void aDuration() {
-            Duration duration = Duration.getDefaultInstance();
-            String expected = Durations.toString(duration);
+            var duration = Duration.getDefaultInstance();
+            var expected = Durations.toString(duration);
 
             checkStringifies(duration, expected);
         }
@@ -117,20 +113,20 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("a Protobuf `Message`")
         void aProtobufMessage() {
-            STaskId id = STaskId.newBuilder()
+            var id = STaskId.newBuilder()
                     .setUuid(newUuid())
                     .build();
-            STask message = STask.newBuilder()
+            var message = STask.newBuilder()
                     .setId(id)
                     .setStatus(DONE)
                     .build();
 
-            String expected = Json.toCompactJson(message);
+            var expected = Json.toCompactJson(message);
             checkStringifies(message, expected);
         }
 
         private void checkStringifies(Object value, String expected) {
-            String conversionResult = Stringifiers.toString(value);
+            var conversionResult = Stringifiers.toString(value);
             assertThat(conversionResult).isEqualTo(expected);
         }
     }
@@ -146,14 +142,14 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @DisplayName("`List`")
         void list() {
             List<Timestamp> stamps = createList();
-            Stringifier<List<Timestamp>> stringifier = newForListOf(Timestamp.class, DELIMITER);
+            var stringifier = newForListOf(Timestamp.class, DELIMITER);
 
-            String out = stringifier.toString(stamps);
+            var out = stringifier.toString(stamps);
 
-            StringSubject assertOut = assertThat(out);
+            var assertOut = assertThat(out);
             assertOut.contains(String.valueOf(DELIMITER));
-            Quoter quoter = Quoter.forLists();
-            for (Timestamp stamp : stamps) {
+            var quoter = Quoter.forLists();
+            for (var stamp : stamps) {
                 assertOut.contains(quoter.quote(Timestamps.toString(stamp)));
             }
         }
@@ -161,16 +157,15 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @Test
         @DisplayName("`Map`")
         void map() {
-            ImmutableMap<Long, Timestamp> stamps = createMap();
-            Stringifier<Map<Long, Timestamp>> stringifier =
-                    newForMapOf(Long.class, Timestamp.class, DELIMITER);
+            var stamps = createMap();
+            var stringifier = newForMapOf(Long.class, Timestamp.class, DELIMITER);
 
-            String out = stringifier.toString(stamps);
-            StringSubject assertOut = assertThat(out);
+            var out = stringifier.toString(stamps);
+            var assertOut = assertThat(out);
             assertOut.contains(String.valueOf(DELIMITER));
 
-            Quoter quoter = Quoter.forMaps();
-            for (Long key : stamps.keySet()) {
+            var quoter = Quoter.forMaps();
+            for (var key : stamps.keySet()) {
                 assertOut.contains(String.valueOf(key));
                 assertOut.contains(quoter.quote(Timestamps.toString(stamps.get(key))));
             }
@@ -178,7 +173,7 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
 
         private ImmutableList<Timestamp> createList() {
             ImmutableList.Builder<Timestamp> builder = ImmutableList.builder();
-            for (int i = 0; i < SIZE; i++) {
+            for (var i = 0; i < SIZE; i++) {
                 builder.add(Time.currentTime());
             }
             return builder.build();
@@ -186,8 +181,8 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
 
         private ImmutableMap<Long, Timestamp> createMap() {
             ImmutableMap.Builder<Long, Timestamp> builder = ImmutableMap.builder();
-            for (int i = 0; i < SIZE; i++) {
-                Timestamp t = Time.currentTime();
+            for (var i = 0; i < SIZE; i++) {
+                var t = Time.currentTime();
                 builder.put((long) i, t);
             }
             return builder.build();
@@ -220,10 +215,10 @@ class StringifiersTest extends UtilityClassTest<Stringifiers> {
         @DisplayName("`List`")
         void list() {
             List<Integer> numbers = ImmutableList.of(100, 200, -300);
-            Stringifier<List<Integer>> stringifier = Stringifiers.newForListOf(Integer.class);
-            String numString = stringifier.toString(numbers);
+            var stringifier = Stringifiers.newForListOf(Integer.class);
+            var numString = stringifier.toString(numbers);
 
-            List<Integer> parsed = stringifier.fromString(numString);
+            var parsed = stringifier.fromString(numString);
             assertThat(parsed).containsExactlyElementsIn(numbers);
         }
     }

--- a/base/src/test/java/io/spine/string/TimestampStringifierTest.java
+++ b/base/src/test/java/io/spine/string/TimestampStringifierTest.java
@@ -34,7 +34,7 @@ import static io.spine.base.Time.currentTime;
 import static io.spine.string.Stringifiers.fromString;
 import static io.spine.testing.Assertions.assertIllegalArgument;
 
-@DisplayName("TimestampStringifier should")
+@DisplayName("`TimestampStringifier` should")
 class TimestampStringifierTest extends AbstractStringifierTest<Timestamp> {
 
     TimestampStringifierTest() {
@@ -47,10 +47,10 @@ class TimestampStringifierTest extends AbstractStringifierTest<Timestamp> {
     }
 
     @Test
-    @DisplayName("Throw IllegalArgumentException when parsing unsupported format")
+    @DisplayName("throw `IllegalArgumentException` when parsing unsupported format")
     void parsingError() {
         // This uses TextFormat printing, for the output which won't be parsable.
-        String time = currentTime().toString();
+        var time = currentTime().toString();
         assertIllegalArgument(() -> fromString(time, Timestamp.class));
     }
 }

--- a/base/src/test/java/io/spine/type/KnownTypesTest.java
+++ b/base/src/test/java/io/spine/type/KnownTypesTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.type;
 
-import com.google.common.truth.StringSubject;
 import com.google.protobuf.Any;
 import com.google.protobuf.Duration;
 import com.google.protobuf.Empty;
@@ -45,7 +44,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
-import java.util.Optional;
 import java.util.Set;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -58,7 +56,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * Tests {@link io.spine.type.KnownTypes}.
  */
-@DisplayName("KnownTypes should")
+@DisplayName("`KnownTypes` should")
 class KnownTypesTest {
 
     private final KnownTypes knownTypes = KnownTypes.instance();
@@ -66,7 +64,7 @@ class KnownTypesTest {
     @Test
     @DisplayName("obtain type URLs of known proto types")
     void typeUrls() {
-        Set<TypeUrl> typeUrls = knownTypes.allUrls();
+        var typeUrls = knownTypes.allUrls();
 
         assertFalse(typeUrls.isEmpty());
     }
@@ -93,8 +91,8 @@ class KnownTypesTest {
         }
 
         private void assertContainsClass(Class<? extends Message> msgClass) {
-            TypeUrl typeUrl = TypeUrl.of(msgClass);
-            ClassName className = knownTypes.classNameOf(typeUrl);
+            var typeUrl = TypeUrl.of(msgClass);
+            var className = knownTypes.classNameOf(typeUrl);
 
             assertThat(className)
                     .isEqualTo(ClassName.of(msgClass));
@@ -103,8 +101,8 @@ class KnownTypesTest {
         @Test
         @DisplayName("nested into other proto types")
         void containNestedProtoTypes() {
-            TypeUrl typeUrl = TypeUrl.from(EntityOption.Kind.getDescriptor());
-            ClassName className = knownTypes.classNameOf(typeUrl);
+            var typeUrl = TypeUrl.from(EntityOption.Kind.getDescriptor());
+            var className = knownTypes.classNameOf(typeUrl);
 
             assertThat(className)
                     .isEqualTo(ClassName.of(EntityOption.Kind.class));
@@ -114,10 +112,10 @@ class KnownTypesTest {
     @Test
     @DisplayName("find type URL by type name")
     void findTypeUrlByName() {
-        TypeUrl typeUrlExpected = TypeUrl.from(StringValue.getDescriptor());
+        var typeUrlExpected = TypeUrl.from(StringValue.getDescriptor());
 
-        Optional<TypeUrl> typeUrlActual = knownTypes.find(typeUrlExpected.toTypeName())
-                                                    .map(Type::url);
+        var typeUrlActual = knownTypes.find(typeUrlExpected.toTypeName())
+                                      .map(Type::url);
         assertTrue(typeUrlActual.isPresent());
         assertEquals(typeUrlExpected, typeUrlActual.get());
     }
@@ -125,13 +123,13 @@ class KnownTypesTest {
     @Test
     @DisplayName("obtain all types under a given package")
     void typesFromPackage() {
-        TypeUrl taskId = TypeUrl.from(KnownTaskId.getDescriptor());
-        TypeUrl taskName = TypeUrl.from(KnownTaskName.getDescriptor());
-        TypeUrl task = TypeUrl.from(KnownTask.getDescriptor());
+        var taskId = TypeUrl.from(KnownTaskId.getDescriptor());
+        var taskName = TypeUrl.from(KnownTaskName.getDescriptor());
+        var task = TypeUrl.from(KnownTask.getDescriptor());
 
-        String packageName = "spine.test.types";
+        var packageName = "spine.test.types";
 
-        Set<TypeUrl> packageTypes = knownTypes.allFromPackage(packageName);
+        var packageTypes = knownTypes.allFromPackage(packageName);
 
         assertThat(packageTypes)
                 .containsAtLeast(taskId, taskName, task);
@@ -140,7 +138,7 @@ class KnownTypesTest {
     @Test
     @DisplayName("return empty set of types for unknown package")
     void emptyTypeSetForUnknownPackage() {
-        String packageName = "com.foo.invalid.package";
+        var packageName = "com.foo.invalid.package";
         Set<?> emptyTypesCollection = knownTypes.allFromPackage(packageName);
         assertNotNull(emptyTypesCollection);
         assertTrue(emptyTypesCollection.isEmpty());
@@ -149,7 +147,7 @@ class KnownTypesTest {
     @Test
     @DisplayName("do not return types by package prefix")
     void noTypesByPrefix() {
-        String prefix = "spine.test.ty"; // "spine.test.types" is a valid package
+        var prefix = "spine.test.ty"; // "spine.test.types" is a valid package
 
         Collection<TypeUrl> packageTypes = knownTypes.allFromPackage(prefix);
         assertTrue(packageTypes.isEmpty());
@@ -158,29 +156,29 @@ class KnownTypesTest {
     @Test
     @DisplayName("throw UnknownTypeException for requesting info on an unknown type")
     void throwOnUnknownType() {
-        TypeUrl unexpectedUrl = TypeUrl.parse("prefix/unexpected.type");
+        var unexpectedUrl = TypeUrl.parse("prefix/unexpected.type");
         assertUnknownType(() -> knownTypes.classNameOf(unexpectedUrl));
     }
 
     @Test
     @DisplayName("print known type URLs in alphabetical order")
     void printingTypeUrls() {
-        String list = knownTypes.printAllTypes();
+        var list = knownTypes.printAllTypes();
 
-        StringSubject assertOutput = assertThat(list);
+        var assertOutput = assertThat(list);
         assertOutput.isNotEmpty();
 
-        String anyUrl = TypeUrl.from(Any.getDescriptor()).value();
-        String timestampUrl = TypeUrl.from(Timestamp.getDescriptor()).value();
-        String durationUrl = TypeUrl.from(Duration.getDescriptor()).value();
+        var anyUrl = TypeUrl.from(Any.getDescriptor()).value();
+        var timestampUrl = TypeUrl.from(Timestamp.getDescriptor()).value();
+        var durationUrl = TypeUrl.from(Duration.getDescriptor()).value();
 
         assertOutput.contains(anyUrl);
         assertOutput.contains(timestampUrl);
         assertOutput.contains(durationUrl);
 
-        int anyIndex = list.indexOf(anyUrl);
-        int durationIndex = list.indexOf(durationUrl);
-        int timestampIndex = list.indexOf(timestampUrl);
+        var anyIndex = list.indexOf(anyUrl);
+        var durationIndex = list.indexOf(durationUrl);
+        var timestampIndex = list.indexOf(timestampUrl);
 
         assertTrue(anyIndex < timestampIndex);
         assertTrue(durationIndex < timestampIndex);

--- a/base/src/test/java/io/spine/type/NestedTypeNameTest.java
+++ b/base/src/test/java/io/spine/type/NestedTypeNameTest.java
@@ -90,12 +90,12 @@ class NestedTypeNameTest {
     @DisplayName("join parts with underscores")
     void printWithUnderscores() {
         Type<?, ?> type = new MessageType(Uri.Protocol.getDescriptor());
-        NestedTypeName name = NestedTypeName.of(type);
+        var name = NestedTypeName.of(type);
         assertThat(name.joinWithUnderscore()).isEqualTo("Uri_Protocol");
     }
 
     private static void check(String expected, Type<?, ?> type) {
-        NestedTypeName name = type.nestedSimpleName();
+        var name = type.nestedSimpleName();
         assertThat(name.value()).isEqualTo(expected);
     }
 }

--- a/base/src/test/java/io/spine/type/TypeNameTest.java
+++ b/base/src/test/java/io/spine/type/TypeNameTest.java
@@ -78,12 +78,10 @@ class TypeNameTest {
     @DisplayName("return simple name if no package")
     void simpleNameIfNoPackage() {
         // A msg type without Protobuf package
-        String name = IfMissingOption.class.getSimpleName();
-        TypeUrl typeUrl = TypeName.of(name)
-                                  .toUrl();
+        var name = IfMissingOption.class.getSimpleName();
+        var typeUrl = TypeName.of(name).toUrl();
 
-        String actual = TypeName.from(typeUrl)
-                                .simpleName();
+        var actual = TypeName.from(typeUrl).simpleName();
 
         assertEquals(name, actual);
     }
@@ -95,7 +93,7 @@ class TypeNameTest {
         @Test
         @DisplayName("for `Message`")
         void forMessage() {
-            TypeName typeName = TypeName.of(StringValue.getDefaultInstance());
+            var typeName = TypeName.of(StringValue.getDefaultInstance());
             assertNotNull(typeName);
             assertEquals(StringValue.class.getSimpleName(), typeName.simpleName());
         }
@@ -103,7 +101,7 @@ class TypeNameTest {
         @Test
         @DisplayName("for Java class")
         void forJavaClass() {
-            TypeName typeName = TypeName.of(StringValue.class);
+            var typeName = TypeName.of(StringValue.class);
             assertNotNull(typeName);
             assertEquals(StringValue.class.getSimpleName(), typeName.simpleName());
         }
@@ -111,7 +109,7 @@ class TypeNameTest {
         @Test
         @DisplayName("by descriptor")
         void byDescriptor() {
-            TypeName typeName = TypeName.from(UInt64Value.getDescriptor());
+            var typeName = TypeName.from(UInt64Value.getDescriptor());
             assertNotNull(typeName);
             assertEquals(UInt64Value.class.getSimpleName(), typeName.simpleName());
         }
@@ -120,8 +118,8 @@ class TypeNameTest {
     @Test
     @DisplayName("provide proto descriptor")
     void descriptorByTypeName() {
-        TypeName typeName = TypeName.of("spine.test.types.KnownTask");
-        Descriptor typeDescriptor = typeName.messageDescriptor();
+        var typeName = TypeName.of("spine.test.types.KnownTask");
+        var typeDescriptor = typeName.messageDescriptor();
         assertNotNull(typeDescriptor);
         assertEquals(typeName.value(), typeDescriptor.getFullName());
     }
@@ -129,7 +127,7 @@ class TypeNameTest {
     @Test
     @DisplayName("fail to find invalid type descriptor")
     void invalidTypeDescriptor() {
-        TypeName invalidTypeName = TypeName.of("no.such.package.InvalidType");
+        var invalidTypeName = TypeName.of("no.such.package.InvalidType");
         assertUnknownType(invalidTypeName::genericDescriptor);
     }
 }

--- a/base/src/test/java/io/spine/type/TypeUrlTest.java
+++ b/base/src/test/java/io/spine/type/TypeUrlTest.java
@@ -55,7 +55,7 @@ import static io.spine.type.TypeUrl.composeTypeUrl;
 import static io.spine.type.TypeUrl.parse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("TypeUrl should")
+@DisplayName("`TypeUrl` should")
 class TypeUrlTest {
 
     /** The descriptor of the type used for the tests. */
@@ -81,14 +81,14 @@ class TypeUrlTest {
     }
 
     @Nested
-    @DisplayName("Create an instance by")
+    @DisplayName("create an instance by")
     class CreateBy {
 
         @Test
         @DisplayName("`Message`")
         void message() {
-            Message msg = toMessage(newUuid());
-            TypeUrl typeUrl = TypeUrl.of(msg);
+            var msg = toMessage(newUuid());
+            var typeUrl = TypeUrl.of(msg);
 
             assertTypeUrl(typeUrl);
         }
@@ -96,8 +96,7 @@ class TypeUrlTest {
         @Test
         @DisplayName("fully-qualified type name")
         void typeName() {
-            TypeUrl typeUrl = TypeName.of(TYPE_NAME)
-                                      .toUrl();
+            var typeUrl = TypeName.of(TYPE_NAME).toUrl();
 
             assertTypeUrl(typeUrl);
         }
@@ -105,7 +104,7 @@ class TypeUrlTest {
         @Test
         @DisplayName("type URL")
         void typeUrl() {
-            TypeUrl typeUrl = TypeUrl.parse(TYPE_URL_VALUE);
+            var typeUrl = TypeUrl.parse(TYPE_URL_VALUE);
 
             assertTypeUrl(typeUrl);
         }
@@ -113,7 +112,7 @@ class TypeUrlTest {
         @Test
         @DisplayName("a descriptor of standard Protobuf type")
         void standardDescriptor() {
-            TypeUrl typeUrl = TypeUrl.from(TYPE_DESCRIPTOR);
+            var typeUrl = TypeUrl.from(TYPE_DESCRIPTOR);
 
             assertTypeUrl(typeUrl);
         }
@@ -121,11 +120,11 @@ class TypeUrlTest {
         @Test
         @DisplayName("a descriptor of Spine type")
         void spineDescriptor() {
-            Descriptors.Descriptor descriptor = EntityOption.getDescriptor();
-            String expectedUrl = composeTypeUrl(TypeUrl.Prefix.SPINE.value(),
-                                                descriptor.getFullName());
+            var descriptor = EntityOption.getDescriptor();
+            var expectedUrl = composeTypeUrl(TypeUrl.Prefix.SPINE.value(),
+                                             descriptor.getFullName());
 
-            TypeUrl typeUrl = TypeUrl.from(descriptor);
+            var typeUrl = TypeUrl.from(descriptor);
 
             assertValue(expectedUrl, typeUrl);
         }
@@ -147,15 +146,15 @@ class TypeUrlTest {
         @Test
         @DisplayName("by a class")
         void byClass() {
-            TypeUrl typeUrl = TypeUrl.of(StringValue.class);
+            var typeUrl = TypeUrl.of(StringValue.class);
 
             assertTypeUrl(typeUrl);
         }
 
         private void assertCreatedTypeUrl(String expectedPrefix, EnumDescriptor descriptor) {
-            String expected = composeTypeUrl(expectedPrefix, descriptor.getFullName());
+            var expected = composeTypeUrl(expectedPrefix, descriptor.getFullName());
 
-            TypeUrl typeUrl = TypeUrl.from(descriptor);
+            var typeUrl = TypeUrl.from(descriptor);
             assertValue(expected, typeUrl);
         }
 
@@ -195,13 +194,13 @@ class TypeUrlTest {
      * is provided by Protobuf, or by the Spine framework.
      */
     @Nested
-    @DisplayName("Allow empty prefix when")
+    @DisplayName("allow empty prefix when")
     class EmptyPrefix {
 
         private TypeUrl noPrefixType;
 
         @Test
-        @DisplayName("parcing type name")
+        @DisplayName("parsing type name")
         void inTypeName() {
             noPrefixType = parse("/package.Type");
             assertEmptyPrefix();
@@ -221,7 +220,7 @@ class TypeUrlTest {
     }
 
     @Nested
-    @DisplayName("Reject")
+    @DisplayName("reject")
     class Reject {
 
         @Test
@@ -239,11 +238,10 @@ class TypeUrlTest {
         @Test
         @DisplayName("invalid URL of a packed message")
         void anyWithInvalidUrl() {
-            Any any = Any.newBuilder()
-                         .setTypeUrl("invalid_type_url")
-                         .build();
-            RuntimeException exception =
-                    assertThrows(RuntimeException.class, () -> TypeUrl.ofEnclosed(any));
+            var any = Any.newBuilder()
+                    .setTypeUrl("invalid_type_url")
+                    .build();
+            var exception = assertThrows(RuntimeException.class, () -> TypeUrl.ofEnclosed(any));
             assertThat(exception.getCause())
                  .isInstanceOf(InvalidProtocolBufferException.class);
         }
@@ -290,7 +288,7 @@ class TypeUrlTest {
     @Test
     @DisplayName("throw `UnknownTypeException` when trying to obtain unknown Java class")
     void unknownJavaClass() {
-        TypeUrl url = TypeUrl.parse("unknown/JavaClass");
+        var url = TypeUrl.parse("unknown/JavaClass");
         assertUnknownType(url::toJavaClass);
     }
 
@@ -320,7 +318,7 @@ class TypeUrlTest {
     @Test
     @DisplayName("have popular type prefixes")
     void prefixEnumeration() {
-        TypeUrl.Prefix spinePrefix = TypeUrl.Prefix.SPINE;
+        var spinePrefix = TypeUrl.Prefix.SPINE;
         assertThat(spinePrefix.toString())
              .ignoringCase()
              .contains(spinePrefix.name());

--- a/base/src/test/java/io/spine/type/UnknownTypeExceptionTest.java
+++ b/base/src/test/java/io/spine/type/UnknownTypeExceptionTest.java
@@ -24,9 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.protobuf.error;
+package io.spine.type;
 
-import io.spine.type.UnknownTypeException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -34,14 +33,14 @@ import static io.spine.base.Identifier.newUuid;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("UnknownTypeException should")
+@DisplayName("`UnknownTypeException` should")
 class UnknownTypeExceptionTest {
 
     @Test
     @DisplayName("have constructor with type name")
     void have_ctor_with_type_name() {
-        String str = newUuid();
-        UnknownTypeException exception = new UnknownTypeException(str);
+        var str = newUuid();
+        var exception = new UnknownTypeException(str);
 
         assertTrue(exception.getMessage()
                             .contains(str));
@@ -50,9 +49,9 @@ class UnknownTypeExceptionTest {
     @Test
     @DisplayName("have constructor with type name and cause")
     void have_ctor_with_type_name_and_cause() {
-        String str = newUuid();
-        RuntimeException cause = new RuntimeException("");
-        UnknownTypeException exception = new UnknownTypeException(str, cause);
+        var str = newUuid();
+        var cause = new RuntimeException("");
+        var exception = new UnknownTypeException(str, cause);
 
         assertTrue(exception.getMessage()
                             .contains(str));

--- a/base/src/test/java/io/spine/util/DuplicatesTest.java
+++ b/base/src/test/java/io/spine/util/DuplicatesTest.java
@@ -27,7 +27,6 @@
 package io.spine.util;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,21 +43,21 @@ class DuplicatesTest extends UtilityClassTest<Duplicates> {
     @Test
     @DisplayName("report duplicates")
     void reportDuplicates() {
-        ImmutableSet<?> duplicates = Duplicates.findIn(ImmutableList.of(1, 2, 3, 1, 42, 42));
+        var duplicates = Duplicates.findIn(ImmutableList.of(1, 2, 3, 1, 42, 42));
         assertThat(duplicates).containsExactly(1, 42);
     }
 
     @Test
     @DisplayName("report if no duplicates")
     void empty() {
-        ImmutableSet<?> duplicates = Duplicates.findIn(ImmutableList.of(1, 2, 3, 42));
+        var duplicates = Duplicates.findIn(ImmutableList.of(1, 2, 3, 42));
         assertThat(duplicates).isEmpty();
     }
 
     @Test
     @DisplayName("report no duplicates in an empty list")
     void emptyInput() {
-        ImmutableSet<?> duplicates = Duplicates.findIn(ImmutableList.of());
+        var duplicates = Duplicates.findIn(ImmutableList.of());
         assertThat(duplicates).isEmpty();
     }
 }

--- a/base/src/test/java/io/spine/util/ExceptionsTest.java
+++ b/base/src/test/java/io/spine/util/ExceptionsTest.java
@@ -41,7 +41,7 @@ import static io.spine.util.Exceptions.unsupported;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("Exceptions utility class should")
+@DisplayName("`Exceptions` utility class should")
 class ExceptionsTest extends UtilityClassTest<Exceptions> {
 
     ExceptionsTest() {
@@ -78,13 +78,12 @@ class ExceptionsTest extends UtilityClassTest<Exceptions> {
         @Test
         @DisplayName("with formatted message")
         void formattedMessage() {
-            String arg1 = getClass().getCanonicalName();
-            long arg2 = 100500L;
-            UnsupportedOperationException exception =
-                    assertThrows(
-                            UnsupportedOperationException.class,
-                            () -> unsupported("%s %d", arg1, arg2));
-            String exceptionMessage = exception.getMessage();
+            var arg1 = getClass().getCanonicalName();
+            var arg2 = 100500L;
+            var exception = assertThrows(
+                    UnsupportedOperationException.class,
+                    () -> unsupported("%s %d", arg1, arg2));
+            var exceptionMessage = exception.getMessage();
             assertTrue(exceptionMessage.contains(arg1));
             assertTrue(exceptionMessage.contains(String.valueOf(arg2)));
         }
@@ -112,7 +111,7 @@ class ExceptionsTest extends UtilityClassTest<Exceptions> {
     }
 
     @Nested
-    @DisplayName("throw IllegalStateException with")
+    @DisplayName("throw `IllegalStateException` with")
     @SuppressWarnings({"ResultOfMethodCallIgnored", "ThrowableNotThrown"})
     class ThrowISE {
 

--- a/base/src/test/java/io/spine/util/Preconditions2Test.java
+++ b/base/src/test/java/io/spine/util/Preconditions2Test.java
@@ -26,7 +26,6 @@
 
 package io.spine.util;
 
-import com.google.common.truth.StringSubject;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.testing.TestValues;
@@ -66,8 +65,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         }
 
         private void assertThrowsWithMessage(String arg, String errorMessage) {
-            IllegalArgumentException exception =
-                    assertIllegalArgument(() -> checkNotEmptyOrBlank(arg, errorMessage));
+            var exception = assertIllegalArgument(() -> checkNotEmptyOrBlank(arg, errorMessage));
             assertThat(exception).hasMessageThat()
                                  .contains(errorMessage);
         }
@@ -77,16 +75,16 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         void nullStr() {
             assertNpe(() -> checkNotEmptyOrBlank(null));
 
-            String errorTemplateBase = randomString();
-            String[] errorArg = { randomString(), randomString() };
-            String errorTemplate = errorTemplateBase + "%s %s";
+            var errorTemplateBase = randomString();
+            var errorArg = new String[]{randomString(), randomString()};
+            var errorTemplate = errorTemplateBase + "%s %s";
 
-            NullPointerException exception = assertThrows(
+            var exception = assertThrows(
                     NullPointerException.class,
                     () -> checkNotEmptyOrBlank(null, errorTemplate, errorArg[0], errorArg[1])
             );
 
-            StringSubject assertExceptionMessage = assertThat(exception).hasMessageThat();
+            var assertExceptionMessage = assertThat(exception).hasMessageThat();
             assertExceptionMessage.contains(errorTemplateBase);
             assertExceptionMessage.contains(errorArg[0]);
             assertExceptionMessage.contains(errorArg[1]);
@@ -114,11 +112,11 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
     }
 
     @Nested
-    @DisplayName("Check that a value is positive")
+    @DisplayName("check that a value is positive")
     class PositiveValue {
 
         private void assertThrowsOn(long value) {
-            IllegalArgumentException exception =
+            var exception =
                     assertThrows(IllegalArgumentException.class,
                                  () -> checkPositive(value));
             assertThat(exception)
@@ -127,7 +125,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         }
 
         private void assertThrowsWithMessage(long value, String errorMessage) {
-            IllegalArgumentException exception =
+            var exception =
                     assertThrows(IllegalArgumentException.class,
                                  () -> checkPositive(value, errorMessage));
             assertThat(exception).hasMessageThat()
@@ -151,7 +149,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         @Test
         @DisplayName("accepting and returning it")
         void positive() {
-            long expected = TestValues.longRandom(1, 100_000);
+            var expected = TestValues.longRandom(1, 100_000);
             assertThat(checkPositive(expected))
                     .isEqualTo(expected);
         }
@@ -164,7 +162,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
     }
 
     @Nested
-    @DisplayName("Check that a message is not in the default state")
+    @DisplayName("check that a message is not in the default state")
     class NotDefaultMessage {
 
         private final Message defaultValue = StringValue.getDefaultInstance();
@@ -180,7 +178,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         void stateChecking() {
             assertIllegalState(() -> checkNotDefaultState(defaultValue));
 
-            IllegalStateException exception =
+            var exception =
                     assertThrows(IllegalStateException.class,
                                  () -> checkNotDefaultState(defaultValue, customErrorMessage));
             assertThat(exception).hasMessageThat()
@@ -191,7 +189,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         @DisplayName("throwing `IllegalArgumentException` for argument checks")
         void argumentChecking() {
             assertIllegalArgument(() -> checkNotDefaultArg(defaultValue));
-            IllegalArgumentException exception =
+            var exception =
                     assertThrows(IllegalArgumentException.class,
                                  () -> checkNotDefaultArg(defaultValue, customErrorMessage));
             assertThat(exception)
@@ -202,7 +200,7 @@ class Preconditions2Test extends UtilityClassTest<Preconditions2> {
         @Test
         @DisplayName("return non-default value on check")
         void returnValue() {
-            StringValue nonDefault = newUuidValue();
+            var nonDefault = newUuidValue();
             assertEquals(nonDefault, checkNotDefaultArg(nonDefault));
             assertEquals(nonDefault, checkNotDefaultArg(nonDefault, customErrorMessage));
             assertEquals(nonDefault, checkNotDefaultState(nonDefault));

--- a/base/src/test/java/io/spine/validate/AnyTest.java
+++ b/base/src/test/java/io/spine/validate/AnyTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.validate;
 
-import com.google.protobuf.Any;
 import io.spine.protobuf.AnyPacker;
 import io.spine.test.validate.RequiredMsgFieldValue;
 import io.spine.test.validate.anyfields.AnyContainer;
@@ -37,43 +36,39 @@ import org.junit.jupiter.api.Test;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 import static io.spine.validate.given.MessageValidatorTestEnv.newStringValue;
 
-@DisplayName(VALIDATION_SHOULD + "when validating google.protobuf.Any")
+@DisplayName(VALIDATION_SHOULD + "when validating `google.protobuf.Any`")
 class AnyTest extends ValidationOfConstraintTest {
 
     @Test
-    @DisplayName("consider Any valid if content is valid")
+    @DisplayName("consider `Any` valid if content is valid")
     void considerAnyValidIfContentIsValid() {
-        RequiredMsgFieldValue value = RequiredMsgFieldValue
-                .newBuilder()
+        var value = RequiredMsgFieldValue.newBuilder()
                 .setValue(newStringValue())
                 .build();
-        Any content = AnyPacker.pack(value);
-        AnyContainer container = AnyContainer
-                .newBuilder()
+        var content = AnyPacker.pack(value);
+        var container = AnyContainer.newBuilder()
                 .setAny(content)
                 .build();
         assertValid(container);
     }
 
     @Test
-    @DisplayName("consider Any not valid if content is not valid")
+    @DisplayName("consider `Any` not valid if content is not valid")
     void considerAnyNotValidIfContentIsNotValid() {
-        RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
-        Any content = AnyPacker.pack(value);
-        AnyContainer container = AnyContainer
-                .newBuilder()
+        var value = RequiredMsgFieldValue.getDefaultInstance();
+        var content = AnyPacker.pack(value);
+        var container = AnyContainer.newBuilder()
                 .setAny(content)
                 .build();
         assertNotValid(container);
     }
 
     @Test
-    @DisplayName("consider Any valid if validation is not required")
+    @DisplayName("consider `Any` valid if validation is not required")
     void considerAnyValidIfValidationIsNotRequired() {
-        RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
-        Any content = AnyPacker.pack(value);
-        UncheckedAnyContainer container = UncheckedAnyContainer
-                .newBuilder()
+        var value = RequiredMsgFieldValue.getDefaultInstance();
+        var content = AnyPacker.pack(value);
+        var container = UncheckedAnyContainer.newBuilder()
                 .setAny(content)
                 .build();
         assertValid(container);
@@ -82,15 +77,13 @@ class AnyTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate recursive messages")
     void validateRecursiveMessages() {
-        RequiredMsgFieldValue value = RequiredMsgFieldValue.getDefaultInstance();
-        Any internalAny = AnyPacker.pack(value);
-        AnyContainer internal = AnyContainer
-                .newBuilder()
+        var value = RequiredMsgFieldValue.getDefaultInstance();
+        var internalAny = AnyPacker.pack(value);
+        var internal = AnyContainer.newBuilder()
                 .setAny(internalAny)
                 .build();
-        Any externalAny = AnyPacker.pack(internal);
-        AnyContainer external = AnyContainer
-                .newBuilder()
+        var externalAny = AnyPacker.pack(internal);
+        var external = AnyContainer.newBuilder()
                 .setAny(externalAny)
                 .build();
         assertNotValid(external);

--- a/base/src/test/java/io/spine/validate/ComparableNumberTest.java
+++ b/base/src/test/java/io/spine/validate/ComparableNumberTest.java
@@ -40,7 +40,7 @@ class ComparableNumberTest {
     @Test
     @DisplayName(NOT_ACCEPT_NULLS)
     void notAcceptNulls() {
-        NullPointerTester tester = new NullPointerTester();
+        var tester = new NullPointerTester();
         tester.testAllPublicConstructors(ComparableNumber.class);
         tester.testAllPublicInstanceMethods(new ComparableNumber(42));
     }
@@ -52,8 +52,8 @@ class ComparableNumberTest {
         @Test
         @DisplayName("between instances")
         void testEquals() {
-            String longMaxValue = String.valueOf(Long.MAX_VALUE);
-            String doubleMinValue = String.valueOf(Double.MIN_VALUE);
+            var longMaxValue = String.valueOf(Long.MAX_VALUE);
+            var doubleMinValue = String.valueOf(Double.MIN_VALUE);
             new EqualsTester()
                     .addEqualityGroup(new NumberText(1L).toNumber(), new NumberText("1").toNumber())
                     .addEqualityGroup(new NumberText(longMaxValue).toNumber(),
@@ -66,10 +66,10 @@ class ComparableNumberTest {
         @Test
         @DisplayName("between instances and primitives")
         void testEqualsBetweenPrimitives() {
-            double doubleValue = Double.MAX_VALUE;
-            int intValue = Integer.MAX_VALUE;
-            float floatValue = Float.MAX_VALUE;
-            long longValue = Long.MAX_VALUE;
+            var doubleValue = Double.MAX_VALUE;
+            var intValue = Integer.MAX_VALUE;
+            var floatValue = Float.MAX_VALUE;
+            var longValue = Long.MAX_VALUE;
 
             new EqualsTester()
                     .addEqualityGroup(doubleValue, new ComparableNumber(doubleValue).doubleValue())

--- a/base/src/test/java/io/spine/validate/EnclosedMessageValidationTest.java
+++ b/base/src/test/java/io/spine/validate/EnclosedMessageValidationTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.validate;
 
-import com.google.protobuf.Message;
 import io.spine.test.validate.EnclosedMessageFieldValue;
 import io.spine.test.validate.EnclosedMessageFieldValueWithCustomInvalidMessage;
 import io.spine.test.validate.EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage;
@@ -35,8 +34,6 @@ import io.spine.test.validate.EnclosedMessageWithoutAnnotationFieldValue;
 import io.spine.test.validate.PatternStringFieldValue;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 import static io.spine.validate.given.MessageValidatorTestEnv.EMAIL;
@@ -52,69 +49,64 @@ class EnclosedMessageValidationTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("find out that enclosed message field is valid")
     void findOutThatEnclosedMessageFieldIsValid() {
-        PatternStringFieldValue enclosedMsg =
-                PatternStringFieldValue.newBuilder()
-                                       .setEmail("valid.email@mail.com")
-                                       .build();
-        EnclosedMessageFieldValue msg = EnclosedMessageFieldValue.newBuilder()
-                                                                 .setOuterMsgField(enclosedMsg)
-                                                                 .build();
+        var enclosedMsg = PatternStringFieldValue.newBuilder()
+                .setEmail("valid.email@mail.com")
+                .build();
+        var msg = EnclosedMessageFieldValue.newBuilder()
+                .setOuterMsgField(enclosedMsg)
+                .build();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("find out enclosed message field is NOT valid")
     void findOutThatEnclosedMessageFieldIsNotValid() {
-        PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
-                                                                     .setEmail("invalid email")
-                                                                     .build();
-        EnclosedMessageFieldValue msg = EnclosedMessageFieldValue.newBuilder()
-                                                                 .setOuterMsgField(enclosedMsg)
-                                                                 .build();
+        var enclosedMsg = PatternStringFieldValue.newBuilder()
+                .setEmail("invalid email")
+                .build();
+        var msg = EnclosedMessageFieldValue.newBuilder()
+                .setOuterMsgField(enclosedMsg)
+                .build();
         assertNotValid(msg);
     }
 
     @Test
     @DisplayName("consider field valid if no valid option is set")
     void considerFieldValidIfNoValidOptionIsSet() {
-        PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
-                                                                     .setEmail("invalid email")
-                                                                     .build();
-        EnclosedMessageWithoutAnnotationFieldValue msg =
-                EnclosedMessageWithoutAnnotationFieldValue.newBuilder()
-                                                          .setOuterMsgField(enclosedMsg)
-                                                          .build();
+        var enclosedMsg = PatternStringFieldValue.newBuilder()
+                .setEmail("invalid email")
+                .build();
+        var msg = EnclosedMessageWithoutAnnotationFieldValue.newBuilder()
+                .setOuterMsgField(enclosedMsg)
+                .build();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("consider field valid if it is not set")
     void considerFieldValidIfItIsNotSet() {
-        EnclosedMessageWithRequiredString msg = EnclosedMessageWithRequiredString.newBuilder()
-                                                                                 .build();
+        var msg = EnclosedMessageWithRequiredString.getDefaultInstance();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("provide valid violations if enclosed message field is not valid")
     void provideValidViolationsIfEnclosedMessageFieldIsNotValid() {
-        PatternStringFieldValue enclosedMsg = PatternStringFieldValue
-                .newBuilder()
+        var enclosedMsg = PatternStringFieldValue.newBuilder()
                 .setEmail("invalid email")
                 .build();
-        EnclosedMessageFieldValue msg = EnclosedMessageFieldValue
-                .newBuilder()
+        var msg = EnclosedMessageFieldValue.newBuilder()
                 .setOuterMsgField(enclosedMsg)
                 .build();
         validate(msg);
 
-        ConstraintViolation violation = singleViolation();
+        var violation = singleViolation();
         assertEquals("The message must have valid properties.", violation.getMsgFormat());
         assertFieldPathIs(violation, OUTER_MSG_FIELD);
-        List<ConstraintViolation> innerViolations = violation.getViolationList();
+        var innerViolations = violation.getViolationList();
         assertEquals(1, innerViolations.size());
 
-        ConstraintViolation innerViolation = innerViolations.get(0);
+        var innerViolation = innerViolations.get(0);
         assertEquals(MATCH_REGEXP_MSG, innerViolation.getMsgFormat());
         assertFieldPathIs(innerViolation, OUTER_MSG_FIELD, EMAIL);
         assertTrue(innerViolation.getViolationList()
@@ -124,23 +116,22 @@ class EnclosedMessageValidationTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("provide custom invalid field message if specified")
     void provideCustomInvalidFieldMessageIfSpecified() {
-        PatternStringFieldValue enclosedMsg = PatternStringFieldValue.newBuilder()
-                                                                     .setEmail("invalid email")
-                                                                     .build();
-        EnclosedMessageFieldValueWithCustomInvalidMessage msg =
-                EnclosedMessageFieldValueWithCustomInvalidMessage.newBuilder()
-                                                                 .setOuterMsgField(enclosedMsg)
-                                                                 .build();
+        var enclosedMsg = PatternStringFieldValue.newBuilder()
+                .setEmail("invalid email")
+                .build();
+        var msg = EnclosedMessageFieldValueWithCustomInvalidMessage.newBuilder()
+                .setOuterMsgField(enclosedMsg)
+                .build();
         validate(msg);
 
-        ConstraintViolation violation = singleViolation();
+        var violation = singleViolation();
         assertEquals("Custom error", violation.getMsgFormat());
     }
 
     @Test
     @DisplayName("ignore custom invalid field message if validation is disabled")
     void ignoreCustomInvalidFieldMessageIfValidationIsDisabled() {
-        Message msg = EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage
+        var msg = EnclosedMessageFieldValueWithoutAnnotationFieldValueWithCustomInvalidMessage
                 .getDefaultInstance();
         assertValid(msg);
     }

--- a/base/src/test/java/io/spine/validate/EntityIdTest.java
+++ b/base/src/test/java/io/spine/validate/EntityIdTest.java
@@ -49,39 +49,39 @@ class EntityIdTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("find out that non-default message is valid")
         void findOutThatMessageEntityIdInCommandIsValid() {
-            EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.newBuilder()
-                                                             .setValue(newStringValue())
-                                                             .build();
+            var msg = EntityIdMsgFieldValue.newBuilder()
+                    .setValue(newStringValue())
+                    .build();
             assertValid(msg);
         }
 
         @Test
         @DisplayName("find out that default message is NOT valid")
         void findOutThatMessageEntityIdInCommandIsNotValid() {
-            EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.getDefaultInstance();
+            var msg = EntityIdMsgFieldValue.getDefaultInstance();
             assertNotValid(msg);
         }
 
         @Test
         @DisplayName("find out that non-empty string is valid")
         void findOutThatStringEntityIdInCommandIsValid() {
-            EntityIdStringFieldValue msg = EntityIdStringFieldValue.newBuilder()
-                                                                   .setValue(newUuid())
-                                                                   .build();
+            var msg = EntityIdStringFieldValue.newBuilder()
+                    .setValue(newUuid())
+                    .build();
             assertValid(msg);
         }
 
         @Test
         @DisplayName("find out that empty string is NOT valid")
         void findOutThatStringEntityIdInCommandIsNotValid() {
-            EntityIdStringFieldValue msg = EntityIdStringFieldValue.getDefaultInstance();
+            var msg = EntityIdStringFieldValue.getDefaultInstance();
             assertNotValid(msg);
         }
 
         @Test
         @DisplayName("provide one valid violation if is not valid")
         void provideOneValidViolationIfEntityIdInCommandIsNotValid() {
-            EntityIdMsgFieldValue msg = EntityIdMsgFieldValue.getDefaultInstance();
+            var msg = EntityIdMsgFieldValue.getDefaultInstance();
             assertSingleViolation(msg, VALUE);
         }
     }
@@ -93,23 +93,23 @@ class EntityIdTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("consider it required by default")
         void requiredByDefault() {
-            AggregateState stateWithDefaultId = AggregateState.getDefaultInstance();
+            var stateWithDefaultId = AggregateState.getDefaultInstance();
             assertNotValid(stateWithDefaultId);
         }
 
         @Test
         @DisplayName("match only the first field named `id` or ending with `_id`")
         void onlyFirstField() {
-            AggregateState onlyEntityIdSet = AggregateState.newBuilder()
-                                                           .setEntityId(newUuid())
-                                                           .build();
+            var onlyEntityIdSet = AggregateState.newBuilder()
+                    .setEntityId(newUuid())
+                    .build();
             assertValid(onlyEntityIdSet);
         }
 
         @Test
         @DisplayName("not consider it (required) if the option is set explicitly set to false")
         void notRequiredIfOptionIsFalse() {
-            ProjectionState stateWithDefaultId = ProjectionState.getDefaultInstance();
+            var stateWithDefaultId = ProjectionState.getDefaultInstance();
             assertValid(stateWithDefaultId);
         }
     }

--- a/base/src/test/java/io/spine/validate/ErrorMessageTest.java
+++ b/base/src/test/java/io/spine/validate/ErrorMessageTest.java
@@ -27,7 +27,6 @@
 package io.spine.validate;
 
 import com.google.protobuf.Descriptors.Descriptor;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.Message;
 import io.spine.option.OptionsProto;
 import io.spine.test.validate.CustomMessageRequiredByteStringFieldValue;
@@ -48,59 +47,53 @@ class ErrorMessageTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("Message field is NOT set")
     void msgNotSet() {
-        CustomMessageRequiredMsgFieldValue invalidMsg =
-                CustomMessageRequiredMsgFieldValue.getDefaultInstance();
+        var invalidMsg = CustomMessageRequiredMsgFieldValue.getDefaultInstance();
         assertErrorMessage(invalidMsg);
     }
 
     @Test
     @DisplayName("String field is NOT set")
     void stringNotSet() {
-        CustomMessageRequiredStringFieldValue invalidMsg =
-                CustomMessageRequiredStringFieldValue.getDefaultInstance();
+        var invalidMsg = CustomMessageRequiredStringFieldValue.getDefaultInstance();
         assertErrorMessage(invalidMsg);
     }
 
     @Test
     @DisplayName("ByteString field is NOT set")
     void bytesNotSet() {
-        CustomMessageRequiredByteStringFieldValue invalidMsg =
-                CustomMessageRequiredByteStringFieldValue.getDefaultInstance();
+        var invalidMsg = CustomMessageRequiredByteStringFieldValue.getDefaultInstance();
         assertErrorMessage(invalidMsg);
     }
 
     @Test
     @DisplayName("repeated field is NOT set")
     void repeatedNotSet() {
-        CustomMessageRequiredRepeatedMsgFieldValue invalidMsg =
-                CustomMessageRequiredRepeatedMsgFieldValue.getDefaultInstance();
+        var invalidMsg = CustomMessageRequiredRepeatedMsgFieldValue.getDefaultInstance();
         assertErrorMessage(invalidMsg);
     }
 
     @Test
     @DisplayName("Enum field is NOT set")
     void enumNotSet() {
-        CustomMessageRequiredEnumFieldValue invalidMsg =
-                CustomMessageRequiredEnumFieldValue.getDefaultInstance();
+        var invalidMsg = CustomMessageRequiredEnumFieldValue.getDefaultInstance();
         assertErrorMessage(invalidMsg);
     }
 
     private void assertErrorMessage(Message message) {
         assertNotValid(message);
-        Descriptor descriptor = message.getDescriptorForType();
-        String expectedErrorMessage = customErrorMessageFrom(descriptor);
+        var descriptor = message.getDescriptorForType();
+        var expectedErrorMessage = customErrorMessageFrom(descriptor);
         checkErrorMessage(expectedErrorMessage);
     }
 
     private void checkErrorMessage(String expectedMessage) {
-        ConstraintViolation constraintViolation = firstViolation();
+        var constraintViolation = firstViolation();
         assertEquals(expectedMessage, constraintViolation.getMsgFormat());
     }
 
     @SuppressWarnings("deprecation") /* Old validation won't migrate to the new error messages. */
     private static String customErrorMessageFrom(Descriptor descriptor) {
-        FieldDescriptor firstFieldDescriptor = descriptor.getFields()
-                                                         .get(0);
+        var firstFieldDescriptor = descriptor.getFields().get(0);
         return firstFieldDescriptor.getOptions()
                                    .getExtension(OptionsProto.ifMissing)
                                    .getMsgFormat();

--- a/base/src/test/java/io/spine/validate/ExternalConstraintOptionsTest.java
+++ b/base/src/test/java/io/spine/validate/ExternalConstraintOptionsTest.java
@@ -26,8 +26,6 @@
 
 package io.spine.validate;
 
-import com.google.common.truth.OptionalSubject;
-import com.google.protobuf.Descriptors;
 import io.spine.code.proto.FieldContext;
 import io.spine.option.OptionsProto;
 import io.spine.test.validation.AField;
@@ -38,20 +36,20 @@ import org.junit.jupiter.api.Test;
 import static com.google.common.truth.Truth8.assertThat;
 import static io.spine.validate.ExternalConstraintOptions.getOptionValue;
 
-@DisplayName("ExternalConstraintOptions should")
+@DisplayName("`ExternalConstraintOptions` should")
 final class ExternalConstraintOptionsTest {
 
     @DisplayName("retrieve option value from context")
     @Test
     void retrieveOptionValue() {
-        FieldContext targetContext = FieldContext.create(AMessage.getDescriptor()
-                                                                 .getFields()
-                                                                 .get(0));
-        Descriptors.FieldDescriptor nameField = AField.getDescriptor()
-                                                      .getFields()
-                                                      .get(0);
-        FieldContext context = targetContext.forChild(nameField);
-        OptionalSubject subject = assertThat(getOptionValue(context, OptionsProto.required));
+        var targetContext = FieldContext.create(AMessage.getDescriptor()
+                                                        .getFields()
+                                                        .get(0));
+        var nameField = AField.getDescriptor()
+                              .getFields()
+                              .get(0);
+        var context = targetContext.forChild(nameField);
+        var subject = assertThat(getOptionValue(context, OptionsProto.required));
         subject.isPresent();
         subject.hasValue(true);
     }
@@ -59,26 +57,27 @@ final class ExternalConstraintOptionsTest {
     @DisplayName("return empty for field without options")
     @Test
     void returnEmptyForNonExistingRuleOptions() {
-        FieldContext targetContext = FieldContext.create(AMessage.getDescriptor()
-                                                                 .getFields()
-                                                                 .get(0));
-        Descriptors.FieldDescriptor addressField = AField.getDescriptor()
-                                                         .getFields()
-                                                         .get(3);
-        FieldContext context = targetContext.forChild(addressField);
+        var targetContext = FieldContext.create(AMessage.getDescriptor()
+                                                        .getFields()
+                                                        .get(0));
+        var addressField = AField.getDescriptor()
+                                 .getFields()
+                                 .get(3);
+        var context = targetContext.forChild(addressField);
         assertThat(getOptionValue(context, OptionsProto.required)).isEmpty();
     }
 
-    @DisplayName("not return `default` option value if the option is not present while the field context does match")
+    @DisplayName("not return `default` option value if the option is not present" +
+            " while the field context does match")
     @Test
     void notReturnOptionIfItIsNotPresentButContextMatch() {
-        FieldContext targetContext = FieldContext.create(AMessage.getDescriptor()
-                                                                 .getFields()
-                                                                 .get(0));
-        Descriptors.FieldDescriptor nameField = AField.getDescriptor()
-                                                      .getFields()
-                                                      .get(0);
-        FieldContext context = targetContext.forChild(nameField);
+        var targetContext = FieldContext.create(AMessage.getDescriptor()
+                                                        .getFields()
+                                                        .get(0));
+        var nameField = AField.getDescriptor()
+                              .getFields()
+                              .get(0);
+        var context = targetContext.forChild(nameField);
         assertThat(getOptionValue(context, OptionsProto.goes)).isEmpty();
     }
 }

--- a/base/src/test/java/io/spine/validate/ExternalConstraintTest.java
+++ b/base/src/test/java/io/spine/validate/ExternalConstraintTest.java
@@ -27,7 +27,6 @@
 package io.spine.validate;
 
 import com.google.common.collect.ImmutableList;
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.test.validation.AMessage;
 import io.spine.test.validation.AnExternalConstraint;
 import org.junit.jupiter.api.DisplayName;
@@ -41,7 +40,7 @@ import static com.google.protobuf.Descriptors.Descriptor;
 import static io.spine.testing.Assertions.assertIllegalState;
 import static io.spine.testing.Assertions.assertNpe;
 
-@DisplayName("ExternalMessageConstraint should")
+@DisplayName("`ExternalMessageConstraint` should")
 final class ExternalConstraintTest {
 
     private static final String PACKAGE = "spine.test.validation";
@@ -52,7 +51,7 @@ final class ExternalConstraintTest {
         return new ExternalMessageConstraint(DESCRIPTOR, ImmutableList.of(path));
     }
 
-    @DisplayName("not allow null")
+    @DisplayName("not allow `null`")
     @Nested
     final class NotAllowNull {
 
@@ -72,20 +71,18 @@ final class ExternalConstraintTest {
     @Test
     @DisplayName("build field descriptors")
     void buildFieldDescriptors() {
-        ExternalMessageConstraint rule = constraint(VALIDATED_FIELD);
+        var rule = constraint(VALIDATED_FIELD);
         assertThat(DESCRIPTOR).isEqualTo(rule.getDescriptor());
-        ImmutableList<FieldDescriptor> targets =
-                rule.getTargets()
-                    .asList();
+        var targets = rule.getTargets().asList();
         assertThat(targets).isNotEmpty();
-        FieldDescriptor fieldDescriptor = targets.get(0);
+        var fieldDescriptor = targets.get(0);
         assertThat(fieldDescriptor.getFullName()).isEqualTo(VALIDATED_FIELD);
     }
 
     @Test
     @DisplayName("build same validation rules")
     void buildSameRules() {
-        ExternalMessageConstraint rule = constraint(VALIDATED_FIELD);
+        var rule = constraint(VALIDATED_FIELD);
         assertThat(rule).isEqualTo(constraint(VALIDATED_FIELD));
     }
 
@@ -103,14 +100,14 @@ final class ExternalConstraintTest {
         @DisplayName("a non-existing field path")
         @Test
         void forNonExistingField() {
-            String fieldName = PACKAGE + ".AMessage.non_existing";
+            var fieldName = PACKAGE + ".AMessage.non_existing";
             assertIllegalState(() -> constraint(fieldName));
         }
 
         @DisplayName("a non-message field path")
         @Test
         void forNonMessageField() {
-            String fieldName = PACKAGE + ".AMessage.non_message_field";
+            var fieldName = PACKAGE + ".AMessage.non_message_field";
             assertIllegalState(() ->  constraint(fieldName));
         }
 

--- a/base/src/test/java/io/spine/validate/ExternalConstraintsTest.java
+++ b/base/src/test/java/io/spine/validate/ExternalConstraintsTest.java
@@ -36,13 +36,13 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("ExternalConstraints should")
+@DisplayName("`ExternalConstraints` should")
 final class ExternalConstraintsTest {
 
     @DisplayName("update rules from types")
     @Test
     void updateRulesFromTypes() {
-        MessageType ruleType = new MessageType(AnExternalConstraint.getDescriptor());
+        var ruleType = new MessageType(AnExternalConstraint.getDescriptor());
         ExternalConstraints.updateFrom(ImmutableSet.of(ruleType));
         assertThat(ExternalConstraints.all()).hasSize(6);
     }
@@ -50,14 +50,14 @@ final class ExternalConstraintsTest {
     @Test
     @DisplayName("tell if an external constraint is defined for a field")
     void checkIfDefined() {
-        boolean defined = ExternalConstraints.isDefinedFor(AMessage.getDescriptor(), "field");
+        var defined = ExternalConstraints.isDefinedFor(AMessage.getDescriptor(), "field");
         assertThat(defined).isTrue();
     }
 
     @Test
     @DisplayName("tell if an external constraint is NOT defined for a field")
     void checkIfNotDefined() {
-        boolean defined = ExternalConstraints.isDefinedFor(Uri.getDescriptor(), "host");
+        var defined = ExternalConstraints.isDefinedFor(Uri.getDescriptor(), "host");
         assertThat(defined).isFalse();
     }
 }

--- a/base/src/test/java/io/spine/validate/FieldAwareMessageTest.java
+++ b/base/src/test/java/io/spine/validate/FieldAwareMessageTest.java
@@ -43,16 +43,16 @@ class FieldAwareMessageTest {
     @Test
     @DisplayName("read values when `readValues` is properly implemented")
     void readValues() {
-        AggregateState msg = FieldAwareMessageTestEnv.msg();
-        FieldAwareMsg state = new FieldAwareMsg(msg);
+        var msg = FieldAwareMessageTestEnv.msg();
+        var state = new FieldAwareMsg(msg);
         assertThat(state.checkFieldsReachable()).isTrue();
     }
 
     @Test
     @DisplayName("fail to read values when `readValues` has implementation issues")
     void failToReadValues() {
-        AggregateState msg = msg();
-        BrokenFieldAware state = new BrokenFieldAware(msg);
+        var msg = msg();
+        var state = new BrokenFieldAware(msg);
         assertIllegalArgument(state::checkFieldsReachable);
     }
 }

--- a/base/src/test/java/io/spine/validate/FieldValueTest.java
+++ b/base/src/test/java/io/spine/validate/FieldValueTest.java
@@ -28,8 +28,6 @@ package io.spine.validate;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.protobuf.Descriptors.EnumValueDescriptor;
-import com.google.protobuf.Syntax;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -48,7 +46,7 @@ import static io.spine.validate.given.GivenField.scalarContext;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("FieldValue should")
+@DisplayName("`FieldValue` should")
 class FieldValueTest {
 
     @Nested
@@ -59,7 +57,7 @@ class FieldValueTest {
         @DisplayName("a map to values")
         void map() {
             Map<String, String> map = ImmutableMap.of(newUuid(), newUuid(), newUuid(), newUuid());
-            FieldValue fieldValue = FieldValue.of(map, mapContext());
+            var fieldValue = FieldValue.of(map, mapContext());
             assertConversion(map.values(), fieldValue);
         }
 
@@ -67,47 +65,44 @@ class FieldValueTest {
         @DisplayName("a repeated field")
         void repeated() {
             List<String> repeated = ImmutableList.of(newUuid(), newUuid());
-            FieldValue fieldValue =
-                    FieldValue.of(repeated, repeatedContext());
+            var fieldValue = FieldValue.of(repeated, repeatedContext());
             assertConversion(repeated, fieldValue);
         }
 
         @Test
         @DisplayName("a scalar field")
         void scalar() {
-            String scalar = newUuid();
-            FieldValue fieldValue = FieldValue.of(scalar, scalarContext());
+            var scalar = newUuid();
+            var fieldValue = FieldValue.of(scalar, scalarContext());
             assertConversion(singletonList(scalar), fieldValue);
         }
     }
 
     @Nested
-    @DisplayName("determine JavaType for")
+    @DisplayName("determine `JavaType` for")
     class DetermineJavaType {
 
         @Test
         @DisplayName("a map")
         void map() {
-            FieldValue mapValue =
-                    FieldValue.of(ImmutableMap.<String, String>of(), mapContext());
+            var mapValue = FieldValue.of(ImmutableMap.<String, String>of(), mapContext());
             assertEquals(STRING, mapValue.javaType());
         }
 
         @Test
         @DisplayName("a repeated")
         void repeated() {
-            FieldValue repeatedValue =
-                    FieldValue.of(ImmutableList.<String>of(), repeatedContext());
+            var repeatedValue = FieldValue.of(ImmutableList.<String>of(), repeatedContext());
             assertEquals(STRING, repeatedValue.javaType());
         }
     }
 
     @Test
-    @DisplayName("handle Enum value")
+    @DisplayName("handle `Enum` value")
     void enumValue() {
-        Syntax rawValue = SYNTAX_PROTO3;
-        FieldValue enumValue = FieldValue.of(rawValue, scalarContext());
-        List<EnumValueDescriptor> expectedValues = singletonList(rawValue.getValueDescriptor());
+        var rawValue = SYNTAX_PROTO3;
+        var enumValue = FieldValue.of(rawValue, scalarContext());
+        var expectedValues = singletonList(rawValue.getValueDescriptor());
         assertConversion(expectedValues, enumValue);
     }
 

--- a/base/src/test/java/io/spine/validate/MessageValueTest.java
+++ b/base/src/test/java/io/spine/validate/MessageValueTest.java
@@ -36,8 +36,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Optional;
-
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.Assertions.assertIllegalArgument;
 import static io.spine.validate.MessageValue.atTopLevel;
@@ -60,33 +58,32 @@ final class MessageValueTest extends ClassTest<MessageValue> {
     }
 
     @Nested
-    @DisplayName("Obtain oneof value")
+    @DisplayName("obtain oneof value")
     class OneofValue {
 
         @Test
         @DisplayName("using the valid descriptor")
         void withValidDescriptor() {
-            boolean boolValue = false;
-            Value message = Value
-                    .newBuilder()
+            var boolValue = false;
+            var message = Value.newBuilder()
                     .setBoolValue(boolValue)
                     .build();
-            MessageValue value = MessageValue.atTopLevel(message);
+            var value = MessageValue.atTopLevel(message);
             assertOneofValue(value, boolValue);
         }
 
         @Test
-        @DisplayName("and throw IAE if a oneof is not declared in a message")
+        @DisplayName("and throw `IAE` if a oneof is not declared in a message")
         void throwOnMissingOneof() {
-            StringValue message = StringValue.getDefaultInstance();
-            MessageValue value = atTopLevel(message);
+            var message = StringValue.getDefaultInstance();
+            var value = atTopLevel(message);
             assertIllegalArgument(() -> value.valueOf(VALUE_ONEOF));
         }
 
         private void assertOneofValue(MessageValue message, Object expectedValue) {
-            Optional<FieldValue> optionalValue = message.valueOf(VALUE_ONEOF);
+            var optionalValue = message.valueOf(VALUE_ONEOF);
             assertTrue(optionalValue.isPresent());
-            FieldValue value = optionalValue.get();
+            var value = optionalValue.get();
             assertThat(value.singleValue())
                     .isEqualTo(expectedValue);
         }

--- a/base/src/test/java/io/spine/validate/NumberConversionTest.java
+++ b/base/src/test/java/io/spine/validate/NumberConversionTest.java
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("NumberConversionChecker should")
+@DisplayName("`NumberConversion` utility should")
 final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
 
     NumberConversionTest() {
@@ -50,40 +50,40 @@ final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
     @Nested
     final class PossibleToConvert {
 
-        @DisplayName("to byte")
+        @DisplayName("to `byte`")
         @Test
         void toByte() {
             assertTrue(NumberConversion.check(Byte.valueOf("1"), Byte.valueOf("2")));
         }
 
-        @DisplayName("to short")
+        @DisplayName("to `short`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#shorts")
         void toShort(Number shortNumber) {
             assertTrue(NumberConversion.check(Short.valueOf("1"), shortNumber));
         }
 
-        @DisplayName("to integer")
+        @DisplayName("to `integer`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#integers")
         void toInteger(Number integerNumber) {
             assertTrue(NumberConversion.check(1, integerNumber));
         }
 
-        @DisplayName("to long")
+        @DisplayName("to `long`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#longs")
         void toLong(Number longNumber) {
             assertTrue(NumberConversion.check(1L, longNumber));
         }
 
-        @DisplayName("to float")
+        @DisplayName("to `float`")
         @Test
         void toFloat() {
             assertTrue(NumberConversion.check(1.0f, 3.14f));
         }
 
-        @DisplayName("to double")
+        @DisplayName("to `double`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#doubles")
         void toDouble(Number doubleNumber) {
@@ -95,42 +95,42 @@ final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
     @Nested
     final class NotPossibleToConvert {
 
-        @DisplayName("it is not possible to convert non-byte to byte")
+        @DisplayName("it is not possible to convert non-`byte` to `byte`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonBytes")
         void byteToOthers(Number nonByte) {
             assertFalse(NumberConversion.check(Byte.valueOf("1"), nonByte));
         }
 
-        @DisplayName("it is not possible to convert non-short to short")
+        @DisplayName("it is not possible to convert non-`short` to `short`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonShorts")
         void shortToOthers(Number nonShort) {
             assertFalse(NumberConversion.check(Short.valueOf("1"), nonShort));
         }
 
-        @DisplayName("it is not possible to convert non-integer to integer")
+        @DisplayName("it is not possible to convert non-`integer` to `integer`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonIntegers")
         void integerToOthers(Number nonInteger) {
             assertFalse(NumberConversion.check(1, nonInteger));
         }
 
-        @DisplayName("it is not possible to convert non-long to long")
+        @DisplayName("it is not possible to convert non-`long` to `long`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonLongs")
         void longToOthers(Number nonLong) {
             assertFalse(NumberConversion.check(1L, nonLong));
         }
 
-        @DisplayName("it is not possible to convert non-float to float")
+        @DisplayName("it is not possible to convert non-`float` to `float`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonFloats")
         void floatToOthers(Number nonFloat) {
             assertFalse(NumberConversion.check(1.0f, nonFloat));
         }
 
-        @DisplayName("it is not possible to convert non-double to double")
+        @DisplayName("it is not possible to convert non-`double` to `double`")
         @ParameterizedTest
         @MethodSource("io.spine.validate.NumberConversionTest#nonDoubles")
         void doubleToOthers(Number nonDouble) {
@@ -138,19 +138,20 @@ final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
         }
     }
 
-    @DisplayName("tell that ComparableNumber instances are automatically unwrapped")
+    @DisplayName("tell that `ComparableNumber` instances are automatically unwrapped")
     @Test
     void comparableNumbersAreUnwrapped() {
-        ComparableNumber number = new ComparableNumber(3);
+        var number = new ComparableNumber(3);
         assertTrue(NumberConversion.check(number, number));
     }
 
-    @DisplayName("tell that BigDecimals are not supported")
+    @DisplayName("tell that `BigDecimal`s are not supported")
     @Test
     void bigDecimalsAreNotSupported() {
         assertFalse(NumberConversion.check(BigDecimal.valueOf(1), 1L));
     }
 
+    @SuppressWarnings("unused") /* Serves as a source for argument values. */
     private static Stream<Number> nonBytes() {
         return Stream.concat(Stream.of(Short.valueOf("1")), nonShorts());
     }
@@ -167,6 +168,7 @@ final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
         return Stream.of(4.0, 5.1f);
     }
 
+    @SuppressWarnings("unused") /* Serves as a source for argument values. */
     private static Stream<Number> nonFloats() {
         return Stream.concat(nonDoubles(), Stream.of(4.0));
     }
@@ -183,6 +185,7 @@ final class NumberConversionTest extends UtilityClassTest<NumberConversion> {
         return Stream.concat(shorts(), Stream.of(2));
     }
 
+    @SuppressWarnings("unused") /* Serves as a source for argument values. */
     private static Stream<Number> longs() {
         return Stream.concat(integers(), Stream.of(3L));
     }

--- a/base/src/test/java/io/spine/validate/NumberRangeTest.java
+++ b/base/src/test/java/io/spine/validate/NumberRangeTest.java
@@ -26,7 +26,6 @@
 
 package io.spine.validate;
 
-import com.google.common.truth.StringSubject;
 import com.google.protobuf.DoubleValue;
 import com.google.protobuf.Message;
 import io.spine.test.validate.InvalidBound;
@@ -51,11 +50,11 @@ import static io.spine.validate.given.MessageValidatorTestEnv.LESS_THAN_MIN;
 import static io.spine.validate.given.MessageValidatorTestEnv.VALUE;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (min) and (max) options and")
+@DisplayName(VALIDATION_SHOULD + "analyze `(min)` and `(max)` options and")
 class NumberRangeTest extends ValidationOfConstraintTest {
 
     @Test
-    @DisplayName("Consider number field is valid if no number options set")
+    @DisplayName("consider number field is valid if no number options set")
     void considerNumberFieldIsValidIfNoNumberOptionsSet() {
         Message nonZeroValue = DoubleValue.newBuilder()
                                           .setValue(5)
@@ -152,10 +151,9 @@ class NumberRangeTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("not allow fraction boundaries for integer fields")
     void fractionsBounds() {
-        IllegalStateException exception =
-                assertThrows(IllegalStateException.class,
+        var exception = assertThrows(IllegalStateException.class,
                              () -> validate(InvalidBound.getDefaultInstance()));
-        StringSubject assertMessage = assertThat(exception).hasMessageThat();
+        var assertMessage = assertThat(exception).hasMessageThat();
         assertMessage
                 .contains("2.71");
         assertMessage
@@ -164,12 +162,10 @@ class NumberRangeTest extends ValidationOfConstraintTest {
 
     private void minNumberTest(double value, boolean inclusive, boolean valid) {
         Message msg = inclusive
-                      ? MinInclusiveNumberFieldValue
-                              .newBuilder()
+                      ? MinInclusiveNumberFieldValue.newBuilder()
                               .setValue(value)
                               .build()
-                      : MinExclusiveNumberFieldValue
-                              .newBuilder()
+                      : MinExclusiveNumberFieldValue.newBuilder()
                               .setValue(value)
                               .build();
         validate(msg);
@@ -178,12 +174,10 @@ class NumberRangeTest extends ValidationOfConstraintTest {
 
     private void maxNumberTest(double value, boolean inclusive, boolean valid) {
         Message msg = inclusive
-                      ? MaxInclusiveNumberFieldValue
-                              .newBuilder()
+                      ? MaxInclusiveNumberFieldValue.newBuilder()
                               .setValue(value)
                               .build()
-                      : MaxExclusiveNumberFieldValue
-                              .newBuilder()
+                      : MaxExclusiveNumberFieldValue.newBuilder()
                               .setValue(value)
                               .build();
         validate(msg);

--- a/base/src/test/java/io/spine/validate/NumberTextTest.java
+++ b/base/src/test/java/io/spine/validate/NumberTextTest.java
@@ -47,7 +47,7 @@ class NumberTextTest {
     @Test
     @DisplayName("have a correct equality relationship")
     void testEquals() {
-        EqualsTester equalsTester = new EqualsTester();
+        var equalsTester = new EqualsTester();
         equalsTester.addEqualityGroup(new NumberText("0.0"), new NumberText("0.0"))
                     .addEqualityGroup(new NumberText("0.1"), new NumberText("0.10"))
                     .testEquals();
@@ -56,42 +56,42 @@ class NumberTextTest {
     @Test
     @DisplayName("recognize that two numbers have different types")
     void differentTypeTest() {
-        String plainNumber = "1";
-        String numberWithDecimalPart = "1.0";
-        NumberText plain = new NumberText(plainNumber);
-        NumberText withDecimal = new NumberText(numberWithDecimalPart);
+        var plainNumber = "1";
+        var numberWithDecimalPart = "1.0";
+        var plain = new NumberText(plainNumber);
+        var withDecimal = new NumberText(numberWithDecimalPart);
         assertFalse(plain.isOfSameType(withDecimal));
     }
 
     @Test
     @DisplayName("recognize that two numbers are of the same types")
     void sameTypeTest() {
-        String fitsIntoByte = "4";
-        String maxInteger = String.valueOf(Integer.MAX_VALUE);
-        NumberText small = new NumberText(fitsIntoByte);
-        NumberText large = new NumberText(maxInteger);
+        var fitsIntoByte = "4";
+        var maxInteger = String.valueOf(Integer.MAX_VALUE);
+        var small = new NumberText(fitsIntoByte);
+        var large = new NumberText(maxInteger);
         assertTrue(small.isOfSameType(large));
     }
 
     @Test
     @DisplayName("compare values")
     void comparisonTest() {
-        String smallerValue = "0.1";
-        String largerValue = "15";
-        NumberText smaller = new NumberText(smallerValue);
-        NumberText larger = new NumberText(largerValue);
-        int comparison = smaller.toNumber()
+        var smallerValue = "0.1";
+        var largerValue = "15";
+        var smaller = new NumberText(smallerValue);
+        var larger = new NumberText(largerValue);
+        var comparison = smaller.toNumber()
                                 .compareTo(larger.toNumber());
         assertTrue(comparison < 0);
     }
 
     @Test
-    @DisplayName("store numbers that do not fit into int")
+    @DisplayName("store numbers that do not fit into `int`")
     void testDoesNotFitIntoInt() {
-        String longMaxValue = String.valueOf(Long.MAX_VALUE);
-        String lessThanLongMaxValue = String.valueOf(Long.MAX_VALUE - 1);
-        NumberText larger = new NumberText(longMaxValue);
-        NumberText smaller = new NumberText(lessThanLongMaxValue);
+        var longMaxValue = String.valueOf(Long.MAX_VALUE);
+        var lessThanLongMaxValue = String.valueOf(Long.MAX_VALUE - 1);
+        var larger = new NumberText(longMaxValue);
+        var smaller = new NumberText(lessThanLongMaxValue);
         assertEquals(1, larger.toNumber()
                               .compareTo(smaller.toNumber()));
     }
@@ -100,7 +100,7 @@ class NumberTextTest {
     @MethodSource("textNumbers")
     @DisplayName("stringify values")
     void toStringTest(Number input, String expected) {
-        NumberText text = new NumberText(input);
+        var text = new NumberText(input);
         assertEquals(expected, text.toString());
     }
 

--- a/base/src/test/java/io/spine/validate/OneofTest.java
+++ b/base/src/test/java/io/spine/validate/OneofTest.java
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.Test;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 
-@DisplayName(VALIDATION_SHOULD + "consider oneof")
+@DisplayName(VALIDATION_SHOULD + "consider `oneof`")
 final class OneofTest extends ValidationOfConstraintTest {
 
     @DisplayName("valid if")
@@ -48,8 +48,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("a required field is set to a non-default value")
         void requiredFieldIsNotDefault() {
-            OneofWithRequiredFields requiredIsSet = OneofWithRequiredFields
-                    .newBuilder()
+            var requiredIsSet = OneofWithRequiredFields.newBuilder()
                     .setFirst(newUuid())
                     .build();
             assertValid(requiredIsSet);
@@ -58,8 +57,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("all required fields are set")
         void allRequiredFieldsAreNotDefault() {
-            OneofAndOtherAreRequired requiredAreSet = OneofAndOtherAreRequired
-                    .newBuilder()
+            var requiredAreSet = OneofAndOtherAreRequired.newBuilder()
                     .setSecond(newUuid())
                     .setThird(newUuid())
                     .build();
@@ -69,8 +67,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("an optional field is set to the default value")
         void optionalIsDefault() {
-            OneofWithOptionalFields optionalIsDefault = OneofWithOptionalFields
-                    .newBuilder()
+            var optionalIsDefault = OneofWithOptionalFields.newBuilder()
                     .setFirst("")
                     .build();
             assertValid(optionalIsDefault);
@@ -80,8 +77,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("an optional field is properly validated")
         void optionalIsValid() {
-            OneofWithValidation validFieldSet = OneofWithValidation
-                    .newBuilder()
+            var validFieldSet = OneofWithValidation.newBuilder()
                     .setWithValidation("valid")
                     .build();
             assertValid(validFieldSet);
@@ -96,8 +92,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("an optional field without validation is set")
         void optionalFieldWithoutValidationSet() {
-            OneofWithValidation fieldWithoutValidationSet = OneofWithValidation
-                    .newBuilder()
+            var fieldWithoutValidationSet = OneofWithValidation.newBuilder()
                     .setNoValidation("does not require validation")
                     .build();
             assertValid(fieldWithoutValidationSet);
@@ -106,8 +101,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("a required field without validation is set")
         void requiredNonValidatedFieldSet() {
-            RequiredOneofWithValidation requiredWithoutValidationSet = RequiredOneofWithValidation
-                    .newBuilder()
+            var requiredWithoutValidationSet = RequiredOneofWithValidation.newBuilder()
                     .setRawValue("o_0")
                     .build();
             assertValid(requiredWithoutValidationSet);
@@ -116,8 +110,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("a required field with validation is set")
         void requiredValidatedFieldSet() {
-            RequiredOneofWithValidation requiredWithValidationSet = RequiredOneofWithValidation
-                    .newBuilder()
+            var requiredWithValidationSet = RequiredOneofWithValidation.newBuilder()
                     .setValidValue("aaa1111")
                     .build();
             assertValid(requiredWithValidationSet);
@@ -131,18 +124,16 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("a required field is set to the default value")
         void requiredFieldIsDefault() {
-            OneofWithRequiredFields requiredIsDefault = OneofWithRequiredFields
-                    .newBuilder()
+            var requiredIsDefault = OneofWithRequiredFields.newBuilder()
                     .setFirst("")
                     .build();
             assertNotValid(requiredIsDefault, false);
         }
 
         @Test
-        @DisplayName("a field within oneof is not valid")
+        @DisplayName("a field within `oneof` is not valid")
         void fieldIsNotValid() {
-            OneofWithValidation validFieldSet = OneofWithValidation
-                    .newBuilder()
+            var validFieldSet = OneofWithValidation.newBuilder()
                     .setWithValidation("   ")
                     .build();
             assertNotValid(validFieldSet);
@@ -157,8 +148,7 @@ final class OneofTest extends ValidationOfConstraintTest {
         @Test
         @DisplayName("a required field is not valid")
         void requiredFieldIsNotValid() {
-            RequiredOneofWithValidation requiredWithValidationSet = RequiredOneofWithValidation
-                    .newBuilder()
+            var requiredWithValidationSet = RequiredOneofWithValidation.newBuilder()
                     .setValidValue("###")
                     .build();
             assertNotValid(requiredWithValidationSet);

--- a/base/src/test/java/io/spine/validate/ValidateTest.java
+++ b/base/src/test/java/io/spine/validate/ValidateTest.java
@@ -43,8 +43,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static com.google.common.truth.Truth.assertThat;
 import static io.spine.validate.Validate.checkValidChange;
 import static io.spine.validate.Validate.violationsOf;
@@ -70,9 +68,9 @@ class ValidateTest extends UtilityClassTest<Validate> {
     @DisplayName("run custom validation " +
             "and obtain no violations if there are no custom constraints")
     void customValidation() {
-        RequiredMsgFieldValue message = RequiredMsgFieldValue.getDefaultInstance();
-        List<ConstraintViolation> violations = violationsOf(message);
-        List<ConstraintViolation> customViolations = violationsOfCustomConstraints(message);
+        var message = RequiredMsgFieldValue.getDefaultInstance();
+        var violations = violationsOf(message);
+        var customViolations = violationsOfCustomConstraints(message);
         assertThat(violations).hasSize(1);
         assertThat(customViolations).isEmpty();
     }
@@ -80,34 +78,30 @@ class ValidateTest extends UtilityClassTest<Validate> {
     @Test
     @DisplayName("format message from constraint violation")
     void formatMessageFromConstraintViolation() {
-        ConstraintViolation violation = ConstraintViolation
-                .newBuilder()
+        var violation = ConstraintViolation.newBuilder()
                 .setMsgFormat("test %s test %s")
                 .addParam("1")
                 .addParam("2")
                 .build();
-        String formatted = ViolationText.of(violation)
-                                        .toString();
+        var formatted = ViolationText.of(violation).toString();
 
         assertEquals("test 1 test 2", formatted);
     }
 
     @MuteLogging
     @Nested
-    @DisplayName("test message changes upon (set_once) and")
+    @DisplayName("test message changes upon `(set_once)` and")
     class SetOnce {
 
         private static final String BIRTHPLACE = "birthplace";
 
         @Test
-        @DisplayName("throw ValidationException if a (set_once) field is overridden")
+        @DisplayName("throw `ValidationException` if a `(set_once)` field is overridden")
         void reportIllegalChanges() {
-            Passport oldValue = Passport
-                    .newBuilder()
+            var oldValue = Passport.newBuilder()
                     .setBirthplace("Kyiv")
                     .build();
-            Passport newValue = Passport
-                    .newBuilder()
+            var newValue = Passport.newBuilder()
                     .setBirthplace("Kharkiv")
                     .build();
             checkViolated(oldValue, newValue, BIRTHPLACE);
@@ -116,25 +110,23 @@ class ValidateTest extends UtilityClassTest<Validate> {
         @Test
         @DisplayName("ignore ID changes by default")
         void reportIdChanges() {
-            Passport oldValue = Passport
-                    .newBuilder()
+            var oldValue = Passport.newBuilder()
                     .setId("MT 000100010001")
                     .build();
-            Passport newValue = Passport
-                    .newBuilder()
+            var newValue = Passport.newBuilder()
                     .setId("JC 424242424242")
                     .build();
             checkValidChange(oldValue, newValue);
         }
 
         @Test
-        @DisplayName("throw ValidationException with several violations")
+        @DisplayName("throw `ValidationException` with several violations")
         void reportManyFields() {
-            Passport oldValue = Passport.newBuilder()
+            var oldValue = Passport.newBuilder()
                     .setId("MT 111")
                     .setBirthplace("London")
                     .build();
-            Passport newValue = Passport.newBuilder()
+            var newValue = Passport.newBuilder()
                     .setId("JC 424")
                     .setBirthplace("Edinburgh")
                     .build();
@@ -144,41 +136,40 @@ class ValidateTest extends UtilityClassTest<Validate> {
         @Test
         @DisplayName("allow overriding repeated fields")
         void ignoreRepeated() {
-            Passport oldValue = Passport.newBuilder()
+            var oldValue = Passport.newBuilder()
                     .addPhoto(Url.newBuilder().setSpec("foo.bar/pic1").build())
                     .build();
-            Passport newValue = Passport.getDefaultInstance();
+            var newValue = Passport.getDefaultInstance();
             checkValidChange(oldValue, newValue);
         }
 
         @Test
-        @DisplayName("allow overriding if (set_once) = false")
+        @DisplayName("allow overriding if `(set_once) = false`")
         void ignoreNonSetOnce() {
-            Passport oldValue = Passport.getDefaultInstance();
-            PersonName name = PersonName.newBuilder()
+            var oldValue = Passport.getDefaultInstance();
+            var name = PersonName.newBuilder()
                     .setGivenName("John")
                     .setFamilyName("Doe")
                     .build();
-            Passport newValue = Passport.newBuilder()
+            var newValue = Passport.newBuilder()
                     .setName(name)
                     .build();
             checkValidChange(oldValue, newValue);
         }
 
         private void checkViolated(Passport oldValue, Passport newValue, String... fields) {
-            ValidationException exception =
-                    assertThrows(ValidationException.class,
+            var exception = assertThrows(ValidationException.class,
                                  () -> checkValidChange(oldValue, newValue));
-            List<ConstraintViolation> violations = exception.getConstraintViolations();
+            var violations = exception.getConstraintViolations();
             assertThat(violations).hasSize(fields.length);
 
-            for (int i = 0; i < fields.length; i++) {
-                ConstraintViolation violation = violations.get(i);
-                String field = fields[i];
+            for (var i = 0; i < fields.length; i++) {
+                var violation = violations.get(i);
+                var field = fields[i];
 
                 assertThat(violation.getMsgFormat()).contains("(set_once)");
 
-                String expectedTypeName = TypeName.of(newValue).value();
+                var expectedTypeName = TypeName.of(newValue).value();
                 assertThat(violation.getTypeName()).contains(expectedTypeName);
 
                 assertThat(violation.getFieldPath())

--- a/base/src/test/java/io/spine/validate/ValidatingOptionFactoryTest.java
+++ b/base/src/test/java/io/spine/validate/ValidatingOptionFactoryTest.java
@@ -69,7 +69,7 @@ class ValidatingOptionFactoryTest {
     }
 
     private void assetEmpty(Function<ValidatingOptionFactory, Set<?>> typeSelector) {
-        Set<?> result = typeSelector.apply(options);
+        var result = typeSelector.apply(options);
         assertThat(result).isEmpty();
     }
 }

--- a/base/src/test/java/io/spine/validate/ValidationExceptionTest.java
+++ b/base/src/test/java/io/spine/validate/ValidationExceptionTest.java
@@ -32,23 +32,21 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("ValidationException should")
+@DisplayName("`ValidationException` should")
 class ValidationExceptionTest {
 
     @Test
-    @DisplayName("provide ValidationError")
+    @DisplayName("provide `ValidationError`")
     void error() {
-        ImmutableList<ConstraintViolation> violations =
-                ImmutableList.of(ConstraintViolation
-                                         .newBuilder()
+        var violations =
+                ImmutableList.of(ConstraintViolation.newBuilder()
                                          .setTypeName("example.org/example.Type")
                                          .setMsgFormat("Test error")
                                          .build());
-        ValidationException exception = new ValidationException(violations);
+        var exception = new ValidationException(violations);
         assertThat(exception.asValidationError())
-             .isEqualTo(ValidationError
-                                .newBuilder()
-                                .addAllConstraintViolation(violations)
-                                .build());
+                .isEqualTo(ValidationError.newBuilder()
+                                   .addAllConstraintViolation(violations)
+                                   .build());
     }
 }

--- a/base/src/test/java/io/spine/validate/ValidationOfConstraintTest.java
+++ b/base/src/test/java/io/spine/validate/ValidationOfConstraintTest.java
@@ -86,7 +86,7 @@ public abstract class ValidationOfConstraintTest {
                                          boolean checkFieldPath) {
         assertThat(violations)
                 .isNotEmpty();
-        for (ConstraintViolation violation : violations) {
+        for (var violation : violations) {
             assertHasCorrectFormat(violation);
             if (checkFieldPath) {
                 assertHasFieldPath(violation);
@@ -95,10 +95,9 @@ public abstract class ValidationOfConstraintTest {
     }
 
     private static void assertHasCorrectFormat(ConstraintViolation violation) {
-        String format = violation.getMsgFormat();
+        var format = violation.getMsgFormat();
         assertFalse(format.isEmpty());
-        boolean noParams = violation.getParamList()
-                                    .isEmpty();
+        var noParams = violation.getParamList().isEmpty();
         if (noParams) {
             assertThat(format)
                     .doesNotContain("%s");
@@ -124,9 +123,9 @@ public abstract class ValidationOfConstraintTest {
 
     /** Checks that a message is not valid and has a single violation. */
     protected void assertSingleViolation(String expectedErrMsg, String invalidFieldName) {
-        ConstraintViolation violation = firstViolation();
-        String actualErrorMessage = format(violation.getMsgFormat(), violation.getParamList()
-                                                                              .toArray());
+        var violation = firstViolation();
+        var actualErrorMessage = format(violation.getMsgFormat(), violation.getParamList()
+                                                                           .toArray());
         assertThat(actualErrorMessage)
                 .isEqualTo(expectedErrMsg);
         assertFieldPathIs(violation, invalidFieldName);

--- a/base/src/test/java/io/spine/validate/diags/ViolationTextTest.java
+++ b/base/src/test/java/io/spine/validate/diags/ViolationTextTest.java
@@ -28,7 +28,6 @@ package io.spine.validate.diags;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.testing.NullPointerTester;
-import com.google.common.truth.StringSubject;
 import com.google.protobuf.Timestamp;
 import io.spine.base.Field;
 import io.spine.type.TypeName;
@@ -38,11 +37,11 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("ViolationText should")
+@DisplayName("`ViolationText` should")
 class ViolationTextTest {
 
     @Test
-    @DisplayName("not accept null violations")
+    @DisplayName("not accept `null` violations")
     void nullTolerance() {
         new NullPointerTester()
                 .testAllPublicStaticMethods(ViolationText.class);
@@ -51,24 +50,22 @@ class ViolationTextTest {
     @Test
     @DisplayName("include type info in the violation text")
     void includeType() {
-        TypeName type = TypeName.of(Timestamp.class);
-        ConstraintViolation violation = ConstraintViolation
-                .newBuilder()
+        var type = TypeName.of(Timestamp.class);
+        var violation = ConstraintViolation.newBuilder()
                 .setTypeName(type.value())
                 .build();
-        ViolationText text = ViolationText.of(violation);
+        var text = ViolationText.of(violation);
         assertThat(text.toString()).contains(type.value());
     }
 
     @Test
     @DisplayName("include field info in the violation text")
     void includeField() {
-        Field field = Field.parse("msg.foo.bar");
-        ConstraintViolation violation = ConstraintViolation
-                .newBuilder()
+        var field = Field.parse("msg.foo.bar");
+        var violation = ConstraintViolation.newBuilder()
                 .setFieldPath(field.path())
                 .build();
-        ViolationText text = ViolationText.of(violation);
+        var text = ViolationText.of(violation);
         assertThat(text.toString())
                 .contains(field.toString());
     }
@@ -76,16 +73,14 @@ class ViolationTextTest {
     @Test
     @DisplayName("compile tests for many violations into one")
     void compileManyTexts() {
-        ConstraintViolation first = ConstraintViolation
-                .newBuilder()
+        var first = ConstraintViolation.newBuilder()
                 .setMsgFormat("Errored with a message")
                 .build();
-        ConstraintViolation second = ConstraintViolation
-                .newBuilder()
+        var second = ConstraintViolation.newBuilder()
                 .setMsgFormat("Messaged with an error")
                 .build();
-        String text = ViolationText.ofAll(ImmutableList.of(first, second));
-        StringSubject assertText = assertThat(text);
+        var text = ViolationText.ofAll(ImmutableList.of(first, second));
+        var assertText = assertThat(text);
         assertText.contains(ViolationText.of(first).toString());
         assertText.contains(ViolationText.of(second).toString());
     }

--- a/base/src/test/java/io/spine/validate/given/FieldAwareMessageTestEnv.java
+++ b/base/src/test/java/io/spine/validate/given/FieldAwareMessageTestEnv.java
@@ -314,7 +314,7 @@ public final class FieldAwareMessageTestEnv {
 
         @Override
         public Object readValue(Descriptors.FieldDescriptor field) {
-            int index = field.getIndex();
+            var index = field.getIndex();
             switch (index) {
                 case 0:
                     return getEntityId();

--- a/base/src/test/java/io/spine/validate/given/GivenField.java
+++ b/base/src/test/java/io/spine/validate/given/GivenField.java
@@ -26,7 +26,6 @@
 
 package io.spine.validate.given;
 
-import com.google.protobuf.Descriptors.FieldDescriptor;
 import io.spine.code.proto.FieldContext;
 import io.spine.test.validate.field.Message;
 
@@ -37,20 +36,20 @@ public class GivenField {
     }
 
     public static FieldContext mapContext() {
-        FieldDescriptor mapField = Message.getDescriptor()
-                                          .findFieldByName("map");
+        var mapField = Message.getDescriptor()
+                              .findFieldByName("map");
         return FieldContext.create(mapField);
     }
 
     public static FieldContext repeatedContext() {
-        FieldDescriptor repeatedField = Message.getDescriptor()
-                                               .findFieldByName("repeated");
+        var repeatedField = Message.getDescriptor()
+                                   .findFieldByName("repeated");
         return FieldContext.create(repeatedField);
     }
 
     public static FieldContext scalarContext() {
-        FieldDescriptor scalarField = Message.getDescriptor()
-                                             .findFieldByName("scalar");
+        var scalarField = Message.getDescriptor()
+                                 .findFieldByName("scalar");
         return FieldContext.create(scalarField);
     }
 }

--- a/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
+++ b/base/src/test/java/io/spine/validate/given/MessageValidatorTestEnv.java
@@ -27,9 +27,7 @@
 package io.spine.validate.given;
 
 import com.google.protobuf.ByteString;
-import com.google.protobuf.ProtocolStringList;
 import com.google.protobuf.StringValue;
-import io.spine.base.FieldPath;
 import io.spine.validate.ConstraintViolation;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -59,8 +57,8 @@ public class MessageValidatorTestEnv {
     }
 
     public static void assertFieldPathIs(ConstraintViolation violation, String... expectedFields) {
-        FieldPath path = violation.getFieldPath();
-        ProtocolStringList actualFields = path.getFieldNameList();
+        var path = violation.getFieldPath();
+        var actualFields = path.getFieldNameList();
         assertThat(actualFields)
                 .containsExactlyElementsIn(expectedFields);
     }
@@ -70,7 +68,7 @@ public class MessageValidatorTestEnv {
     }
 
     public static ByteString newByteString() {
-        ByteString bytes = ByteString.copyFromUtf8(newUuid());
+        var bytes = ByteString.copyFromUtf8(newUuid());
         return bytes;
     }
 }

--- a/base/src/test/java/io/spine/validate/option/DistinctTest.java
+++ b/base/src/test/java/io/spine/validate/option/DistinctTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (distinct) option and")
+@DisplayName(VALIDATION_SHOULD + "analyze `(distinct)` option and")
 final class DistinctTest extends ValidationOfConstraintTest {
 
     @Test
@@ -50,8 +50,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void enums() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addEnums(DistinctValues.Planet.EARTH)
                     .addEnums(DistinctValues.Planet.MARS)
                     .addEnums(DistinctValues.Planet.JUPITER)
@@ -61,8 +60,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void ints() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addInts(1)
                     .addInts(2)
                     .addInts(3)
@@ -72,8 +70,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void strings() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addStrings("First")
                     .addStrings("Second")
                     .addStrings("Third")
@@ -83,8 +80,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void messages() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addMessages(customMessageOf(1))
                     .addMessages(customMessageOf(2))
                     .addMessages(customMessageOf(3))
@@ -99,8 +95,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void enums() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addEnums(DistinctValues.Planet.EARTH)
                     .addEnums(DistinctValues.Planet.EARTH)
                     .addEnums(DistinctValues.Planet.JUPITER)
@@ -110,8 +105,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void ints() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addInts(1)
                     .addInts(2)
                     .addInts(1)
@@ -121,8 +115,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void strings() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addStrings("First")
                     .addStrings("Second")
                     .addStrings("First")
@@ -132,8 +125,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void messages() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addMessages(customMessageOf(1))
                     .addMessages(customMessageOf(2))
                     .addMessages(customMessageOf(1))
@@ -148,8 +140,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void enums() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addEnums(DistinctValues.Planet.EARTH)
                     .addEnums(DistinctValues.Planet.EARTH)
                     .addEnums(DistinctValues.Planet.JUPITER)
@@ -159,8 +150,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void ints() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addInts(1)
                     .addInts(2)
                     .addInts(1)
@@ -170,8 +160,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void strings() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addStrings("First")
                     .addStrings("Second")
                     .addStrings("First")
@@ -181,8 +170,7 @@ final class DistinctTest extends ValidationOfConstraintTest {
 
         @Test
         void messages() {
-            DistinctValues msg = DistinctValues
-                    .newBuilder()
+            var msg = DistinctValues.newBuilder()
                     .addMessages(customMessageOf(1))
                     .addMessages(customMessageOf(2))
                     .addMessages(customMessageOf(1))
@@ -191,16 +179,14 @@ final class DistinctTest extends ValidationOfConstraintTest {
         }
 
         private DistinctValuesWithExternalConstraint withExternalConstraint(DistinctValues value) {
-            return DistinctValuesWithExternalConstraint
-                    .newBuilder()
+            return DistinctValuesWithExternalConstraint.newBuilder()
                     .setDistinctValues(value)
                     .build();
         }
     }
 
     private static DistinctValues.CustomMessage customMessageOf(long value) {
-        return DistinctValues.CustomMessage
-                .newBuilder()
+        return DistinctValues.CustomMessage.newBuilder()
                 .setValue(value)
                 .build();
     }

--- a/base/src/test/java/io/spine/validate/option/FieldValidatingOptionTest.java
+++ b/base/src/test/java/io/spine/validate/option/FieldValidatingOptionTest.java
@@ -200,15 +200,14 @@ final class FieldValidatingOptionTest {
             var value = containingMessage.valueOf(field());
             int maxLength = optionValue();
             var context = value.context();
+            var violation = ConstraintViolation.newBuilder()
+                    .setFieldPath(context.fieldPath())
+                    .setTypeName(containingMessage.declaration().name().value())
+                    .setMsgFormat(errorMessage(context))
+                    .build();
             return value.nonDefault()
                         .filter(val -> val.toString().length() > maxLength)
-                        .map(val -> ConstraintViolation.newBuilder()
-                                .setFieldPath(context.fieldPath())
-                                .setTypeName(containingMessage.declaration()
-                                                              .name()
-                                                              .value())
-                                .setMsgFormat(errorMessage(context))
-                                .build())
+                        .map(val -> violation)
                         .collect(toImmutableList());
         }
     }

--- a/base/src/test/java/io/spine/validate/option/FieldValidatingOptionTest.java
+++ b/base/src/test/java/io/spine/validate/option/FieldValidatingOptionTest.java
@@ -63,99 +63,93 @@ final class FieldValidatingOptionTest {
 
     @BeforeAll
     static void beforeClass() {
-        MessageType externalConstraint = new MessageType(ATestMessageConstraint.getDescriptor());
+        var externalConstraint = new MessageType(ATestMessageConstraint.getDescriptor());
         ExternalConstraints.updateFrom(ImmutableSet.of(externalConstraint));
     }
 
     @DisplayName("return empty value if option is not present in external or field constraints")
     @Test
     void returnEmptyValueIfNotPresent() {
-        ATestMessageWithConstraint msg = ATestMessageWithConstraint.getDefaultInstance();
-        MessageValue value = MessageValue.atTopLevel(msg);
-        FieldValue fieldValue = valueField(value);
-        MaxLength maxLength = new MaxLength();
+        var msg = ATestMessageWithConstraint.getDefaultInstance();
+        var value = MessageValue.atTopLevel(msg);
+        var fieldValue = valueField(value);
+        var maxLength = new MaxLength();
         assertThat(maxLength.valueFrom(fieldValue.context())).isEmpty();
     }
 
     @DisplayName("return value if option is present in external constraint only")
     @Test
     void returnValueIfOptionIsPresentInExternalConstraint() {
-        FieldValue fieldValue = valueFieldWithExternalConstraint();
-        MaxLength maxLength = new MaxLength();
+        var fieldValue = valueFieldWithExternalConstraint();
+        var maxLength = new MaxLength();
         assertThat(maxLength.valueFrom(fieldValue.context())).isPresent();
     }
 
     @DisplayName("return value if option is present in field option")
     @Test
     void returnValueIfOptionIsPresentInFieldOption() {
-        ATestMessage msg = ATestMessage
-                .newBuilder()
+        var msg = ATestMessage.newBuilder()
                 .setValue(randomString())
                 .build();
-        MessageValue value = MessageValue.atTopLevel(msg);
-        FieldValue fieldValue = valueField(value);
-        MaxLength maxLength = new MaxLength();
+        var value = MessageValue.atTopLevel(msg);
+        var fieldValue = valueField(value);
+        var maxLength = new MaxLength();
         assertThat(maxLength.valueFrom(fieldValue.context())).isPresent();
     }
 
     @DisplayName("throw `IllegalStateException` if a specified option is not a field option")
     @Test
     void throwISEIfOptionIsNotPresentInFieldOption() {
-        ATestMessageWithConstraint msg = ATestMessageWithConstraint.getDefaultInstance();
-        MessageValue value = atTopLevel(msg);
-        FieldValue fieldValue = valueField(value);
-        MaxLength maxLength = new MaxLength();
+        var msg = ATestMessageWithConstraint.getDefaultInstance();
+        var value = atTopLevel(msg);
+        var fieldValue = valueField(value);
+        var maxLength = new MaxLength();
         assertIllegalState(() -> maxLength.optionValue(fieldValue.context()));
     }
 
     @DisplayName("not validate field if option is not present in external or field constraints")
     @Test
     void notValidateIfOptionNotPresent() {
-        NoValidationTestMessage msg = NoValidationTestMessage
-                .newBuilder()
+        var msg = NoValidationTestMessage.newBuilder()
                 .setValue(randomString())
                 .build();
-        MessageValue value = MessageValue.atTopLevel(msg);
-        FieldValue fieldValue = valueField(value);
-        MaxLength maxLength = new MaxLength();
+        var value = MessageValue.atTopLevel(msg);
+        var fieldValue = valueField(value);
+        var maxLength = new MaxLength();
         assertFalse(maxLength.shouldValidate(fieldValue.context()));
     }
 
     @DisplayName("validate field if option is present in external constraint")
     @Test
     void validateIfOptionIsPresentInExternalConstraint() {
-        FieldValue fieldValue = valueFieldWithExternalConstraint();
-        MaxLength maxLength = new MaxLength();
+        var fieldValue = valueFieldWithExternalConstraint();
+        var maxLength = new MaxLength();
         assertTrue(maxLength.shouldValidate(fieldValue.context()));
     }
 
     @DisplayName("validate field if option is present in field option")
     @Test
     void validateIfOptionIsPresentInFieldOption() {
-        ATestMessage msg = ATestMessage
-                .newBuilder()
+        var msg = ATestMessage.newBuilder()
                 .setValue(randomString())
                 .build();
-        MessageValue value = MessageValue.atTopLevel(msg);
-        FieldValue fieldValue = valueField(value);
-        MaxLength maxLength = new MaxLength();
+        var value = MessageValue.atTopLevel(msg);
+        var fieldValue = valueField(value);
+        var maxLength = new MaxLength();
         assertTrue(maxLength.shouldValidate(fieldValue.context()));
     }
 
     private static FieldValue valueFieldWithExternalConstraint() {
-        NoValidationTestMessage testMessage = NoValidationTestMessage
-                .newBuilder()
+        var testMessage = NoValidationTestMessage.newBuilder()
                 .setValue(randomString())
                 .build();
-        ATestMessageWithExternalConstraintOnly msg = ATestMessageWithExternalConstraintOnly
-                .newBuilder()
+        var msg = ATestMessageWithExternalConstraintOnly.newBuilder()
                 .setMessage(testMessage)
                 .build();
-        MessageValue value = MessageValue.atTopLevel(msg);
-        FieldValue messageValue = value
-                .valueOf("message")
+        var value = MessageValue.atTopLevel(msg);
+        var messageValue = value.valueOf("message")
                 .orElseGet(Assertions::fail);
-        MessageValue withExternalConstraints = MessageValue
+        var withExternalConstraints = MessageValue
                 .nestedIn(messageValue.context(), (Message) messageValue.singleValue());
         return valueField(withExternalConstraints);
     }
@@ -203,18 +197,18 @@ final class FieldValidatingOptionTest {
 
         @Override
         public ImmutableList<ConstraintViolation> validate(MessageValue containingMessage) {
-            FieldValue value = containingMessage.valueOf(field());
+            var value = containingMessage.valueOf(field());
             int maxLength = optionValue();
-            FieldContext context = value.context();
+            var context = value.context();
             return value.nonDefault()
                         .filter(val -> val.toString().length() > maxLength)
                         .map(val -> ConstraintViolation.newBuilder()
-                                                       .setFieldPath(context.fieldPath())
-                                                       .setTypeName(containingMessage.declaration()
-                                                                                     .name()
-                                                                                     .value())
-                                                       .setMsgFormat(errorMessage(context))
-                                                       .build())
+                                .setFieldPath(context.fieldPath())
+                                .setTypeName(containingMessage.declaration()
+                                                              .name()
+                                                              .value())
+                                .setMsgFormat(errorMessage(context))
+                                .build())
                         .collect(toImmutableList());
         }
     }

--- a/base/src/test/java/io/spine/validate/option/GoesTest.java
+++ b/base/src/test/java/io/spine/validate/option/GoesTest.java
@@ -42,59 +42,52 @@ import static io.spine.base.Identifier.newUuid;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (goes) option and find out that ")
+@DisplayName(VALIDATION_SHOULD + "analyze `(goes)` option and find out that ")
 final class GoesTest extends ValidationOfConstraintTest {
 
-    @DisplayName("(goes).with fields are both optional")
+    @DisplayName("`(goes).with` fields are both optional")
     @Test
     void goesWithFieldsAreBothOptional() {
-        Payment msg = Payment
-                .newBuilder()
+        var msg = Payment.newBuilder()
                 .setDescription("Scheduled payment")
                 .build();
         assertValid(msg);
     }
 
-    @DisplayName("(goes).with fields are not filled simultaneously")
+    @DisplayName("`(goes).with` fields are not filled simultaneously")
     @Test
     void goesWithFieldsShouldBeFilledSimultaneously() {
-        PaymentId id = PaymentId
-                .newBuilder()
+        var id = PaymentId.newBuilder()
                 .setUuid(newUuid())
                 .build();
-        Payment withId = Payment
-                .newBuilder()
+        var withId = Payment.newBuilder()
                 .setId(id)
                 .build();
         assertNotValid(withId);
 
-        Payment withTimestamp = Payment
-                .newBuilder()
+        var withTimestamp = Payment.newBuilder()
                 .setTimestamp(Timestamps.MAX_VALUE)
                 .build();
         assertNotValid(withTimestamp);
     }
 
-    @DisplayName("(goes).with fields are filled simultaneously")
+    @DisplayName("`(goes).with` fields are filled simultaneously")
     @Test
     void goesWithFieldsAreFilledSimultaneously() {
-        PaymentId id = PaymentId
-                .newBuilder()
+        var id = PaymentId.newBuilder()
                 .setUuid(newUuid())
                 .build();
-        Payment msg = Payment
-                .newBuilder()
+        var msg = Payment.newBuilder()
                 .setId(id)
                 .setTimestamp(Timestamps.MAX_VALUE)
                 .build();
         assertValid(msg);
     }
 
-    @DisplayName("(goes).with field is not found")
+    @DisplayName("`(goes).with` field is not found")
     @Test
     void findOutThatGoesWithFieldIsNotFound() {
-        WithFieldNotFound msg = WithFieldNotFound
-                .newBuilder()
+        var msg = WithFieldNotFound.newBuilder()
                 .setId(newUuid())
                 .setAvatar(ByteString.copyFrom(new byte[]{0, 1, 2}))
                 .build();
@@ -105,19 +98,16 @@ final class GoesTest extends ValidationOfConstraintTest {
                 .contains("user_id");
     }
 
-    @DisplayName("(goes).with is set as external constraint")
+    @DisplayName("`(goes).with` is set as external constraint")
     @Test
     void findOutThatGoesWithIsSetAsExternalConstraint() {
-        PaymentId id = PaymentId
-                .newBuilder()
+        var id = PaymentId.newBuilder()
                 .setUuid(newUuid())
                 .build();
-        PaymentData data = PaymentData
-                .newBuilder()
+        var data = PaymentData.newBuilder()
                 .setTimestamp(Timestamps.MAX_VALUE)
                 .build();
-        PaymentWithExternalConstraint msg = PaymentWithExternalConstraint
-                .newBuilder()
+        var msg = PaymentWithExternalConstraint.newBuilder()
                 .setId(id)
                 .setData(data)
                 .build();

--- a/base/src/test/java/io/spine/validate/option/IsRequiredTest.java
+++ b/base/src/test/java/io/spine/validate/option/IsRequiredTest.java
@@ -37,14 +37,13 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.base.Identifier.newUuid;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (is_required) oneof option and")
+@DisplayName(VALIDATION_SHOULD + "analyze `(is_required)` oneof option and")
 class IsRequiredTest extends ValidationOfConstraintTest {
 
     @Test
     @DisplayName("throw if required field group is not set")
     void required() {
-        Meal message = Meal
-                .newBuilder()
+        var message = Meal.newBuilder()
                 .setCheese(Sauce.getDefaultInstance())
                 .buildPartial();
         validate(message);
@@ -55,12 +54,10 @@ class IsRequiredTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("not throw if required field group is set")
     void requiredSet() {
-        Fish fish = Fish
-                .newBuilder()
+        var fish = Fish.newBuilder()
                 .setDescription(newUuid())
                 .build();
-        Meal message = Meal
-                .newBuilder()
+        var message = Meal.newBuilder()
                 .setCheese(Sauce.getDefaultInstance())
                 .setFish(fish)
                 .buildPartial();
@@ -70,12 +67,10 @@ class IsRequiredTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("ignore non-required field groups")
     void notRequired() {
-        Fish fish = Fish
-                .newBuilder()
+        var fish = Fish.newBuilder()
                 .setDescription(newUuid())
                 .build();
-        Meal message = Meal
-                .newBuilder()
+        var message = Meal.newBuilder()
                 .setFish(fish)
                 .buildPartial();
         assertValid(message);

--- a/base/src/test/java/io/spine/validate/option/PatternTest.java
+++ b/base/src/test/java/io/spine/validate/option/PatternTest.java
@@ -41,49 +41,47 @@ import static io.spine.validate.given.MessageValidatorTestEnv.EMAIL;
 import static io.spine.validate.given.MessageValidatorTestEnv.MATCH_REGEXP_MSG;
 import static java.lang.String.format;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (pattern) option and")
+@DisplayName(VALIDATION_SHOULD + "analyze `(pattern)` option and")
 class PatternTest extends ValidationOfConstraintTest {
 
     @Test
     @DisplayName("find out that string matches to regex pattern")
     void findOutThatStringMatchesToRegexPattern() {
-        PatternStringFieldValue msg = patternStringFor("valid.email@mail.com");
+        var msg = patternStringFor("valid.email@mail.com");
         assertValid(msg);
     }
 
     @Test
     @DisplayName("find out that string does not match to regex pattern")
     void findOutThatStringDoesNotMatchToRegexPattern() {
-        PatternStringFieldValue msg = patternStringFor("invalid email");
+        var msg = patternStringFor("invalid email");
         assertNotValid(msg);
     }
 
     @Test
-    @DisplayName("consider field is valid if PatternOption is not set")
+    @DisplayName("consider field is valid if `PatternOption` is not set")
     void considerFieldIsValidIfNoPatternOptionSet() {
-        StringValue msg = StringValue.getDefaultInstance();
+        var msg = StringValue.getDefaultInstance();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("provide one valid violation if string does not match to regex pattern")
     void provideOneValidViolationIfStringDoesNotMatchToRegexPattern() {
-        PatternStringFieldValue msg = patternStringFor("invalid email");
+        var msg = patternStringFor("invalid email");
         @Regex
         String regex = "^[_A-Za-z0-9-\\+]+(\\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\\.[A-Za-z0-9]+)*(\\.[A-Za-z]{2,})$";
-        String expectedErrMsg = format(MATCH_REGEXP_MSG, regex);
+        var expectedErrMsg = format(MATCH_REGEXP_MSG, regex);
         assertSingleViolation(msg, expectedErrMsg, EMAIL);
     }
 
     @Test
     @DisplayName("find out that string does not match to external regex pattern")
     void findOutThatStringDoesNotMatchExternalConstraint() {
-        SimpleStringValue stringValue = SimpleStringValue
-                .newBuilder()
+        var stringValue = SimpleStringValue.newBuilder()
                 .setValue("A wordy sentence")
                 .build();
-        WithStringValue msg = WithStringValue
-                .newBuilder()
+        var msg = WithStringValue.newBuilder()
                 .setStringValue(stringValue)
                 .build();
         assertValid(stringValue);
@@ -93,14 +91,12 @@ class PatternTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate with `case_insensitive` modifier")
     void caseInsensitive() {
-        AllThePatterns message = AllThePatterns
-                .newBuilder()
+        var message = AllThePatterns.newBuilder()
                 .setLetters("AbC")
                 .buildPartial();
         assertValid(message);
 
-        AllThePatterns invalid = AllThePatterns
-                .newBuilder()
+        var invalid = AllThePatterns.newBuilder()
                 .setLetters("12345")
                 .buildPartial();
         assertNotValid(invalid);
@@ -109,14 +105,12 @@ class PatternTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate with `multiline` modifier")
     void multiline() {
-        AllThePatterns message = AllThePatterns
-                .newBuilder()
+        var message = AllThePatterns.newBuilder()
                 .setManyLines("text" + System.lineSeparator() + "more text")
                 .buildPartial();
         assertValid(message);
 
-        AllThePatterns invalid = AllThePatterns
-                .newBuilder()
+        var invalid = AllThePatterns.newBuilder()
                 .setManyLines("single line text")
                 .buildPartial();
         assertNotValid(invalid);
@@ -125,14 +119,12 @@ class PatternTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate with `partial` modifier")
     void partial() {
-        AllThePatterns message = AllThePatterns
-                .newBuilder()
+        var message = AllThePatterns.newBuilder()
                 .setPartial("Hello World!")
                 .buildPartial();
         assertValid(message);
 
-        AllThePatterns invalid = AllThePatterns
-                .newBuilder()
+        var invalid = AllThePatterns.newBuilder()
                 .setPartial("123456")
                 .buildPartial();
         assertNotValid(invalid);
@@ -141,14 +133,12 @@ class PatternTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate with `unicode` modifier")
     void utf8() {
-        AllThePatterns message = AllThePatterns
-                .newBuilder()
+        var message = AllThePatterns.newBuilder()
                 .setUtf8("ґ")
                 .buildPartial();
         assertValid(message);
 
-        AllThePatterns invalid = AllThePatterns
-                .newBuilder()
+        var invalid = AllThePatterns.newBuilder()
                 .setUtf8("\\\\")
                 .buildPartial();
         assertNotValid(invalid);
@@ -157,16 +147,14 @@ class PatternTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("validate with `dot_all` modifier")
     void dotAll() {
-        AllThePatterns message = AllThePatterns
-                .newBuilder()
+        var message = AllThePatterns.newBuilder()
                 .setDotAll("ab" + System.lineSeparator() + "cd")
                 .buildPartial();
         assertValid(message);
     }
 
     private static PatternStringFieldValue patternStringFor(String email) {
-        return PatternStringFieldValue
-                .newBuilder()
+        return PatternStringFieldValue.newBuilder()
                 .setEmail(email)
                 .build();
     }

--- a/base/src/test/java/io/spine/validate/option/RangeConstraintTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeConstraintTest.java
@@ -28,11 +28,9 @@ package io.spine.validate.option;
 
 import com.google.common.collect.BoundType;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import io.spine.code.proto.FieldDeclaration;
 import io.spine.test.type.Url;
-import io.spine.validate.ComparableNumber;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -55,10 +53,11 @@ class RangeConstraintTest {
     @MethodSource("validRanges")
     @DisplayName("be able to parse valid range strings")
     void acceptProperRanges(String range, BoundType expected) {
-        Range<ComparableNumber> result = RangeConstraint.rangeFromOption(range, aDeclaration());
+        var result = RangeConstraint.rangeFromOption(range, aDeclaration());
         assertEquals(expected, result.upperBoundType());
     }
 
+    @SuppressWarnings("unused") /* Serves as a method source. */
     private static Stream<Arguments> validRanges() {
         return Stream.of(
                 Arguments.of("[1..2]", BoundType.CLOSED),
@@ -76,6 +75,7 @@ class RangeConstraintTest {
                      () -> RangeConstraint.rangeFromOption(badRange, aDeclaration()));
     }
 
+    @SuppressWarnings("unused") /* Serves as a method source. */
     private static ImmutableSet<Arguments> badRanges() {
         return argumentsFrom(
                 "{3..5]",
@@ -101,15 +101,16 @@ class RangeConstraintTest {
         assertIllegalArgument(() -> rangeFromOption(emptyRange, aDeclaration()));
     }
 
+    @SuppressWarnings("unused") /* Serves as a method source. */
     private static Set<Arguments> emptyRanges() {
-        int right = 0;
-        int left = right + 1;
-        ImmutableSet<Arguments> leftGreaterThanRight =
+        var right = 0;
+        var left = right + 1;
+        var leftGreaterThanRight =
                 rangeCombinationsFor(left,
                                      right,
                                      ImmutableSet.of('[', '('),
                                      ImmutableSet.of(']', ')'));
-        Arguments closedWithSameNumber = arguments("(0..0)");
+        var closedWithSameNumber = arguments("(0..0)");
         return Sets.union(leftGreaterThanRight, ImmutableSet.of(closedWithSameNumber));
     }
 
@@ -118,26 +119,22 @@ class RangeConstraintTest {
                          Number right,
                          ImmutableSet<Character> leftBoundary,
                          ImmutableSet<Character> rightBoundary) {
-        ImmutableSet<String> lefts = leftBoundary
-                .stream()
+        var lefts = leftBoundary.stream()
                 .map(boundary -> String.valueOf(boundary) + left + "..")
                 .collect(toImmutableSet());
-        ImmutableSet<String> rights = rightBoundary
-                .stream()
+        var rights = rightBoundary.stream()
                 .map(boundary -> String.valueOf(right) + boundary)
                 .collect(toImmutableSet());
-        ImmutableSet<Arguments> result =
-                Sets.cartesianProduct(lefts, rights)
-                    .stream()
-                    .flatMap(product -> Stream.of(product.get(0) + product.get(1)))
-                    .map(Arguments::of)
-                    .collect(toImmutableSet());
+        var result = Sets.cartesianProduct(lefts, rights).stream()
+                .flatMap(product -> Stream.of(product.get(0) + product.get(1)))
+                .map(Arguments::of)
+                .collect(toImmutableSet());
         return result;
     }
 
     private static ImmutableSet<Arguments> argumentsFrom(Object... elements) {
         ImmutableSet.Builder<Arguments> builder = ImmutableSet.builder();
-        for (Object element : elements) {
+        for (var element : elements) {
             builder.add(Arguments.of(element));
         }
         return builder.build();

--- a/base/src/test/java/io/spine/validate/option/RangeTest.java
+++ b/base/src/test/java/io/spine/validate/option/RangeTest.java
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 
 @SuppressWarnings("unused") // methods are invoked via `@MethodSource`.
-@DisplayName(VALIDATION_SHOULD + "analyze (range) option and find out that")
+@DisplayName(VALIDATION_SHOULD + "analyze `(range)` option and find out that")
 final class RangeTest extends ValidationOfConstraintTest {
 
     @Nested
@@ -56,7 +56,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validHours")
         void fitIntoRange(int hour) {
-            NumRanges msg = hourRange(hour);
+            var msg = hourRange(hour);
             assertValid(msg);
         }
 
@@ -64,7 +64,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validHalfDayHours")
         void fitIntoExternalConstraintRange(int hour) {
-            NumRanges msg = hourRange(hour);
+            var msg = hourRange(hour);
             assertValid(holderOf(msg));
         }
 
@@ -72,7 +72,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidHours")
         void doNotFitIntoRange(int hour) {
-            NumRanges msg = hourRange(hour);
+            var msg = hourRange(hour);
             assertNotValid(msg);
         }
 
@@ -80,7 +80,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidHalfDayHours")
         void doNotFitIntoExternalConstraintRange(int hour) {
-            NumRanges msg = hourRange(hour);
+            var msg = hourRange(hour);
             assertNotValid(holderOf(msg));
         }
 
@@ -98,7 +98,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validMinutes")
         void fitIntoRange(long minute) {
-            NumRanges msg = minuteRange(minute);
+            var msg = minuteRange(minute);
             assertValid(msg);
         }
 
@@ -106,7 +106,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validHalfHourMinutes")
         void fitIntoExternalConstraintRange(long minute) {
-            NumRanges msg = minuteRange(minute);
+            var msg = minuteRange(minute);
             assertValid(holderOf(msg));
         }
 
@@ -114,7 +114,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidMinutes")
         void doNotFitIntoRange(long minute) {
-            NumRanges msg = minuteRange(minute);
+            var msg = minuteRange(minute);
             assertNotValid(msg);
         }
 
@@ -122,7 +122,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidHalfHourMinutes")
         void doNotFitIntoExternalConstraintRange(long minute) {
-            NumRanges msg = minuteRange(minute);
+            var msg = minuteRange(minute);
             assertNotValid(holderOf(msg));
         }
 
@@ -140,7 +140,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validDegrees")
         void fitIntoRange(float degree) {
-            NumRanges msg = floatRange(degree);
+            var msg = floatRange(degree);
             assertValid(msg);
         }
 
@@ -148,7 +148,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validHalfRangeDegrees")
         void fitIntoExternalConstraintRange(float degree) {
-            NumRanges msg = floatRange(degree);
+            var msg = floatRange(degree);
             assertValid(holderOf(msg));
         }
 
@@ -156,7 +156,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidDegrees")
         void doNotFitIntoRange(float degree) {
-            NumRanges msg = floatRange(degree);
+            var msg = floatRange(degree);
             assertNotValid(msg);
         }
 
@@ -164,7 +164,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidHalfRangeDegrees")
         void doNotFitIntoExternalConstraintRange(float degree) {
-            NumRanges msg = floatRange(degree);
+            var msg = floatRange(degree);
             assertNotValid(holderOf(msg));
         }
 
@@ -182,7 +182,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validAngles")
         void fitIntoRange(double angle) {
-            NumRanges msg = doubleRange(angle);
+            var msg = doubleRange(angle);
             assertValid(msg);
         }
 
@@ -190,7 +190,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#validHalfRangeAngles")
         void fitIntoExternalConstraintRange(double angle) {
-            NumRanges msg = doubleRange(angle);
+            var msg = doubleRange(angle);
             assertValid(holderOf(msg));
         }
 
@@ -198,7 +198,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidAngles")
         void doNotFitIntoRange(double angle) {
-            NumRanges msg = doubleRange(angle);
+            var msg = doubleRange(angle);
             assertNotValid(msg);
         }
 
@@ -206,7 +206,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @ParameterizedTest
         @MethodSource("io.spine.validate.option.RangeTest#invalidHalfRangeAngles")
         void doNotFitIntoExternalConstraintRange(double angle) {
-            NumRanges msg = doubleRange(angle);
+            var msg = doubleRange(angle);
             assertNotValid(holderOf(msg));
         }
 
@@ -223,8 +223,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @DisplayName("valid")
         @Test
         void valid() {
-            Hours hours = Hours
-                    .newBuilder()
+            var hours = Hours.newBuilder()
                     .addAllHour(validHours().collect(ImmutableList.toImmutableList()))
                     .build();
             assertValid(hours);
@@ -233,8 +232,7 @@ final class RangeTest extends ValidationOfConstraintTest {
         @DisplayName("invalid")
         @Test
         void invalid() {
-            Hours hours = Hours
-                    .newBuilder()
+            var hours = Hours.newBuilder()
                     .addAllHour(invalidHours().collect(ImmutableList.toImmutableList()))
                     .build();
             assertNotValid(hours);
@@ -242,15 +240,13 @@ final class RangeTest extends ValidationOfConstraintTest {
     }
 
     private static RangesHolder holderOf(NumRanges ranges) {
-        return RangesHolder
-                .newBuilder()
+        return RangesHolder.newBuilder()
                 .setRanges(ranges)
                 .build();
     }
 
     private static NumRanges.Builder validRange() {
-        return NumRanges
-                .newBuilder()
+        return NumRanges.newBuilder()
                 .setHour(1)
                 .setAngle(1)
                 .setDegree(1)

--- a/base/src/test/java/io/spine/validate/option/RequiredFieldTest.java
+++ b/base/src/test/java/io/spine/validate/option/RequiredFieldTest.java
@@ -45,7 +45,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.validate.ValidationOfConstraintTest.VALIDATION_SHOULD;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (required_field) message option and consider message")
+@DisplayName(VALIDATION_SHOULD + "analyze `(required_field)` message option and consider message")
 final class RequiredFieldTest extends ValidationOfConstraintTest {
 
     @DisplayName("valid if")
@@ -55,8 +55,7 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
         @DisplayName("all required fields are set")
         @Test
         void allRequiredFieldsAreSet() {
-            EveryFieldRequired message = EveryFieldRequired
-                    .newBuilder()
+            var message = EveryFieldRequired.newBuilder()
                     .setFirst("first field set")
                     .setSecond("second field set")
                     .setThird("third field set")
@@ -64,15 +63,14 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
             assertValid(message);
         }
 
-        @DisplayName("oneof field")
+        @DisplayName("`oneof` field")
         @Nested
         final class OneofField {
 
             @DisplayName("'first' is set")
             @Test
             void first() {
-                OneofRequired withFirstField = OneofRequired
-                        .newBuilder()
+                var withFirstField = OneofRequired.newBuilder()
                         .setFirst("first field set")
                         .build();
                 assertValid(withFirstField);
@@ -81,8 +79,7 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
             @DisplayName("'second' is set")
             @Test
             void second() {
-                OneofRequired withSecondField = OneofRequired
-                        .newBuilder()
+                var withSecondField = OneofRequired.newBuilder()
                         .setSecond("second field set")
                         .build();
                 assertValid(withSecondField);
@@ -90,11 +87,10 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
         }
 
         @Disabled("See https://github.com/SpineEventEngine/base/issues/381")
-        @DisplayName("oneof and other field are set")
+        @DisplayName("`oneof` and other field are set")
         @Test
         void oneofAndOtherFieldsAreSet() {
-            OneofFieldAndOtherFieldRequired message = OneofFieldAndOtherFieldRequired
-                    .newBuilder()
+            var message = OneofFieldAndOtherFieldRequired.newBuilder()
                     .setSecond("second field set")
                     .setThird("third field set")
                     .build();
@@ -105,8 +101,7 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
         @Test
         void optionalFieldsAreNotSet() {
             assertValid(EveryFieldOptional.getDefaultInstance());
-            EveryFieldOptional message = EveryFieldOptional
-                    .newBuilder()
+            var message = EveryFieldOptional.newBuilder()
                     .setFirst("first field set")
                     .setThird("third field set")
                     .build();
@@ -124,16 +119,14 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
 
     @SuppressWarnings("unused") // used via `@MethodSource` value
     private static Stream<ComplexRequiredFields> validComplexMessages() {
-        ComplexRequiredFields message = ComplexRequiredFields
-                .newBuilder()
+        var message = ComplexRequiredFields.newBuilder()
                 .addFirst("first field set")
                 .setFourth("fourth field set")
                 .setFifth(ComplexRequiredFields.FifthField
                                   .newBuilder()
                                   .setValue("fifthFieldValue"))
                 .build();
-        ComplexRequiredFields alternativeMessage = ComplexRequiredFields
-                .newBuilder()
+        var alternativeMessage = ComplexRequiredFields.newBuilder()
                 .putSecond("key", "second field set")
                 .setThird("fourth field set")
                 .setFifth(ComplexRequiredFields.FifthField
@@ -151,32 +144,29 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
         @Test
         void requiredFieldIsNotSet() {
             assertNotValid(EveryFieldRequired.getDefaultInstance(), false);
-            EveryFieldRequired onlyOneRequiredSet = EveryFieldRequired
-                    .newBuilder()
+            var onlyOneRequiredSet = EveryFieldRequired.newBuilder()
                     .setFirst("only one set")
                     .build();
             assertNotValid(onlyOneRequiredSet, false);
 
-            EveryFieldRequired twoRequiredSet = EveryFieldRequired
-                    .newBuilder()
+            var twoRequiredSet = EveryFieldRequired.newBuilder()
                     .setFirst("first set")
                     .setSecond("second set")
                     .build();
             assertNotValid(twoRequiredSet, false);
         }
 
-        @DisplayName("a required oneof is not set")
+        @DisplayName("a required `oneof` is not set")
         @Test
         void oneofNotSet() {
             assertNotValid(OneofRequired.getDefaultInstance(), false);
-            OneofRequired withDefaultValue = OneofRequired
-                    .newBuilder()
+            var withDefaultValue = OneofRequired.newBuilder()
                     .setFirst("")
                     .build();
             assertNotValid(withDefaultValue, false);
         }
 
-        @DisplayName("oneof or other field is not set")
+        @DisplayName("`oneof` or other field is not set")
         @Test
         void oneofOrOtherNotSet() {
             Exception exception = assertThrows(
@@ -200,23 +190,19 @@ final class RequiredFieldTest extends ValidationOfConstraintTest {
 
     @SuppressWarnings("unused") // invoked via `@MethodSource`.
     private static Stream<ComplexRequiredFields> invalidComplexMessages() {
-        ComplexRequiredFields.FifthField.Builder fifthFieldValue =
-                ComplexRequiredFields.FifthField.newBuilder()
-                                                .setValue("fifthFieldValue");
-        ComplexRequiredFields withoutListOrMap = ComplexRequiredFields
-                .newBuilder()
+        var fifthFieldValue = ComplexRequiredFields.FifthField.newBuilder()
+                .setValue("fifthFieldValue");
+        var withoutListOrMap = ComplexRequiredFields.newBuilder()
                 .setFourth("fourth field set")
                 .setFifth(fifthFieldValue)
                 .build();
 
-        ComplexRequiredFields withoutOneof = ComplexRequiredFields
-                .newBuilder()
+        var withoutOneof = ComplexRequiredFields.newBuilder()
                 .putSecond("key", "second field set")
                 .setFifth(fifthFieldValue)
                 .build();
 
-        ComplexRequiredFields withoutMessage = ComplexRequiredFields
-                .newBuilder()
+        var withoutMessage = ComplexRequiredFields.newBuilder()
                 .putSecond("key", "second field set")
                 .setThird("fourth field set")
                 .build();

--- a/base/src/test/java/io/spine/validate/option/RequiredTest.java
+++ b/base/src/test/java/io/spine/validate/option/RequiredTest.java
@@ -46,14 +46,13 @@ import static io.spine.validate.given.MessageValidatorTestEnv.VALUE;
 import static io.spine.validate.given.MessageValidatorTestEnv.newByteString;
 import static io.spine.validate.given.MessageValidatorTestEnv.newStringValue;
 
-@DisplayName(VALIDATION_SHOULD + "analyze (required) option and")
+@DisplayName(VALIDATION_SHOULD + "analyze `(required)` option and")
 class RequiredTest extends ValidationOfConstraintTest {
 
     @Test
-    @DisplayName("find out that required Message field is set")
+    @DisplayName("find out that required `Message` field is set")
     void findOutThatRequiredMessageFieldIsSet() {
-        RequiredMsgFieldValue validMsg = RequiredMsgFieldValue
-                .newBuilder()
+        var validMsg = RequiredMsgFieldValue.newBuilder()
                 .setValue(newStringValue())
                 .build();
         assertValid(validMsg);
@@ -62,90 +61,87 @@ class RequiredTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("find out that required message field is NOT set")
     void findOutThatRequiredMessageFieldIsNotSet() {
-        RequiredMsgFieldValue invalidMsg = RequiredMsgFieldValue.getDefaultInstance();
+        var invalidMsg = RequiredMsgFieldValue.getDefaultInstance();
         assertNotValid(invalidMsg);
     }
 
     @Test
-    @DisplayName("find out that required String field is set")
+    @DisplayName("find out that required `String` field is set")
     void findOutThatRequiredStringFieldIsSet() {
-        RequiredStringFieldValue validMsg = RequiredStringFieldValue.newBuilder()
-                                                                    .setValue(newUuid())
-                                                                    .build();
+        var validMsg = RequiredStringFieldValue.newBuilder()
+                .setValue(newUuid())
+                .build();
         assertValid(validMsg);
     }
 
     @Test
-    @DisplayName("find out that required String field is NOT set")
+    @DisplayName("find out that required `String` field is NOT set")
     void findOutThatRequiredStringFieldIsNotSet() {
-        RequiredStringFieldValue invalidMsg = RequiredStringFieldValue.getDefaultInstance();
+        var invalidMsg = RequiredStringFieldValue.getDefaultInstance();
         assertNotValid(invalidMsg);
     }
 
     @Test
-    @DisplayName("find out that required ByteString field is set")
+    @DisplayName("find out that required `ByteString` field is set")
     void findOutThatRequiredByteStringFieldIsSet() {
-        RequiredByteStringFieldValue validMsg =
-                RequiredByteStringFieldValue.newBuilder()
-                                            .setValue(newByteString())
-                                            .build();
+        var validMsg = RequiredByteStringFieldValue.newBuilder()
+                .setValue(newByteString())
+                .build();
         assertValid(validMsg);
     }
 
     @Test
-    @DisplayName("find out that required ByteString field is NOT set")
+    @DisplayName("find out that required `ByteString` field is NOT set")
     void findOutThatRequiredByteStringFieldIsNotSet() {
-        RequiredByteStringFieldValue invalidMsg = RequiredByteStringFieldValue.getDefaultInstance();
+        var invalidMsg = RequiredByteStringFieldValue.getDefaultInstance();
         assertNotValid(invalidMsg);
     }
 
     @Test
-    @DisplayName("find out that required Enum field is set")
+    @DisplayName("find out that required `Enum` field is set")
     void findOutThatRequiredEnumFieldIsNotSet() {
-        RequiredEnumFieldValue invalidMsg = RequiredEnumFieldValue.getDefaultInstance();
+        var invalidMsg = RequiredEnumFieldValue.getDefaultInstance();
         assertNotValid(invalidMsg);
     }
 
     @Test
-    @DisplayName("find out that required Enum field is NOT set")
+    @DisplayName("find out that required `Enum` field is NOT set")
     void findOutThatRequiredEnumFieldIsSet() {
-        RequiredEnumFieldValue invalidMsg = RequiredEnumFieldValue.newBuilder()
-                                                                  .setValue(Planet.EARTH)
-                                                                  .build();
+        var invalidMsg = RequiredEnumFieldValue.newBuilder()
+                .setValue(Planet.EARTH)
+                .build();
         assertValid(invalidMsg);
     }
 
     @MuteLogging
     @Test
-    @DisplayName("find out that required NOT set Boolean field passes validation")
+    @DisplayName("find out that required NON-SET `Boolean` field passes validation")
     void findOutThatRequiredNotSetBooleanFieldPassValidation() {
-        RequiredBooleanFieldValue msg = RequiredBooleanFieldValue.getDefaultInstance();
+        var msg = RequiredBooleanFieldValue.getDefaultInstance();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("find out that repeated required field has valid values")
     void findOutThatRepeatedRequiredFieldHasValidValues() {
-        RepeatedRequiredMsgFieldValue invalidMsg =
-                RepeatedRequiredMsgFieldValue.newBuilder()
-                                             .addValue(newStringValue())
-                                             .addValue(newStringValue())
-                                             .build();
+        var invalidMsg = RepeatedRequiredMsgFieldValue.newBuilder()
+                .addValue(newStringValue())
+                .addValue(newStringValue())
+                .build();
         assertValid(invalidMsg);
     }
 
     @Test
     @DisplayName("find out that repeated required field has not values")
     void findOutThatRepeatedRequiredFieldHasNoValues() {
-        RepeatedRequiredMsgFieldValue msg = RepeatedRequiredMsgFieldValue.getDefaultInstance();
+        var msg = RepeatedRequiredMsgFieldValue.getDefaultInstance();
         assertNotValid(msg);
     }
 
     @Test
     @DisplayName("ignore repeated required field with an empty value")
     void ignoreRepeatedRequiredFieldWithEmptyValue() {
-        RepeatedRequiredMsgFieldValue msg = RepeatedRequiredMsgFieldValue
-                .newBuilder()
+        var msg = RepeatedRequiredMsgFieldValue.newBuilder()
                 .addValue(newStringValue()) // valid value
                 .addValue(StringValue.getDefaultInstance()) // empty value
                 .build();
@@ -155,22 +151,21 @@ class RequiredTest extends ValidationOfConstraintTest {
     @Test
     @DisplayName("consider field is valid if no required option set")
     void considerFieldIsValidIfNoRequiredOptionSet() {
-        StringValue msg = StringValue.getDefaultInstance();
+        var msg = StringValue.getDefaultInstance();
         assertValid(msg);
     }
 
     @Test
     @DisplayName("provide one valid violation if required field is NOT set")
     void provideOneValidViolationIfRequiredFieldIsNOTSet() {
-        RequiredStringFieldValue invalidMsg = RequiredStringFieldValue.getDefaultInstance();
+        var invalidMsg = RequiredStringFieldValue.getDefaultInstance();
         assertSingleViolation(invalidMsg, VALUE);
     }
 
     @Test
-    @DisplayName("ignore IfMissingOption if field is not marked required")
+    @DisplayName("ignore `IfMissingOption` if field is not marked required")
     void ignoreIfMissingOptionIfFieldNotMarkedRequired() {
-        CustomMessageWithNoRequiredOption invalidMsg =
-                CustomMessageWithNoRequiredOption.getDefaultInstance();
+        var invalidMsg = CustomMessageWithNoRequiredOption.getDefaultInstance();
         assertValid(invalidMsg);
     }
 }

--- a/base/src/test/java/io/spine/value/ComparableStringValueTest.java
+++ b/base/src/test/java/io/spine/value/ComparableStringValueTest.java
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("ComparableStringValue should")
+@DisplayName("`ComparableStringValue` should")
 class ComparableStringValueTest {
 
     @Test
     @DisplayName("compare")
     @SuppressWarnings("LocalVariableNamingConvention") /* shorter names are meaningful for this test */
     void compare() {
-        TestVal a = new TestVal("a");
-        TestVal b = new TestVal("b");
+        var a = new TestVal("a");
+        var b = new TestVal("b");
 
         assertTrue(a.compareTo(b) < 0);
         assertTrue(b.compareTo(a) > 0);

--- a/base/src/test/java/io/spine/value/StringTypeValueTest.java
+++ b/base/src/test/java/io/spine/value/StringTypeValueTest.java
@@ -35,16 +35,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("StringTypeValue should")
+@DisplayName("`StringTypeValue` should")
 class StringTypeValueTest {
 
     @SuppressWarnings("SerializableInnerClassWithNonSerializableOuterClass")
     @Test
     @DisplayName("return value")
     void getValue() {
-        String expected = "return_value_in_toString";
+        var expected = "return_value_in_toString";
 
-        StringTypeValue value = new StringTypeValue(expected) {
+        var value = new StringTypeValue(expected) {
             private static final long serialVersionUID = 0L;
         };
 
@@ -52,7 +52,7 @@ class StringTypeValueTest {
     }
 
     @Test
-    @DisplayName("have hashCode() and equals()")
+    @DisplayName("have `hashCode()` and `equals()`")
     void hashCodeAndEquals() {
         new EqualsTester().addEqualityGroup(new StrVal("uno"), new StrVal("uno"))
                           .addEqualityGroup(new StrVal("dos"))
@@ -67,7 +67,7 @@ class StringTypeValueTest {
     }
 
     @Test
-    @DisplayName("be Serializable")
+    @DisplayName("be `Serializable`")
     void serialize() {
         reserializeAndAssert(new StrVal(getClass().getName()));
     }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -412,12 +412,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 14:05:12 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 09 19:52:30 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.78`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.79`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
@@ -877,4 +877,4 @@ This report was generated on **Wed Dec 08 14:05:12 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Dec 08 14:05:13 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 09 19:52:31 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.78</version>
+<version>2.0.0-SNAPSHOT.79</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/src/main/java/io/spine/testing/Assertions.java
+++ b/testlib/src/main/java/io/spine/testing/Assertions.java
@@ -201,9 +201,7 @@ public final class Assertions {
         checkNotNull(fieldMask);
         List<String> paths = fieldMask.getPathsList();
 
-        List<FieldDescriptor> fields =
-                message.getDescriptorForType()
-                       .getFields();
+        var fields = message.getDescriptorForType().getFields();
 
         List<String> fieldNames =
                 fields.stream()
@@ -213,12 +211,12 @@ public final class Assertions {
         // Assert that the passed field mask contains the field of this message type.
         assertThat(fieldNames).containsAtLeastElementsIn(paths);
 
-        for (FieldDescriptor field : fields) {
-            boolean maskHasSuchField = paths.contains(field.getName());
+        for (var field : fields) {
+            var maskHasSuchField = paths.contains(field.getName());
             if (field.isRepeated()) {
                 if (maskHasSuchField) {
-                    List<?> repeatedFieldValue = (List<?>) message.getField(field);
-                    boolean repeatsAtLeastOnce = repeatedFieldValue.isEmpty();
+                    var repeatedFieldValue = (List<?>) message.getField(field);
+                    var repeatsAtLeastOnce = repeatedFieldValue.isEmpty();
                     assertFalse(repeatsAtLeastOnce,
                                 format("Field %s wasn't found in the specified message.",
                                        field.getName()));
@@ -246,7 +244,7 @@ public final class Assertions {
      *         the maximum expected difference between the values
      */
     public static void assertInDelta(long expectedValue, long actualValue, long delta) {
-        long actualDelta = abs(expectedValue - actualValue);
+        var actualDelta = abs(expectedValue - actualValue);
         assertTrue(actualDelta <= delta);
     }
 }

--- a/testlib/src/main/java/io/spine/testing/ClassTest.java
+++ b/testlib/src/main/java/io/spine/testing/ClassTest.java
@@ -91,6 +91,7 @@ public abstract class ClassTest<C> {
      *
      * @see #configure(NullPointerTester)
      */
+    @SuppressWarnings("unused") /* Part of the public API. */
     protected final Visibility minimalStaticMethodVisibility() {
         return minimalStaticMethodVisibility;
     }
@@ -105,7 +106,7 @@ public abstract class ClassTest<C> {
     @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
         /* This test does assert via `NullPointerTester. */
     void nullCheckParamsOfStaticMethods() {
-        NullPointerTester tester = new NullPointerTester();
+        var tester = new NullPointerTester();
         configure(tester);
         tester.testStaticMethods(subject(), minimalStaticMethodVisibility);
     }

--- a/testlib/src/main/java/io/spine/testing/SingletonTest.java
+++ b/testlib/src/main/java/io/spine/testing/SingletonTest.java
@@ -100,8 +100,7 @@ public abstract class SingletonTest<S> extends ClassTest<S> {
         @Test
         @DisplayName("prohibiting non-private constructors")
         void prohibitNonPrivate() {
-            ImmutableList<Constructor<?>> nonPrivateConstructors =
-                    constructors(ModifierSupport::isNotPrivate);
+            var nonPrivateConstructors = constructors(ModifierSupport::isNotPrivate);
 
             assertThat(nonPrivateConstructors).isEmpty();
         }
@@ -109,16 +108,15 @@ public abstract class SingletonTest<S> extends ClassTest<S> {
         @Test
         @DisplayName("requiring at least one private constructor")
         void requirePrivate() {
-            ImmutableList<Constructor<?>> privateConstructors =
-                    constructors(ModifierSupport::isPrivate);
+            var privateConstructors = constructors(ModifierSupport::isPrivate);
 
             assertThat(privateConstructors).isNotEmpty();
         }
 
         private ImmutableList<Constructor<?>> constructors(Predicate<Constructor<?>> filter) {
             return constructors.stream()
-                               .filter(filter)
-                               .collect(toImmutableList());
+                    .filter(filter)
+                    .collect(toImmutableList());
         }
     }
 
@@ -128,7 +126,7 @@ public abstract class SingletonTest<S> extends ClassTest<S> {
      */
     @VisibleForTesting
     void ctorCheck() {
-        CheckConstructors check = new CheckConstructors();
+        var check = new CheckConstructors();
         check.prohibitNonPrivate();
         check.requirePrivate();
     }

--- a/testlib/src/main/java/io/spine/testing/TempDir.java
+++ b/testlib/src/main/java/io/spine/testing/TempDir.java
@@ -72,9 +72,9 @@ public final class TempDir {
      * specified by the {@link Files2#systemTempDir()}.
      */
     private static Path createBaseDir() {
-        String tmpDir = systemTempDir();
-        PackageName packageName = PackageName.of(TempDir.class);
-        Path baseDir = Paths.get(tmpDir, packageName.toString());
+        var tmpDir = systemTempDir();
+        var packageName = PackageName.of(TempDir.class);
+        var baseDir = Paths.get(tmpDir, packageName.toString());
         return ensureDirectory(baseDir);
     }
 
@@ -101,7 +101,7 @@ public final class TempDir {
         checkNotNull(prefix);
         checkNotEmptyOrBlank(prefix);
         try {
-            Path directory = Files.createTempDirectory(baseDir, prefix, attrs);
+            var directory = Files.createTempDirectory(baseDir, prefix, attrs);
             return directory.toFile();
         } catch (IOException e) {
             throw newIllegalStateException(
@@ -131,7 +131,7 @@ public final class TempDir {
      */
     public static File forClass(Class<?> testSuite, FileAttribute<?>... attrs) {
         checkNotNull(testSuite);
-        String prefix = testSuite.getSimpleName();
+        var prefix = testSuite.getSimpleName();
         return withPrefix(prefix, attrs);
     }
 }

--- a/testlib/src/main/java/io/spine/testing/TestValues.java
+++ b/testlib/src/main/java/io/spine/testing/TestValues.java
@@ -63,10 +63,10 @@ public final class TestValues {
      * Generates a {@code StringValue} with generated UUID.
      */
     public static StringValue newUuidValue() {
-        String id = randomString();
+        var id = randomString();
         return StringValue.newBuilder()
-                          .setValue(id)
-                          .build();
+                .setValue(id)
+                .build();
     }
 
     /**
@@ -80,7 +80,7 @@ public final class TestValues {
      * Generates a random integer in the range [min, max).
      */
     public static int random(int min, int max) {
-        int randomNum = ThreadLocalRandom.current().nextInt(min, max);
+        var randomNum = ThreadLocalRandom.current().nextInt(min, max);
         return randomNum;
     }
 
@@ -88,7 +88,7 @@ public final class TestValues {
      * Generates a random long value in the range [min, max).
      */
     public static long longRandom(long min, long max) {
-        long randomNum = ThreadLocalRandom.current().nextLong(min, max);
+        var randomNum = ThreadLocalRandom.current().nextLong(min, max);
         return randomNum;
     }
 

--- a/testlib/src/main/java/io/spine/testing/Testing.java
+++ b/testlib/src/main/java/io/spine/testing/Testing.java
@@ -49,7 +49,7 @@ public final class Testing {
      */
     @SuppressWarnings("OverlyBroadCatchBlock") // see Javadoc
     static void callConstructor(Constructor<?> constructor) {
-        boolean accessible = constructor.isAccessible();
+        var accessible = constructor.isAccessible();
         if (!accessible) {
             constructor.setAccessible(true);
         }
@@ -69,7 +69,7 @@ public final class Testing {
      */
     public static void repeat(int count, Runnable action) {
         checkNotNull(action);
-        for (int i = 0; i < count; i++) {
+        for (var i = 0; i < count; i++) {
              action.run();
         }
     }

--- a/testlib/src/main/java/io/spine/testing/logging/AssertingHandler.java
+++ b/testlib/src/main/java/io/spine/testing/logging/AssertingHandler.java
@@ -35,10 +35,10 @@ import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.SimpleFormatter;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.lang.System.lineSeparator;
+import static java.util.Objects.requireNonNull;
 
 /**
  * Test fixture for testing loggers based on JDK Logging.
@@ -57,25 +57,25 @@ final class AssertingHandler extends Handler implements LoggingAssertions {
     }
 
     private List<LogRecord> logRecords() {
-        return checkNotNull(logRecords, "The handler is already closed.");
+        return requireNonNull(logRecords, "The handler is already closed.");
     }
 
     @Override
     public StringSubject textOutput() {
-        LogRecord logRecord = firstRecord();
+        var logRecord = firstRecord();
         assertWithMessage(FACT_NO_RECORDS)
                 .that(logRecord)
                 .isNotNull();
         flush();
-        StringSubject subject = assertThat(logRecordToString(logRecord));
+        var subject = assertThat(logRecordToString(logRecord));
         return subject;
     }
 
     @Override
     public LogRecordSubject record() {
-        LogRecord logRecord = firstRecord();
+        var logRecord = firstRecord();
         flush();
-        LogRecordSubject subject = LogTruth.assertThat(logRecord);
+        var subject = LogTruth.assertThat(logRecord);
         return subject;
     }
 
@@ -93,14 +93,14 @@ final class AssertingHandler extends Handler implements LoggingAssertions {
     }
 
     private static String logRecordToString(LogRecord logRecord) {
-        StringBuilder sb = new StringBuilder();
-        String message = new SimpleFormatter().formatMessage(logRecord);
+        var sb = new StringBuilder();
+        var message = new SimpleFormatter().formatMessage(logRecord);
         sb.append(logRecord.getLevel())
           .append(": ")
           .append(message)
           .append(lineSeparator());
 
-        Throwable thrown = logRecord.getThrown();
+        var thrown = logRecord.getThrown();
         if (thrown != null) {
             sb.append(thrown);
         }

--- a/testlib/src/main/java/io/spine/testing/logging/LogRecordSubject.java
+++ b/testlib/src/main/java/io/spine/testing/logging/LogRecordSubject.java
@@ -28,7 +28,6 @@ package io.spine.testing.logging;
 
 import com.google.common.truth.FailureMetadata;
 import com.google.common.truth.ObjectArraySubject;
-import com.google.common.truth.StandardSubjectBuilder;
 import com.google.common.truth.StringSubject;
 import com.google.common.truth.Subject;
 import com.google.common.truth.ThrowableSubject;
@@ -64,7 +63,7 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that("");
         }
-        StandardSubjectBuilder check = check("getMessage()");
+        var check = check("getMessage()");
         return check.that(actual.getMessage());
     }
 
@@ -74,8 +73,8 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that((Object) null);
         }
-        StandardSubjectBuilder check = check("getLevel()");
-        Subject that = check.that(actual.getLevel());
+        var check = check("getLevel()");
+        var that = check.that(actual.getLevel());
         return that;
     }
 
@@ -95,7 +94,7 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that((Object[]) null);
         }
-        StandardSubjectBuilder check = check("getParameters()");
+        var check = check("getParameters()");
         return check.that(actual.getParameters());
     }
 
@@ -105,7 +104,7 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that((Throwable) null);
         }
-        StandardSubjectBuilder check = check("getThrown()");
+        var check = check("getThrown()");
         return check.that(actual.getThrown());
     }
 
@@ -115,7 +114,7 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that((String) null);
         }
-        StandardSubjectBuilder check = check("getSourceMethodName()");
+        var check = check("getSourceMethodName()");
         return check.that(actual.getSourceMethodName());
     }
 
@@ -125,7 +124,7 @@ public class LogRecordSubject extends Subject {
             shouldExistButDoesNot();
             return ignoreCheck().that((String) null);
         }
-        StandardSubjectBuilder check = check("getSourceClassName()");
+        var check = check("getSourceClassName()");
         return check.that(actual.getSourceClassName());
     }
 

--- a/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
+++ b/testlib/src/main/java/io/spine/testing/logging/MemoizingStream.java
@@ -71,7 +71,7 @@ public final class MemoizingStream extends OutputStream {
      *         if the target stream throws an {@link IOException} on a write operation
      */
     public synchronized void flushTo(OutputStream stream) throws IOException {
-        byte[] bytes = memory.toByteArray();
+        var bytes = memory.toByteArray();
         stream.write(bytes);
         reset();
     }

--- a/testlib/src/main/java/io/spine/testing/logging/mute/MuteLoggingExtension.java
+++ b/testlib/src/main/java/io/spine/testing/logging/mute/MuteLoggingExtension.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import java.io.IOException;
-import java.util.Optional;
 
 /**
  * A JUnit {@link org.junit.jupiter.api.extension.Extension Extension} which mutes all the logs
@@ -61,7 +60,7 @@ public final class MuteLoggingExtension implements BeforeEachCallback, AfterEach
 
     @Override
     public void afterEach(ExtensionContext context) throws IOException {
-        Optional<Throwable> exception = context.getExecutionException();
+        var exception = context.getExecutionException();
         if (exception.isPresent()) {
             loggerTap.flushToSystemErr();
         }

--- a/testlib/src/main/java/io/spine/testing/logging/mute/MutingLoggerTap.java
+++ b/testlib/src/main/java/io/spine/testing/logging/mute/MutingLoggerTap.java
@@ -34,7 +34,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.util.logging.Formatter;
 import java.util.logging.Handler;
 import java.util.logging.Logger;
 
@@ -81,8 +80,8 @@ final class MutingLoggerTap {
      * @see #replaceHandlers()
      */
     private void createHandler() {
-        Handler currentHandler = findHandler();
-        Formatter formatter = currentHandler.getFormatter();
+        var currentHandler = findHandler();
+        var formatter = currentHandler.getFormatter();
         handler = new FlushingHandler(stream(), formatter);
         try {
             handler.setEncoding(currentHandler.getEncoding());
@@ -93,7 +92,7 @@ final class MutingLoggerTap {
     }
 
     private Handler findHandler() {
-        Logger logger = logger();
+        var logger = logger();
         while (logger.getHandlers().length == 0) {
             if (logger.getUseParentHandlers()) {
                 logger = logger.getParent();
@@ -113,10 +112,10 @@ final class MutingLoggerTap {
      */
     private void replaceHandlers() {
         // Remember configuration of the logger.
-        Logger logger = logger();
+        var logger = logger();
         usedParentHandlers = logger.getUseParentHandlers();
         previousHandlers = ImmutableList.copyOf(logger.getHandlers());
-        for (Handler handler : previousHandlers) {
+        for (var handler : previousHandlers) {
             logger.removeHandler(handler);
         }
         logger.addHandler(handler());
@@ -132,10 +131,10 @@ final class MutingLoggerTap {
         if (handler == null) { // not installed.
             return;
         }
-        Logger logger = logger();
+        var logger = logger();
         logger.removeHandler(handler());
         logger.setUseParentHandlers(usedParentHandlers);
-        for (Handler previousHandler : previousHandlers()) {
+        for (var previousHandler : previousHandlers()) {
             logger.addHandler(previousHandler);
         }
         stream().reset();
@@ -160,7 +159,7 @@ final class MutingLoggerTap {
      */
     @VisibleForTesting
     synchronized long streamSize() {
-        MemoizingStream stream = stream();
+        var stream = stream();
         try {
             stream.flush();
         } catch (IOException e) {

--- a/testlib/src/main/java/io/spine/testing/logging/mute/SystemOutputTest.java
+++ b/testlib/src/main/java/io/spine/testing/logging/mute/SystemOutputTest.java
@@ -107,7 +107,7 @@ public abstract class SystemOutputTest {
     }
 
     private static String toString(ByteArrayOutputStream stream) {
-        String result = new String(stream.toByteArray(), charset());
+        var result = stream.toString(charset());
         return result;
     }
 }

--- a/testlib/src/test/java/io/spine/testing/AssertionsTest.java
+++ b/testlib/src/test/java/io/spine/testing/AssertionsTest.java
@@ -71,7 +71,7 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
     }
 
     @Nested
-    @DisplayName("Check private parameterless constructor")
+    @DisplayName("check private parameterless constructor")
     class ParameterlessCtor {
 
         @Test
@@ -100,24 +100,23 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
     }
 
     @Nested
-    @DisplayName("Assert matches mask")
+    @DisplayName("assert matches mask")
     class TestingMatchesMask {
 
         private Timestamp timestampMsg;
 
         @BeforeEach
         void setUp() {
-            long currentTime = Instant.now()
-                                      .toEpochMilli();
+            var currentTime = Instant.now().toEpochMilli();
             timestampMsg = Timestamp.newBuilder()
-                                    .setSeconds(currentTime)
-                                    .build();
+                    .setSeconds(currentTime)
+                    .build();
         }
 
         @Test
         @DisplayName("when field is matched")
         void fieldIsPresent() {
-            FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Timestamp.class, 1);
+            var fieldMask = FieldMaskUtil.fromFieldNumbers(Timestamp.class, 1);
 
             assertMatchesMask(timestampMsg, fieldMask);
         }
@@ -125,7 +124,7 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
         @Test
         @DisplayName("throws the error when field is not present")
         void fieldIsNotPresent() {
-            FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Any.class, 1);
+            var fieldMask = FieldMaskUtil.fromFieldNumbers(Any.class, 1);
 
             assertThrows(AssertionError.class, () -> assertMatchesMask(timestampMsg, fieldMask));
         }
@@ -133,13 +132,13 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
         @Test
         @DisplayName("throws the error when the field value is not set")
         void fieldIsNotSet() {
-            String fieldPath = Timestamp.getDescriptor()
-                                        .getFields()
-                                        .get(0)
-                                        .getFullName();
-            FieldMask.Builder builder = FieldMask.newBuilder();
+            var fieldPath = Timestamp.getDescriptor()
+                                     .getFields()
+                                     .get(0)
+                                     .getFullName();
+            var builder = FieldMask.newBuilder();
             builder.addPaths(fieldPath);
-            FieldMask fieldMask = builder.build();
+            var fieldMask = builder.build();
 
             assertThrows(AssertionError.class,
                          () -> assertMatchesMask(Timestamp.getDefaultInstance(), fieldMask));
@@ -154,19 +153,19 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             @DisplayName("match existing repeated primitive fields")
             @Test
             void matchRepeatedPrimitiveFields() {
-                Prescription prescription = prescribeFromCold();
-                FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Prescription.class,
-                                                                     PRESCRIBED_DRUG_FIELD_NUMBER,
-                                                                     PRESCRIBED_ON_FIELD_NUMBER);
+                var prescription = prescribeFromCold();
+                var fieldMask = FieldMaskUtil.fromFieldNumbers(Prescription.class,
+                                                               PRESCRIBED_DRUG_FIELD_NUMBER,
+                                                               PRESCRIBED_ON_FIELD_NUMBER);
                 assertMatchesMask(prescription, fieldMask);
             }
 
             @DisplayName("not match absent repeated primitive fields")
             @Test
             void notMatchAbsentRepeatedPrimitiveFields() {
-                Prescription emptyPrescription = Prescription.getDefaultInstance();
-                FieldMask fieldMask = FieldMaskUtil.fromFieldNumbers(Prescription.class,
-                                                                     PRESCRIBED_DRUG_FIELD_NUMBER);
+                var emptyPrescription = Prescription.getDefaultInstance();
+                var fieldMask = FieldMaskUtil.fromFieldNumbers(Prescription.class,
+                                                               PRESCRIBED_DRUG_FIELD_NUMBER);
                 assertThrows(AssertionError.class,
                              () -> assertMatchesMask(emptyPrescription, fieldMask));
             }
@@ -174,12 +173,11 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             @DisplayName("match existing repeated non-default message fields")
             @Test
             void matchRepeatedNonDefaultMessageFields() {
-                PrescriptionHistory history = PrescriptionHistory
-                        .newBuilder()
+                var history = PrescriptionHistory.newBuilder()
                         .addReceivedPrescription(prescribeFromCold())
                         .setPrescriptionReceiver(patientId)
                         .build();
-                FieldMask fieldMask =
+                var fieldMask =
                         FieldMaskUtil.fromFieldNumbers(PrescriptionHistory.class,
                                                        PRESCRIPTION_RECEIVER_FIELD_NUMBER,
                                                        RECEIVED_PRESCRIPTION_FIELD_NUMBER);
@@ -189,12 +187,11 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             @DisplayName("not match absent repeated message fields")
             @Test
             void notMatchAbsentRepeatedMessageFields() {
-                PrescriptionHistory history = PrescriptionHistory
-                        .newBuilder()
+                var history = PrescriptionHistory.newBuilder()
                         .setPrescriptionReceiver(patientId)
                         .build();
 
-                FieldMask fieldMask =
+                var fieldMask =
                         FieldMaskUtil.fromFieldNumbers(PrescriptionHistory.class,
                                                        PRESCRIPTION_RECEIVER_FIELD_NUMBER,
                                                        RECEIVED_PRESCRIPTION_FIELD_NUMBER);
@@ -204,13 +201,12 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             @DisplayName("match existing repeated enum fields")
             @Test
             void matchPresentRepeatedEnumFields() {
-                HospitalPolicy policy = HospitalPolicy
-                        .newBuilder()
+                var policy = HospitalPolicy.newBuilder()
                         .addAcceptedCondition(CRITICAL)
                         .addAcceptedCondition(CRITICAL_BUT_STABLE)
                         .build();
 
-                FieldMask fieldMask =
+                var fieldMask =
                         FieldMaskUtil.fromFieldNumbers(HospitalPolicy.class,
                                                        ACCEPTED_CONDITION_FIELD_NUMBER);
                 assertMatchesMask(policy, fieldMask);
@@ -219,22 +215,18 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             @DisplayName("not match absent repeated enum fields")
             @Test
             void notMatchAbsentRepeatedEnumFields() {
-                HospitalPolicy emptyPolicy = HospitalPolicy.getDefaultInstance();
-                FieldMask fieldMask =
-                        FieldMaskUtil.fromFieldNumbers(HospitalPolicy.class,
-                                                       ACCEPTED_CONDITION_FIELD_NUMBER);
+                var emptyPolicy = HospitalPolicy.getDefaultInstance();
+                var fieldMask = FieldMaskUtil.fromFieldNumbers(HospitalPolicy.class,
+                                                               ACCEPTED_CONDITION_FIELD_NUMBER);
                 assertThrows(AssertionError.class, () -> assertMatchesMask(emptyPolicy, fieldMask));
             }
 
             private Prescription prescribeFromCold() {
-                long currentTime = Instant.now()
-                                          .toEpochMilli();
-                Timestamp now = Timestamp
-                        .newBuilder()
+                var currentTime = Instant.now().toEpochMilli();
+                var now = Timestamp.newBuilder()
                         .setSeconds(currentTime)
                         .build();
-                return Prescription
-                        .newBuilder()
+                return Prescription.newBuilder()
                         .setPrescribedOn(now)
                         .addPrescribedDrug("Paracetamol")
                         .addPrescribedDrug("Aspirin")
@@ -243,10 +235,8 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
             }
 
             private PatientId newPatient() {
-                String uuid = UUID.randomUUID()
-                                  .toString();
-                return PatientId
-                        .newBuilder()
+                var uuid = UUID.randomUUID().toString();
+                return PatientId.newBuilder()
                         .setValue(uuid)
                         .build();
             }
@@ -254,7 +244,7 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
     }
 
     @Nested
-    @DisplayName("Assert values in delta")
+    @DisplayName("assert values in delta")
     class TestingInDelta {
 
         private static final long DELTA = 10;
@@ -267,41 +257,41 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
         @Test
         @DisplayName("when values are equal")
         void equalValues() {
-            long expectedValue = getValue();
+            var expectedValue = getValue();
             @SuppressWarnings("UnnecessaryLocalVariable") // For readability of this test.
-            long actualValue = expectedValue;
+            var actualValue = expectedValue;
             assertInDelta(expectedValue, actualValue, 0);
         }
 
         @Test
         @DisplayName("when values are close")
         void closeValues() {
-            long expectedValue = getValue();
-            long actualValue = getValue();
+            var expectedValue = getValue();
+            var actualValue = getValue();
             assertInDelta(expectedValue, actualValue, DELTA);
         }
 
         @Test
         @DisplayName("when actual value less than the sum of the expected value and delta")
         void actualValueLessThanExpectedWithDelta() {
-            long expectedValue = getValue();
-            long actualValue = expectedValue + DELTA - 1;
+            var expectedValue = getValue();
+            var actualValue = expectedValue + DELTA - 1;
             assertInDelta(expectedValue, actualValue, DELTA);
         }
 
         @Test
         @DisplayName("when the actual value equals the sum of the expected value and delta")
         void actualValueEqualsTheSumExpectedValueAndDelta() {
-            long expectedValue = getValue();
-            long actualValue = expectedValue + DELTA;
+            var expectedValue = getValue();
+            var actualValue = expectedValue + DELTA;
             assertInDelta(expectedValue, actualValue, DELTA);
         }
 
         @Test
         @DisplayName("throw when the actual value greater than the sum of the expected value and delta")
         void actualValueGreaterThanTheSumExpectedValueAndDelta() {
-            long expectedValue = getValue();
-            long actualValue = expectedValue + DELTA + 1;
+            var expectedValue = getValue();
+            var actualValue = expectedValue + DELTA + 1;
             assertThrows(
                     AssertionError.class,
                     () -> assertInDelta(expectedValue, actualValue, DELTA)
@@ -311,24 +301,24 @@ class AssertionsTest extends UtilityClassTest<Assertions> {
         @Test
         @DisplayName("when the actual value greater than the subtraction of the expected value and delta")
         void actualValueGreaterThanTheSubtractionOfExpectedValueAndDelta() {
-            long actualValue = getValue();
-            long expectedValue = actualValue + DELTA - 1;
+            var actualValue = getValue();
+            var expectedValue = actualValue + DELTA - 1;
             assertInDelta(expectedValue, actualValue, DELTA);
         }
 
         @Test
         @DisplayName("when the actual value equals the subtraction of the expected value and delta")
         void actualValueEqualsTheSubtractionOfExpectedValueAndDelta() {
-            long actualValue = getValue();
-            long expectedValue = actualValue + DELTA;
+            var actualValue = getValue();
+            var expectedValue = actualValue + DELTA;
             assertInDelta(expectedValue, actualValue, DELTA);
         }
 
         @Test
         @DisplayName("throw when the actual value less than the subtraction of the expected value and delta")
         void actualValueLessThanTheSubtractionExpectedValueAndDelta() {
-            long actualValue = getValue();
-            long expectedValue = actualValue + DELTA + 1;
+            var actualValue = getValue();
+            var expectedValue = actualValue + DELTA + 1;
             assertThrows(
                     AssertionError.class,
                     () -> assertInDelta(expectedValue, actualValue, DELTA)

--- a/testlib/src/test/java/io/spine/testing/ReflectiveBuilderTest.java
+++ b/testlib/src/test/java/io/spine/testing/ReflectiveBuilderTest.java
@@ -41,8 +41,7 @@ class ReflectiveBuilderTest {
     @Test
     @DisplayName("have the result class")
     void resultClass() {
-        var builder =
-                new DummyBuilder().setResultClass(Any.class);
+        var builder = new DummyBuilder().setResultClass(Any.class);
         assertEquals(Any.class, builder.resultClass());
     }
 

--- a/testlib/src/test/java/io/spine/testing/ReflectiveBuilderTest.java
+++ b/testlib/src/test/java/io/spine/testing/ReflectiveBuilderTest.java
@@ -35,13 +35,13 @@ import java.lang.reflect.Constructor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@DisplayName("ReflectiveBuilder should")
+@DisplayName("`ReflectiveBuilder` should")
 class ReflectiveBuilderTest {
 
     @Test
     @DisplayName("have the result class")
     void resultClass() {
-        ReflectiveBuilder<Any> builder =
+        var builder =
                 new DummyBuilder().setResultClass(Any.class);
         assertEquals(Any.class, builder.resultClass());
     }

--- a/testlib/src/test/java/io/spine/testing/TestValuesTest.java
+++ b/testlib/src/test/java/io/spine/testing/TestValuesTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@DisplayName("TestValues utility class should")
+@DisplayName("`TestValues` utility class should")
 class TestValuesTest extends UtilityClassTest<TestValues> {
 
     TestValuesTest() {
@@ -54,7 +54,7 @@ class TestValuesTest extends UtilityClassTest<TestValues> {
     @Test
     @DisplayName("provide a random number in a range")
     void randomNumber() {
-        int value = TestValues.random(-100, 100);
+        var value = TestValues.random(-100, 100);
         assertTrue(value >= -100);
         assertTrue(value <= 100);
     }

--- a/testlib/src/test/java/io/spine/testing/TestingTest.java
+++ b/testlib/src/test/java/io/spine/testing/TestingTest.java
@@ -31,7 +31,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.spine.testing.Testing.repeat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("Tests utility class should")
+@DisplayName("`Testing` utility class should")
 class TestingTest extends UtilityClassTest<Testing> {
 
     TestingTest() {
@@ -46,8 +46,8 @@ class TestingTest extends UtilityClassTest<Testing> {
     @Test
     @DisplayName("repeat an action a number of times")
     void repeating() {
-        int expected = TestValues.random(10);
-        AtomicInteger counter = new AtomicInteger(0);
+        var expected = TestValues.random(10);
+        var counter = new AtomicInteger(0);
         repeat(expected, counter::incrementAndGet);
 
         assertThat(counter.get())

--- a/testlib/src/test/java/io/spine/testing/logging/AssertingHandlerTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/AssertingHandlerTest.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-@DisplayName("AssertingHandler should")
+@DisplayName("`AssertingHandler` should")
 class AssertingHandlerTest {
 
     private static final Logger logger = Logger.getLogger(AssertingHandlerTest.class.getName());
@@ -74,7 +74,7 @@ class AssertingHandlerTest {
     @Test
     @DisplayName("obtain `StringSubject` for the first record")
     void textAssertion() {
-        String msg = TestValues.randomString();
+        var msg = TestValues.randomString();
         logger.info(msg);
         handler.textOutput()
                .contains(msg);

--- a/testlib/src/test/java/io/spine/testing/logging/LogRecordSubjectTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/LogRecordSubjectTest.java
@@ -28,7 +28,6 @@ package io.spine.testing.logging;
 
 import com.google.common.truth.ExpectFailure.SimpleSubjectBuilderCallback;
 import com.google.common.truth.Subject;
-import com.google.common.truth.TruthFailureSubject;
 import io.spine.testing.SubjectTest;
 import io.spine.testing.TestValues;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +41,7 @@ import static com.google.common.truth.ExpectFailure.assertThat;
 import static io.spine.testing.logging.LogRecordSubject.NO_LOG_RECORD;
 import static io.spine.testing.logging.LogRecordSubject.records;
 
-@DisplayName("LogRecordSubject should have")
+@DisplayName("`LogRecordSubject` should have")
 class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
 
     private LogRecord record;
@@ -69,6 +68,7 @@ class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
 
     @Test
     @DisplayName("the check for no logged records")
+    @SuppressWarnings("ResultOfMethodCallIgnored")  /* Intentionally. */
     void noRecords() {
         checkFails(whenTesting -> whenTesting.that(null).hasLevelThat());
         checkFails(whenTesting -> whenTesting.that(null).hasClassNameThat());
@@ -82,7 +82,7 @@ class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
 
     private void
     checkFails(SimpleSubjectBuilderCallback<LogRecordSubject, LogRecord> assertionCallback) {
-        AssertionError failure = expectFailure(assertionCallback);
+        var failure = expectFailure(assertionCallback);
         assertThat(failure)
                 .factKeys()
                 .contains(NO_LOG_RECORD);
@@ -94,14 +94,14 @@ class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
                 .hasMessageThat()
                 .isEqualTo(msg);
 
-        String notExpected = TestValues.randomString();
+        var notExpected = TestValues.randomString();
 
-        AssertionError failure = expectFailure(
+        var failure = expectFailure(
                 whenTesting -> whenTesting.that(record)
                                           .hasMessageThat()
                                           .isEqualTo(notExpected)
         );
-        TruthFailureSubject assertFailure = assertThat(failure);
+        var assertFailure = assertThat(failure);
         assertFailure.factKeys()
                      .containsAnyOf(EXPECTED, BUT_WAS);
     }
@@ -163,7 +163,7 @@ class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
 
     @Test
     void hasMethodThat() {
-        String method = "hasMethodNameThat";
+        var method = "hasMethodNameThat";
         record.setSourceMethodName(method);
         assertWithSubjectThat(record)
                 .hasMethodNameThat()
@@ -175,7 +175,7 @@ class LogRecordSubjectTest extends SubjectTest<LogRecordSubject, LogRecord> {
 
     @Test
     void hasClassThat() {
-        String className = LogRecordSubjectTest.class.getName();
+        var className = LogRecordSubjectTest.class.getName();
         record.setSourceClassName(className);
         assertWithSubjectThat(record)
                 .hasClassNameThat()

--- a/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/MemoizingStreamTest.java
@@ -41,7 +41,7 @@ import static io.spine.testing.TestValues.random;
 import static java.lang.Byte.MAX_VALUE;
 import static java.lang.Byte.MIN_VALUE;
 
-@DisplayName("MemoizingStream should")
+@DisplayName("`MemoizingStream` should")
 class MemoizingStreamTest {
 
     private static final byte[] EMPTY_BYTES = {};
@@ -101,7 +101,7 @@ class MemoizingStreamTest {
     @Test
     @DisplayName("flush all the input")
     void flushEverything() throws IOException {
-        byte[] input = randomBytes(42);
+        var input = randomBytes(42);
 
         stream.write(input);
 
@@ -111,7 +111,7 @@ class MemoizingStreamTest {
     @Test
     @DisplayName("not store flushed bytes")
     void clearAfterFlush() throws IOException {
-        byte[] input = randomBytes(12);
+        var input = randomBytes(12);
 
         stream.write(input);
 
@@ -122,7 +122,7 @@ class MemoizingStreamTest {
     @Test
     @DisplayName("clear memoized bytes on demand")
     void clearOnDemand() throws IOException {
-        byte[] input = randomBytes(4);
+        var input = randomBytes(4);
 
         stream.write(input);
         stream.reset();
@@ -133,7 +133,7 @@ class MemoizingStreamTest {
     @Test
     @DisplayName("allow to clear memoized bytes any number of times")
     void clearAnyNumberOfTimes() throws IOException {
-        byte[] input = randomBytes(4);
+        var input = randomBytes(4);
 
         stream.write(input);
 
@@ -159,9 +159,9 @@ class MemoizingStreamTest {
     }
 
     private void checkMemoized(byte[] expected) throws IOException {
-        ByteArrayOutputStream outputCollector = new ByteArrayOutputStream();
+        var outputCollector = new ByteArrayOutputStream();
         stream.flushTo(outputCollector);
-        byte[] actualBytes = outputCollector.toByteArray();
+        var actualBytes = outputCollector.toByteArray();
 
         assertThat(actualBytes)
                 .asList()
@@ -169,10 +169,10 @@ class MemoizingStreamTest {
     }
 
     private static byte[] randomBytes(int count) {
-        byte[] result = new byte[count];
-        for (int i = 0; i < count; i++) {
+        var result = new byte[count];
+        for (var i = 0; i < count; i++) {
             @SuppressWarnings("NumericCastThatLosesPrecision") // OK because of the bounds.
-            byte randomByte = (byte) random(0, MAX_VALUE);
+            var randomByte = (byte) random(0, MAX_VALUE);
             result[i] = randomByte;
         }
         return result;

--- a/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingExtensionTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingExtensionTest.java
@@ -40,7 +40,6 @@ import org.junit.jupiter.api.extension.TestInstances;
 
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
 import java.util.Map;
 import java.util.Optional;
@@ -53,7 +52,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("UseOfSystemOutOrSystemErr") // Test std I/O overloading.
-@DisplayName("MuteLogging JUnit Extension should")
+@DisplayName("`MuteLogging` JUnit Extension should")
 class MuteLoggingExtensionTest extends SystemOutputTest {
 
     private MuteLoggingExtension extension;
@@ -68,8 +67,8 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
     @Test
     @DisplayName("have public parameter-less constructor")
     void ctor() throws NoSuchMethodException {
-        Constructor<MuteLoggingExtension> constructor = MuteLoggingExtension.class.getConstructor();
-        int modifiers = constructor.getModifiers();
+        var constructor = MuteLoggingExtension.class.getConstructor();
+        var modifiers = constructor.getModifiers();
         assertTrue(isPublic(modifiers));
     }
 
@@ -78,8 +77,8 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
     void printOutputOnException() throws IOException {
         extension.beforeEach(successfulContext());
 
-        LoggingStub stub = new LoggingStub();
-        String errorMessage = stub.logError();
+        var stub = new LoggingStub();
+        var errorMessage = stub.logError();
 
         extension.afterEach(failedContext());
 
@@ -87,7 +86,7 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
         System.err.flush();
 
         assertEquals(0, out().size());
-        String actualErrorOutput = errorOutput();
+        var actualErrorOutput = errorOutput();
         assertThat(actualErrorOutput).contains(errorMessage);
     }
 
@@ -96,7 +95,7 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
     void muteSpineLogging() throws IOException {
         extension.beforeEach(successfulContext());
 
-        LoggingStub stub = new LoggingStub();
+        var stub = new LoggingStub();
         stub.logWarning();
 
         extension.afterEach(successfulContext());
@@ -214,14 +213,14 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
 
         @CanIgnoreReturnValue
         String logWarning() {
-            String warningMessage = "Warning:" + TestValues.randomString();
+            var warningMessage = "Warning:" + TestValues.randomString();
             _warn().log(warningMessage);
             return warningMessage;
         }
 
         @CanIgnoreReturnValue
         String logError() {
-            String errorMessage = "Error: " + TestValues.randomString();
+            var errorMessage = "Error: " + TestValues.randomString();
             _error().log(errorMessage);
             return errorMessage;
         }

--- a/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingTest.java
@@ -26,24 +26,22 @@
 
 package io.spine.testing.logging.mute;
 
-import com.google.common.truth.ObjectArraySubject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.Extension;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("@MuteLogging should")
+@DisplayName("`@MuteLogging` should")
 class MuteLoggingTest {
 
     @Test
     @DisplayName("be marked as an extension")
     void annotated() {
-        Class<MuteLogging> annotation = MuteLogging.class;
-        ExtendWith extendsWith = annotation.getAnnotation(ExtendWith.class);
-        Class<? extends Extension>[] extensions = extendsWith.value();
-        ObjectArraySubject<Class<? extends Extension>> assertExtensions = assertThat(extensions);
+        var annotation = MuteLogging.class;
+        var extendsWith = annotation.getAnnotation(ExtendWith.class);
+        var extensions = extendsWith.value();
+        var assertExtensions = assertThat(extensions);
         assertExtensions.hasLength(1);
         assertExtensions.asList().contains(MuteLoggingExtension.class);
     }

--- a/testlib/src/test/java/io/spine/testing/logging/mute/MutingLoggerTapTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/mute/MutingLoggerTapTest.java
@@ -57,7 +57,7 @@ class MutingLoggerTapTest extends SystemOutputTest {
         @Test
         @DisplayName("regular logging")
         void regularLog() {
-            String expected = "Test non interception.";
+            var expected = "Test non interception.";
             logger().info(expected);
 
             assertThat(loggingOutput()).contains(expected);
@@ -66,7 +66,7 @@ class MutingLoggerTapTest extends SystemOutputTest {
         @Test
         @DisplayName("error logging")
         void errorLog() {
-            String expectedError = "Testing error non interception.";
+            var expectedError = "Testing error non interception.";
             logger().severe(expectedError);
 
             assertThat(loggingOutput()).contains(expectedError);
@@ -90,7 +90,7 @@ class MutingLoggerTapTest extends SystemOutputTest {
         @Test
         @DisplayName("regular logging")
         void regularLog() {
-            String expected = "Test interception.";
+            var expected = "Test interception.";
             logger().info(expected);
 
             assertThat(loggingOutput()).doesNotContain(expected);
@@ -99,7 +99,7 @@ class MutingLoggerTapTest extends SystemOutputTest {
         @Test
         @DisplayName("error logging")
         void errorLog() {
-            String expectedError = "Testing error interception.";
+            var expectedError = "Testing error interception.";
             logger().severe(expectedError);
 
             assertThat(loggingOutput()).doesNotContain(expectedError);
@@ -110,8 +110,8 @@ class MutingLoggerTapTest extends SystemOutputTest {
         void redirection() {
             assertThat(tap.streamSize())
                     .isEqualTo(0);
-            String msg = randomString();
-            Logger logger = logger();
+            var msg = randomString();
+            var logger = logger();
 
             logger.info(msg);
 
@@ -140,18 +140,18 @@ class MutingLoggerTapTest extends SystemOutputTest {
             @Test
             @DisplayName("accumulated output")
             void ofRegularLogs() {
-                String fo = flushedOutput();
+                var fo = flushedOutput();
                 assertThat(fo).contains(logMessage);
             }
 
             @Test
             @DisplayName("accumulated error output")
             void ofErrorLogs() {
-                String fo = flushedOutput();
+                var fo = flushedOutput();
                 assertThat(fo).contains(errorMessage);
             }
             String flushedOutput() {
-                return new String(stream.toByteArray(), Charset.defaultCharset());
+                return stream.toString(Charset.defaultCharset());
             }
         }
     }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.78"
+val base = "2.0.0-SNAPSHOT.79"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This is a second part of #698.

It completes the migration to `var` syntax. Also, deals with some warnings and inconsistencies in test naming.

Lastly, it updates the `README.md` to reflect the recent changes made to the repository code.

The version is set to `2.0.0-SNAPSHOT.79`.