### PR TITLE
Add `Glob` data class

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,9 @@ jobs:
         run: cat ./gradle-plugin-portal.secret.properties >> ./gradle.properties
 
       - name: Publish artifacts to Maven
-        run: ./gradlew build publish --stacktrace
+        # Since we're in the `master` branch already, this means that tests of a PR passed.
+        # So, no need to run the tests again when publishing.
+        run: ./gradlew publish -x test --stacktrace
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -38,5 +38,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
 </project>

--- a/.lift.toml
+++ b/.lift.toml
@@ -1,0 +1,1 @@
+ignoreRules=["SpreadOperator"]

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -48,7 +48,7 @@ public data class Glob(val pattern: String) {
     public companion object {
 
         /**
-         * A pattern which matched any file.
+         * A pattern which matches any file.
          */
         public val any: Glob = Glob("**")
 

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.io
+
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.nio.file.PathMatcher
+
+/**
+ * A [GLOB](https://docs.oracle.com/javase/tutorial/essential/io/fileOps.html#glob) pattern for
+ * matching file paths.
+ *
+ * @see java.nio.file.FileSystem.getPathMatcher
+ */
+public class Glob(pattern: String) {
+
+    init {
+        require(pattern.isNotEmpty())
+    }
+
+    private val matcher: PathMatcher = FileSystems.getDefault()
+        .getPathMatcher("glob:$pattern")
+
+    public companion object {
+
+        /**
+         * A pattern which matched any file.
+         */
+        public val any: Glob = Glob("**")
+
+        /**
+         * A pattern which matches any file with the given extension.
+         *
+         * @param extension
+         *         a file extension with or without the leading dot
+         */
+        @JvmStatic
+        public fun extension(extension: CharSequence): Glob {
+            val ext = if (extension.isEmpty()) extension
+            else if (extension[0] == '.') extension.substring(1) else extension
+            return Glob("**.$ext")
+        }
+    }
+
+    /**
+     * Checks if the given path matches this pattern.
+     */
+    public fun matches(path: Path): Boolean = matcher.matches(path)
+}

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -36,7 +36,7 @@ import java.nio.file.PathMatcher
  *
  * @see java.nio.file.FileSystem.getPathMatcher
  */
-public class Glob(pattern: String) {
+public data class Glob(val pattern: String) {
 
     init {
         require(pattern.isNotEmpty())
@@ -56,7 +56,7 @@ public class Glob(pattern: String) {
          * A pattern which matches any file with the given extension.
          *
          * @param extension
-         *         a file extension with or without the leading dot
+         *         a file extension with or without the leading dot.
          */
         @JvmStatic
         public fun extension(extension: CharSequence): Glob {

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.io
+
+import com.google.common.truth.Truth.assertThat
+import java.nio.file.Paths
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class `'Glob' should` {
+
+
+    @Test
+    fun `prohibit empty pattern`() {
+        assertThrows<IllegalArgumentException> { Glob("") }
+    }
+
+    @Nested
+    inner class `create instances by extension which` {
+
+        @Test
+        fun `is empty`() {
+            assertExtensionMatches("", "some/where/file.")
+        }
+
+        @Test
+        fun `has leading dot`() {
+            assertExtensionMatches(".foo", "1/2/3/file.foo")
+        }
+
+        @Test
+        fun `is just text`() {
+            assertExtensionMatches("bar", "4/5/file.bar")
+        }
+
+        private fun assertExtensionMatches(extension: String, path: String) {
+            val g = Glob.extension(extension)
+            val p = Paths.get(path)
+            val matches = g.matches(p)
+            assertThat(matches).isTrue()
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -34,7 +34,6 @@ import org.junit.jupiter.api.assertThrows
 
 class `'Glob' should` {
 
-
     @Test
     fun `prohibit empty pattern`() {
         assertThrows<IllegalArgumentException> { Glob("") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -201,6 +201,11 @@ subprojects {
     with(configurations) {
         forceVersions()
         excludeProtobufLite()
+        all {
+            resolutionStrategy {
+                force("org.junit:junit-bom:${JUnit.version}")
+            }
+        }
     }
 
     val generatedDir by extra("$projectDir/generated")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -64,22 +64,22 @@ val grGitVersion = "3.1.1"
  * The version of the Kotlin Gradle plugin.
  *
  * Please check that this value matches one defined in
- *  `io.spine.internal.dependency.Kotlin.version`.
+ *  [io.spine.internal.dependency.Kotlin.version].
  */
-val kotlinVersion = "1.6.0"
+val kotlinVersion = "1.6.10"
 
 /**
  * The version of Guava used in `buildSrc`.
  *
- * Always use the same version as the one specified in `io.spine.internal.dependency.Guava`.
+ * Always use the same version as the one specified in [io.spine.internal.dependency.Guava].
  * Otherwise, when testing Gradle plugins, clashes may occur.
  */
-val guavaVersion = "30.1.1-jre"
+val guavaVersion = "31.0.1-jre"
 
 /**
  * The version of ErrorProne Gradle plugin.
  *
- * Please keep in sync. with `io.spine.internal.dependency.ErrorProne.GradlePlugin.version`.
+ * Please keep in sync. with [io.spine.internal.dependency.ErrorProne.GradlePlugin.version].
  *
  * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
  *     Error Prone Gradle Plugin Releases</a>
@@ -89,12 +89,12 @@ val errorProneVersion = "2.0.2"
 /**
  * The version of Protobuf Gradle Plugin.
  *
- * Please keep in sync. with `io.spine.internal.dependency.Protobuf.GradlePlugin.version`.
+ * Please keep in sync. with [io.spine.internal.dependency.Protobuf.GradlePlugin.version].
  *
  * @see <a href="https://github.com/google/protobuf-gradle-plugin/releases">
  *     Protobuf Gradle Plugins Releases</a>
  */
-val protobufPluginVersion = "0.8.17"
+val protobufPluginVersion = "0.8.18"
 
 dependencies {
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")

--- a/buildSrc/src/main/groovy/dart/build-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/build-tasks.gradle
@@ -26,6 +26,9 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+println("`build-tasks.gradle` script is deprecated. " +
+        "Please use `DartTasks.build()` extension instead.")
+
 final def GROUP = 'Dart'
 final def packageIndex = "$projectDir/.packages" as File
 final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''

--- a/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
+++ b/buildSrc/src/main/groovy/dart/pub-publish-tasks.gradle
@@ -26,6 +26,9 @@
 
 import org.apache.tools.ant.taskdefs.condition.Os
 
+println("`pub-publish-tasks.gradle` script is deprecated. " +
+        "Please use `DartTasks.publish()` extension instead.")
+
 final def publicationDir = "$buildDir/pub/publication/$project.name"
 final def extension = Os.isFamily(Os.FAMILY_WINDOWS) ? '.bat' : ''
 final def PUB_EXECUTABLE = 'pub' + extension

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
@@ -26,19 +26,9 @@
 
 package io.spine.internal.dependency
 
-// https://checkerframework.org/
-object CheckerFramework {
-    private const val version = "3.21.0"
-    const val annotations = "org.checkerframework:checker-qual:${version}"
-    @Suppress("unused")
-    val dataflow = listOf(
-        "org.checkerframework:dataflow:${version}",
-        "org.checkerframework:javacutil:${version}"
-    )
-    /**
-     * This is discontinued artifact, which we do not use directly.
-     * This is a transitive dependency for us, which we force in
-     * [DependencyResolution.forceConfiguration]
-     */
-    const val compatQual = "org.checkerframework:checker-compat-qual:2.5.5"
+@Suppress("unused")
+object ApacheHttp {
+
+    // https://hc.apache.org/downloads.cgi
+    const val core = "org.apache.httpcomponents:httpcore:4.4.14"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoCommon.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/google/auto
 object AutoCommon {
-    private const val version = "1.0"
+    private const val version = "1.2.1"
     const val lib = "com.google.auto:auto-common:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoService.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/auto
 object AutoService {
-    private const val version = "1.0"
+    private const val version = "1.0.1"
     const val annotations = "com.google.auto.service:auto-service-annotations:${version}"
     @Suppress("unused")
     const val processor   = "com.google.auto.service:auto-service:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AutoValue.kt
@@ -28,6 +28,6 @@ package io.spine.internal.dependency
 
 // https://github.com/google/auto
 object AutoValue {
-    private const val version = "1.8"
+    private const val version = "1.9"
     const val annotations = "com.google.auto.value:auto-value-annotations:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -30,5 +30,5 @@ package io.spine.internal.dependency
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
 @Suppress("unused")
 object CheckStyle {
-    const val version = "9.1"
+    const val version = "9.2"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
  * Commons CLI is a transitive dependency which we don't use directly.
  * We `force` it in [DependencyResolution.forceConfiguration].
  *
- * [Commons CLI]](https://commons.apache.org/proper/commons-cli/)
+ * [Commons CLI](https://commons.apache.org/proper/commons-cli/)
  */
 object CommonsCli {
     private const val version = "1.4"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
@@ -26,19 +26,9 @@
 
 package io.spine.internal.dependency
 
-// https://checkerframework.org/
-object CheckerFramework {
-    private const val version = "3.21.0"
-    const val annotations = "org.checkerframework:checker-qual:${version}"
-    @Suppress("unused")
-    val dataflow = listOf(
-        "org.checkerframework:dataflow:${version}",
-        "org.checkerframework:javacutil:${version}"
-    )
-    /**
-     * This is discontinued artifact, which we do not use directly.
-     * This is a transitive dependency for us, which we force in
-     * [DependencyResolution.forceConfiguration]
-     */
-    const val compatQual = "org.checkerframework:checker-compat-qual:2.5.5"
+// https://commons.apache.org/proper/commons-codec/changes-report.html
+@Suppress("unused")
+object CommonsCodec {
+    private const val version = "1.15"
+    const val lib = "commons-codec:commons-codec:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.8.0"
+    private const val version = "2.10.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
@@ -27,7 +27,8 @@
 package io.spine.internal.dependency
 
 // https://firebase.google.com/docs/admin/setup#java
+@Suppress("unused")
 object Firebase {
-    private const val adminVersion = "6.12.2"
+    private const val adminVersion = "8.1.0"
     const val admin = "com.google.firebase:firebase-admin:${adminVersion}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/google/flogger
 object Flogger {
-    internal const val version = "0.6"
+    internal const val version = "0.7.4"
     const val lib     = "com.google.flogger:flogger:${version}"
     @Suppress("unused")
     object Runtime {

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
@@ -29,29 +29,30 @@ package io.spine.internal.dependency
 /**
  * Provides dependencies on [GoogleApis projects](https://github.com/googleapis/).
  */
+@Suppress("unused")
 object GoogleApis {
 
     // https://github.com/googleapis/google-api-java-client
-    const val client = "com.google.api-client:google-api-client:1.32.1"
+    const val client = "com.google.api-client:google-api-client:1.32.2"
 
     // https://github.com/googleapis/api-common-java
-    const val common = "com.google.api:api-common:2.0.2"
+    const val common = "com.google.api:api-common:2.1.1"
 
     // https://github.com/googleapis/java-common-protos
-    const val commonProtos = "com.google.api.grpc:proto-google-common-protos:2.5.1"
+    const val commonProtos = "com.google.api.grpc:proto-google-common-protos:2.7.0"
 
     // https://github.com/googleapis/gax-java
-    const val gax = "com.google.api:gax:2.5.0"
+    const val gax = "com.google.api:gax:2.7.1"
 
     // https://github.com/googleapis/java-iam
-    const val protoAim = "com.google.api.grpc:proto-google-iam-v1:1.1.3"
+    const val protoAim = "com.google.api.grpc:proto-google-iam-v1:1.2.0"
 
     // https://github.com/googleapis/google-oauth-java-client
     const val oAuthClient = "com.google.oauth-client:google-oauth-client:1.32.1"
 
     // https://github.com/googleapis/google-auth-library-java
     object AuthLibrary {
-        const val version = "1.1.0"
+        const val version = "1.3.0"
         const val credentials = "com.google.auth:google-auth-library-credentials:${version}"
         const val oAuth2Http = "com.google.auth:google-auth-library-oauth2-http:${version}"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
@@ -30,14 +30,14 @@ package io.spine.internal.dependency
 object GoogleCloud {
 
     // https://github.com/googleapis/java-core
-    const val core = "com.google.cloud:google-cloud-core:2.1.7"
+    const val core = "com.google.cloud:google-cloud-core:2.3.3"
 
-    // https://github.com/googleapis/java-pubsub
-    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.95.1"
+    // https://github.com/googleapis/java-pubsub/tree/main/proto-google-cloud-pubsub-v1
+    const val pubSubGrpcApi = "com.google.api.grpc:proto-google-cloud-pubsub-v1:1.97.0"
 
     // https://github.com/googleapis/java-trace
-    const val trace = "com.google.cloud:google-cloud-trace:1.4.1"
+    const val trace = "com.google.cloud:google-cloud-trace:2.1.0"
 
     // https://github.com/googleapis/java-datastore
-    const val datastore = "com.google.cloud:google-cloud-datastore:1.106.5"
+    const val datastore = "com.google.cloud:google-cloud-datastore:2.2.1"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -30,8 +30,9 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.38.0"
+    const val version        = "1.43.1"
     const val api            = "io.grpc:grpc-api:${version}"
+    const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"
     const val context        = "io.grpc:grpc-context:${version}"
     const val stub           = "io.grpc:grpc-stub:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -33,6 +33,6 @@ package io.spine.internal.dependency
  * [Gson](https://github.com/google/gson)
  */
 object Gson {
-    private const val version = "2.8.6"
+    private const val version = "2.8.9"
     const val lib = "com.google.code.gson:gson:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -35,7 +35,7 @@ package io.spine.internal.dependency
  */
 // https://github.com/google/guava
 object Guava {
-    private const val version = "30.1.1-jre"
+    private const val version = "31.0.1-jre"
     const val lib     = "com.google.guava:guava:${version}"
     const val testLib = "com.google.guava:guava-testlib:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -32,10 +32,11 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object HttpClient {
     // https://github.com/googleapis/google-http-java-client
-    const val version  = "1.40.0"
+    const val version  = "1.40.1"
     const val google   = "com.google.http-client:google-http-client:${version}"
     const val jackson2 = "com.google.http-client:google-http-client-jackson2:${version}"
     const val gson     = "com.google.http-client:google-http-client-gson:${version}"
+    const val apache2  = "com.google.http-client:google-http-client-apache-v2:${version}"
 
     const val apache   = "com.google.http-client:google-http-client-apache:2.1.2"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -32,6 +32,10 @@ package io.spine.internal.dependency
  */
 object J2ObjC {
     // https://github.com/google/j2objc/releases
+    // `1.3.` is the latest version available from Maven Central.
+    // https://search.maven.org/artifact/com.google.j2objc/j2objc-annotations
     private const val version = "1.3"
-    const val lib = "com.google.j2objc:j2objc-annotations:${version}"
+    const val annotations = "com.google.j2objc:j2objc-annotations:${version}"
+    @Deprecated("Please use `annotations` instead.", ReplaceWith("annotations"))
+    const val lib = annotations
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -27,15 +27,16 @@
 package io.spine.internal.dependency
 
 // https://junit.org/junit5/
+@Suppress("unused")
 object JUnit {
-    private const val version            = "5.7.1"
-    private const val platformVersion    = "1.7.1"
+    const val version                    = "5.8.2"
+    private const val platformVersion    = "1.8.2"
     private const val legacyVersion      = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
-    private const val apiGuardianVersion = "1.1.1"
+    private const val apiGuardianVersion = "1.1.2"
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion     = "1.3.8"
+    private const val pioneerVersion     = "1.5.0"
 
     const val legacy = "junit:junit:${legacyVersion}"
     val api = listOf(
@@ -43,11 +44,10 @@ object JUnit {
         "org.junit.jupiter:junit-jupiter-api:${version}",
         "org.junit.jupiter:junit-jupiter-params:${version}"
     )
+    const val bom     = "org.junit:junit-bom:${version}"
     const val runner  = "org.junit.jupiter:junit-jupiter-engine:${version}"
-    @Suppress("unused")
     const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
     const val platformCommons = "org.junit.platform:junit-platform-commons:${platformVersion}"
     const val platformLauncher = "org.junit.platform:junit-platform-launcher:${platformVersion}"
-    @Suppress("unused")
     const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 @Suppress("unused")
 object Jackson {
-    private const val version = "2.13.0"
+    private const val version = "2.13.1"
     // https://github.com/FasterXML/jackson-core
     const val core = "com.fasterxml.jackson.core:jackson-core:${version}"
     // https://github.com/FasterXML/jackson-databind

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -32,6 +32,6 @@ package io.spine.internal.dependency
  * [Java JWT](https://github.com/auth0/java-jwt)
  */
 object JavaJwt {
-    private const val version = "3.14.0"
+    private const val version = "3.18.1"
     const val lib = "com.auth0:java-jwt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
@@ -32,6 +32,6 @@ package io.spine.internal.dependency
  * [Klaxon](https://github.com/cbeust/klaxon)
  */
 object Klaxon {
-    private const val version = "5.4"
+    private const val version = "5.5"
     const val lib = "com.beust:klaxon:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 // https://github.com/Kotlin
 object Kotlin {
     @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version      = "1.6.0"
+    const val version      = "1.6.10"
     const val reflect      = "org.jetbrains.kotlin:kotlin-reflect:${version}"
     const val stdLib       = "org.jetbrains.kotlin:kotlin-stdlib:${version}"
     const val stdLibCommon = "org.jetbrains.kotlin:kotlin-stdlib-common:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 @Suppress("unused")
 object Netty {
     // https://github.com/netty/netty/releases
-    private const val version = "4.1.68.Final"
+    private const val version = "4.1.72.Final"
     const val common = "io.netty:netty-common:${version}"
     const val buffer = "io.netty:netty-buffer:${version}"
     const val transport = "io.netty:netty-transport:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -33,6 +33,6 @@ package io.spine.internal.dependency
  * [Plexus Utils](https://codehaus-plexus.github.io/plexus-utils/)
  */
 object Plexus {
-    private const val version = "3.3.0"
+    private const val version = "3.4.0"
     const val utils = "org.codehaus.plexus:plexus-utils:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -29,5 +29,5 @@ package io.spine.internal.dependency
 // https://pmd.github.io/
 @Suppress("unused") // Will be used when `config/gradle/pmd.gradle` migrates to Kotlin.
 object Pmd {
-    const val version = "6.36.0"
+    const val version = "6.41.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 // https://github.com/protocolbuffers/protobuf
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
-    const val version    = "3.18.0"
+    const val version    = "3.19.1"
     val libs = listOf(
         "com.google.protobuf:protobuf-java:${version}",
         "com.google.protobuf:protobuf-java-util:${version}"
@@ -44,7 +44,7 @@ object Protobuf {
          *
          * When changing the version, also change the version used in the `build.gradle.kts`.
          */
-        const val version = "0.8.17"
+        const val version = "0.8.18"
         const val id = "com.google.protobuf"
         const val lib = "com.google.protobuf:protobuf-gradle-plugin:${version}"
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Roaster.kt
@@ -36,7 +36,7 @@ object Roaster {
      *
      * Please see [this issue][https://github.com/SpineEventEngine/config/issues/220] for details.
      */
-    private const val version = "2.22.2.Final"
+    private const val version = "2.23.2.Final"
 
     const val api = "org.jboss.forge.roaster:roaster-api:${version}"
     const val jdt = "org.jboss.forge.roaster:roaster-jdt:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/DependencyResolution.kt
@@ -110,7 +110,7 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         AutoValue.annotations,
         Gson.lib,
-        J2ObjC.lib,
+        J2ObjC.annotations,
         Plexus.utils,
         Okio.lib,
         CommonsCli.lib,

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartContext.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartContext.kt
@@ -24,21 +24,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.dependency
+package io.spine.internal.gradle.dart
 
-// https://checkerframework.org/
-object CheckerFramework {
-    private const val version = "3.21.0"
-    const val annotations = "org.checkerframework:checker-qual:${version}"
-    @Suppress("unused")
-    val dataflow = listOf(
-        "org.checkerframework:dataflow:${version}",
-        "org.checkerframework:javacutil:${version}"
-    )
+import org.gradle.api.Project
+import org.gradle.api.tasks.Exec
+
+/**
+ * Provides access to the current [DartEnvironment] and shortcuts for running `pub` tool.
+ */
+open class DartContext(dartEnv: DartEnvironment, internal val project: Project)
+    : DartEnvironment by dartEnv
+{
     /**
-     * This is discontinued artifact, which we do not use directly.
-     * This is a transitive dependency for us, which we force in
-     * [DependencyResolution.forceConfiguration]
+     * Executes `pub` command in this [Exec] task.
+     *
+     * The Dart ecosystem uses packages to manage shared software such as libraries and tools.
+     * To get or publish Dart packages, the `pub` package manager is to be used.
      */
-    const val compatQual = "org.checkerframework:checker-compat-qual:2.5.5"
+    fun Exec.pub(vararg args: Any) = commandLine(pubExecutable, *args)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartEnvironment.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart
+
+import java.io.File
+import org.apache.tools.ant.taskdefs.condition.Os
+
+/**
+ * Describes the environment in which Dart code is assembled and processed during the build.
+ *
+ * Consists of two parts describing:
+ *
+ *  1. The module itself.
+ *  2. Tools and their input/output files.
+ */
+interface DartEnvironment {
+
+    /*
+     * A module itself
+     ******************/
+
+    /**
+     * Module's root catalog.
+     */
+    val projectDir: File
+
+    /**
+     * Module's name.
+     */
+    val projectName: String
+
+    /**
+     * A directory which all artifacts are generated into.
+     *
+     * Default value: "$projectDir/build".
+     */
+    val buildDir: File
+        get() = projectDir.resolve("build")
+
+    /**
+     * A directory where artifacts for further publishing would be prepared.
+     *
+     * Default value: "$buildDir/pub/publication/$projectName".
+     */
+    val publicationDir: File
+        get() = buildDir
+            .resolve("pub")
+            .resolve("publication")
+            .resolve(projectName)
+
+    /**
+     * A directory which contains integration test Dart sources.
+     *
+     * Default value: "$projectDir/integration-test".
+     */
+    val integrationTestDir: File
+        get() = projectDir.resolve("integration-test")
+
+    /*
+     * Tools and their input/output files
+     *************************************/
+
+    /**
+     * Name of an executable for running `pub` tool.
+     *
+     * Default value:
+     *
+     *  1. "pub.bat" for Windows.
+     *  2. "pub" for other Oss.
+     */
+    val pubExecutable: String
+        get() = if (isWindows()) "pub.bat" else "pub"
+
+    /**
+     * Dart module's metadata file.
+     *
+     * Every pub package needs some metadata so it can specify its dependencies. Pub packages that
+     * are shared with others also need to provide some other information so users can discover
+     * them. All of this metadata goes in the package’s `pubspec`.
+     *
+     * Default value: "$projectDir/pubspec.yaml".
+     *
+     * See [The pubspec file | Dart](https://dart.dev/tools/pub/pubspec)
+     */
+    val pubSpec: File
+        get() = projectDir.resolve("pubspec.yaml")
+
+    /**
+     * Module dependencies' index that maps resolved package names to location URIs.
+     *
+     * By default, pub creates a [packageConfig] file in the `.dart_tool/` directory for this.
+     * Before the [packageConfig], pub used to create this [packageIndex] file in the root
+     * directory.
+     *
+     * As for Dart 2.14,  `pub` still updates the deprecated file for backwards compatibility.
+     *
+     * Default value: "$projectDir/.packages".
+     */
+    val packageIndex: File
+        get() = projectDir.resolve(".packages")
+
+    /**
+     * Module dependencies' index that maps resolved package names to location URIs.
+     *
+     * Default value: "$projectDir/.dart_tool/package_config.json".
+     */
+    val packageConfig: File
+        get() = projectDir
+            .resolve(".dart_tool")
+            .resolve("package_config.json")
+}
+
+/**
+ * Allows overriding [DartEnvironment]'s defaults.
+ *
+ * Please note, not all properties of the environment can be overridden. Properties that describe
+ * `pub` tool's input/output files can NOT be overridden because `pub` itself doesn't allow to
+ * specify them for its execution.
+ *
+ * The next properties could not be overridden:
+ *
+ *  1. [DartEnvironment.pubSpec].
+ *  2. [DartEnvironment.packageIndex].
+ *  3. [DartEnvironment.packageConfig].
+ */
+class ConfigurableDartEnvironment(initialEnv: DartEnvironment)
+    : DartEnvironment by initialEnv
+{
+    /*
+     * A module itself
+     ******************/
+
+    override var projectDir = initialEnv.projectDir
+    override var projectName = initialEnv.projectName
+    override var buildDir = initialEnv.buildDir
+    override var publicationDir = initialEnv.publicationDir
+    override var integrationTestDir = initialEnv.integrationTestDir
+
+    /*
+     * Tools and their input/output files
+     *************************************/
+
+    override var pubExecutable = initialEnv.pubExecutable
+}
+
+internal fun isWindows(): Boolean = Os.isFamily(Os.FAMILY_WINDOWS)

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/DartExtension.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart
+
+import io.spine.internal.gradle.dart.task.DartTasks
+import io.spine.internal.gradle.dart.plugin.DartPlugins
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.create
+import org.gradle.kotlin.dsl.findByType
+
+/**
+ * Configures [DartExtension] that facilitates configuration of Gradle tasks and plugins
+ * to build Dart projects.
+ *
+ * The whole structure of the extension looks as follows:
+ *
+ * ```
+ * dart {
+ *     environment {
+ *         // ...
+ *     }
+ *     plugins {
+ *         // ...
+ *     }
+ *     tasks {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * ### Environment
+ *
+ * One of the main features of this extension is [DartEnvironment]. Environment describes a module
+ * itself and used tools with their input/output files.
+ *
+ * The extension is shipped with a pre-configured environment. So, no pre-configuration is required.
+ * Most properties in [DartEnvironment] have calculated defaults right in the interface.
+ * Only two properties need explicit override.
+ *
+ * The extension defines them as follows:
+ *
+ *  1. [DartEnvironment.projectDir] –> `project.projectDir`.
+ *  2. [DartEnvironment.projectName] —> `project.name`.
+ *
+ * There are two ways to modify the environment:
+ *
+ *  1. Modify [DartEnvironment] interface directly. Go with this option when it is a global change
+ *     that should affect all projects which use this extension.
+ *  2. Use [DartExtension.environment] scope — for temporary and custom overridings.
+ *
+ * An example of a property overriding:
+ *
+ * ```
+ * dart {
+ *     environment {
+ *         integrationTestDir = projectDir.resolve("tests")
+ *     }
+ * }
+ * ```
+ *
+ * Please note, environment should be set up firstly to have the effect on the parts
+ * of the extension that use it.
+ *
+ * ### Tasks and Plugins
+ *
+ * The spirit of tasks configuration in this extension is extracting the code that defines and
+ * registers tasks into extension functions upon `DartTasks` in `buildSrc`. Those extensions should
+ * be named after a task it registers or a task group if several tasks are registered at once.
+ * Then this extension is called in a project's `build.gradle.kts`.
+ *
+ * `DartTasks` and `DartPlugins` scopes extend [DartContext] which provides access
+ * to the current [DartEnvironment] and shortcuts for running `pub` tool.
+ *
+ * Below is the simplest example of how to create a primitive `printPubVersion` task.
+ *
+ * Firstly, a corresponding extension function should be defined in `buildSrc`:
+ *
+ * ```
+ * fun DartTasks.printPubVersion() =
+ *     register<Exec>("printPubVersion") {
+ *         pub("--version")
+ *     }
+ * ```
+ *
+ * Secondly, in a project's `build.gradle.kts` this extension is called:
+ *
+ * ```
+ * dart {
+ *     tasks {
+ *         printPubVersion()
+ *     }
+ * }
+ * ```
+ *
+ * An extension function is not restricted to register exactly one task. If several tasks can
+ * be grouped into a logical bunch, they should be registered together:
+ *
+ * ```
+ * fun DartTasks.build() {
+ *     assembleDart()
+ *     testDart()
+ *     generateCoverageReport()
+ * }
+ *
+ * private fun DartTasks.assembleDart() = ...
+ *
+ * private fun DartTasks.testDart() = ...
+ *
+ * private fun DartTasks.generateCoverageReport() = ...
+ * ```
+ *
+ * This section is mostly dedicated to tasks. But tasks and plugins are configured
+ * in a very similar way. So, everything above is also applicable to plugins. More detailed
+ * guides can be found in docs to `DartTasks` and `DartPlugins`.
+ *
+ * @see [ConfigurableDartEnvironment]
+ * @see [DartTasks]
+ * @see [DartPlugins]
+ */
+fun Project.dart(configuration: DartExtension.() -> Unit) {
+    extensions.run {
+        configuration.invoke(
+            findByType() ?: create("dartExtension", project)
+        )
+    }
+}
+
+/**
+ * Scope for performing Dart-related configuration.
+ *
+ * @see [dart]
+ */
+open class DartExtension(project: Project) {
+
+    private val environment = ConfigurableDartEnvironment(
+        object : DartEnvironment {
+            override val projectDir = project.projectDir
+            override val projectName = project.name
+        }
+    )
+
+    private val tasks = DartTasks(environment, project)
+    private val plugins = DartPlugins(environment, project)
+
+    /**
+     * Overrides default values of [DartEnvironment].
+     *
+     * Please note, environment should be set up firstly to have the effect on the parts
+     * of the extension that use it.
+     */
+    fun environment(overridings: ConfigurableDartEnvironment.() -> Unit) =
+        environment.run(overridings)
+
+    /**
+     * Configures [Dart-related plugins][DartPlugins].
+     */
+    fun plugins(configurations: DartPlugins.() -> Unit) = plugins.run(configurations)
+
+    /**
+     * Configures [Dart-related tasks][DartTasks].
+     */
+    fun tasks(configurations: DartTasks.() -> Unit) = tasks.run(configurations)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/DartPlugins.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/DartPlugins.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.plugin
+
+import io.spine.internal.gradle.dart.DartContext
+import io.spine.internal.gradle.dart.DartEnvironment
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.plugins.PluginContainer
+import org.gradle.api.tasks.TaskContainer
+
+/**
+ * A scope for applying and configuring Dart-related plugins.
+ *
+ * The scope extends [DartContext] and provides shortcuts for key project's containers:
+ *
+ *  1. [plugins].
+ *  2. [extensions].
+ *  3. [tasks].
+ *
+ * Let's imagine one wants to apply and configure `FooBar` plugin. To do that, several steps
+ * should be completed:
+ *
+ *  1. Declare the corresponding extension function upon [DartContext] named after the plugin.
+ *  2. Apply and configure the plugin inside that function.
+ *  3. Call the resulted extension in your `build.gradle.kts` file.
+ *
+ * Here's an example of `dart/plugin/FooBar.kt`:
+ *
+ * ```
+ * fun DartPlugins.fooBar() {
+ *     plugins.apply("com.fooBar")
+ *     extensions.configure<FooBarExtension> {
+ *         // ...
+ *     }
+ * }
+ * ```
+ *
+ * And here's how to apply it in `build.gradle.kts`:
+ *
+ *  ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.plugins.fooBar
+ *
+ * // ...
+ *
+ * dart {
+ *     plugins {
+ *         fooBar()
+ *     }
+ * }
+ *  ```
+ */
+class DartPlugins(dartEnv: DartEnvironment, project: Project) : DartContext(dartEnv, project) {
+
+    internal val plugins = project.plugins
+    internal val extensions = project.extensions
+    internal val tasks = project.tasks
+
+    internal fun plugins(configurations: PluginContainer.() -> Unit) =
+        plugins.run(configurations)
+
+    internal fun extensions(configurations: ExtensionContainer.() -> Unit) =
+        extensions.run(configurations)
+
+    internal fun tasks(configurations: TaskContainer.() -> Unit) =
+        tasks.run(configurations)
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/plugin/Protobuf.kt
@@ -24,21 +24,30 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.dependency
+package io.spine.internal.gradle.dart.plugin
 
-// https://checkerframework.org/
-object CheckerFramework {
-    private const val version = "3.21.0"
-    const val annotations = "org.checkerframework:checker-qual:${version}"
-    @Suppress("unused")
-    val dataflow = listOf(
-        "org.checkerframework:dataflow:${version}",
-        "org.checkerframework:javacutil:${version}"
-    )
-    /**
-     * This is discontinued artifact, which we do not use directly.
-     * This is a transitive dependency for us, which we force in
-     * [DependencyResolution.forceConfiguration]
-     */
-    const val compatQual = "org.checkerframework:checker-compat-qual:2.5.5"
+import com.google.protobuf.gradle.builtins
+import com.google.protobuf.gradle.id
+import com.google.protobuf.gradle.plugins
+import com.google.protobuf.gradle.protobuf
+import com.google.protobuf.gradle.remove
+import io.spine.internal.dependency.Protobuf
+
+/**
+ * Applies `protobuf` plugin and configures `GenerateProtoTask` to work with a Dart module.
+ *
+ * @see DartPlugins
+ */
+fun DartPlugins.protobuf() {
+
+    plugins.apply(Protobuf.GradlePlugin.id)
+
+    project.protobuf {
+        generateProtoTasks.all().forEach { task ->
+            task.apply {
+                plugins { id("dart") }
+                builtins { remove("java") }
+            }
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Build.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Build.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.base.assemble
+import io.spine.internal.gradle.base.check
+import io.spine.internal.gradle.base.clean
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Registers tasks for building Dart projects.
+ *
+ * List of tasks to be created:
+ *
+ *  1. [TaskContainer.cleanPackageIndex].
+ *  2. [TaskContainer.resolveDependencies].
+ *  3. [TaskContainer.testDart].
+ *
+ * An example of how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.build
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *     }
+ * }
+ * ```
+ *
+ * @param configuration any additional configuration related to the module's building.
+ */
+fun DartTasks.build(configuration: DartTasks.() -> Unit = {}) {
+
+    cleanPackageIndex().also {
+        clean.configure {
+            dependsOn(it)
+        }
+    }
+    resolveDependencies().also {
+        assemble.configure {
+            dependsOn(it)
+        }
+    }
+    testDart().also {
+        check.configure {
+            dependsOn(it)
+        }
+    }
+
+    configuration()
+}
+
+private val resolveDependenciesName = TaskName.of("resolveDependencies", Exec::class)
+
+/**
+ * Locates `resolveDependencies` task in this [TaskContainer].
+ *
+ * The task fetches dependencies declared via `pubspec.yaml` using `pub get` command.
+ */
+val TaskContainer.resolveDependencies: TaskProvider<Exec>
+    get() = named(resolveDependenciesName)
+
+private fun DartTasks.resolveDependencies(): TaskProvider<Exec> =
+    register(resolveDependenciesName) {
+
+        description = "Fetches dependencies declared via `pubspec.yaml`."
+        group = DartTasks.Group.build
+
+        mustRunAfter(cleanPackageIndex)
+
+        inputs.file(pubSpec)
+        outputs.file(packageIndex)
+
+        pub("get")
+    }
+
+private val cleanPackageIndexName = TaskName.of("cleanPackageIndex", Delete::class)
+
+/**
+ * Locates `cleanPackageIndex` task in this [TaskContainer].
+ *
+ * The task deletes the resolved module dependencies' index.
+ *
+ * The standard configuration file that contains index is `package_config.json`. For backwards
+ * compatability `pub` still updates the deprecated `.packages` file. The task deletes both files.
+ */
+val TaskContainer.cleanPackageIndex: TaskProvider<Delete>
+    get() = named(cleanPackageIndexName)
+
+private fun DartTasks.cleanPackageIndex(): TaskProvider<Delete> =
+    register(cleanPackageIndexName) {
+
+        description = "Deletes the resolved `.packages` and `package_config.json` files."
+        group = DartTasks.Group.build
+
+        delete(
+            packageIndex,
+            packageConfig
+        )
+    }
+
+private val testDartName = TaskName.of("testDart", Exec::class)
+
+/**
+ * Locates `testDart` task in this [TaskContainer].
+ *
+ * The task runs Dart tests declared in the `./test` directory.
+ */
+val TaskContainer.testDart: TaskProvider<Exec>
+    get() = named(testDartName)
+
+private fun DartTasks.testDart(): TaskProvider<Exec> =
+    register(testDartName) {
+
+        description = "Runs Dart tests declared in the `./test` directory."
+        group = DartTasks.Group.build
+
+        dependsOn(resolveDependencies)
+
+        pub("run", "test")
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/DartTasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/DartTasks.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.dart.DartContext
+import io.spine.internal.gradle.dart.DartEnvironment
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskContainer
+
+/**
+ * A scope for registering and configuring Dart-related tasks.
+ *
+ * The scope provides:
+ *
+ *  1. Access to the current [DartContext].
+ *  2. Project's [TaskContainer].
+ *  3. Default task groups.
+ *
+ * Supposing, one needs to create a new task that would participate in building. Let the task name
+ * be `testDart`. To do that, several steps should be completed:
+ *
+ *  1. Define the task name and type using [TaskName][io.spine.internal.gradle.TaskName].
+ *  2. Create a public typed reference for the task upon [TaskContainer]. It would facilitate
+ *      referencing to the new task, so that external tasks could depend on it. This reference
+ *      should be documented.
+ *  3. Implement an extension upon [DartTasks] to register the task.
+ *  4. Call the resulted extension from `build.gradle.kts`.
+ *
+ * Here's an example of `testDart()` extension:
+ *
+ * ```
+ * import io.spine.internal.gradle.named
+ * import io.spine.internal.gradle.register
+ * import io.spine.internal.gradle.TaskName
+ * import org.gradle.api.Task
+ * import org.gradle.api.tasks.TaskContainer
+ * import org.gradle.api.tasks.Exec
+ *
+ * // ...
+ *
+ * private val testDartName = TaskName.of("testDart", Exec::class)
+ *
+ * /**
+ *  * Locates `testDart` task in this [TaskContainer].
+ *  *
+ *  * The task runs Dart tests declared in the `./test` directory.
+ *  */
+ * val TaskContainer.testDart: TaskProvider<Exec>
+ *     get() = named(testDartName)
+ *
+ * fun DartTasks.testDart() =
+ *     register(testDartName) {
+ *
+ *         description = "Runs Dart tests declared in the `./test` directory."
+ *         group = DartTasks.Group.build
+ *
+ *         // ...
+ *     }
+ * ```
+ *
+ * And here's how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.testDart
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         testDart()
+ *     }
+ * }
+ * ```
+ *
+ * Declaring typed references upon [TaskContainer] is optional. But it is highly encouraged
+ * to reference other tasks by such extensions instead of hard-typed string values.
+ */
+class DartTasks(dartEnv: DartEnvironment, project: Project)
+    : DartContext(dartEnv, project), TaskContainer by project.tasks
+{
+    /**
+     * Default task groups for tasks that participate in building a Dart module.
+     *
+     * @see [org.gradle.api.Task.getGroup]
+     */
+    internal object Group {
+        const val build = "Dart/Build"
+        const val publish = "Dart/Publish"
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/IntegrationTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+private val integrationTestName = TaskName.of("integrationTest", Exec::class)
+
+/**
+ * Locates `integrationTest` task in this [TaskContainer].
+ *
+ * The task runs integration tests of the `spine-dart` library against a sample
+ * Spine-based application. The tests are run in Chrome browser because they use `WebFirebaseClient`
+ * which only works in web environment.
+ *
+ * A sample Spine-based application is run from the `test-app` module before integration
+ * tests start and is stopped as the tests complete.
+ */
+val TaskContainer.integrationTest: TaskProvider<Exec>
+    get() = named(integrationTestName)
+
+/**
+ * Registers [TaskContainer.integrationTest] task.
+ *
+ * Please note, this task depends on [build] tasks. Therefore, building tasks should be applied in
+ * the first place.
+ *
+ * Here's an example of how to apply it in `build.gradle.kts`:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.task.build
+ * import io.spine.internal.gradle.task.integrationTest
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *         integrationTest()
+ *     }
+ * }
+ * ```
+ */
+fun DartTasks.integrationTest() =
+    register(integrationTestName) {
+
+        dependsOn(
+            resolveDependencies,
+            ":test-app:appBeforeIntegrationTest"
+        )
+
+        pub(
+            "run",
+            "test",
+            integrationTestDir,
+            "-p",
+            "chrome"
+        )
+
+        finalizedBy(":test-app:appAfterIntegrationTest")
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/dart/task/Publish.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2021, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.dart.task
+
+import io.spine.internal.gradle.TaskName
+import io.spine.internal.gradle.base.assemble
+import io.spine.internal.gradle.java.publish.publish
+import io.spine.internal.gradle.named
+import io.spine.internal.gradle.register
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskContainer
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Registers tasks for publishing Dart projects.
+ *
+ * Please note, this task group depends on [build] tasks. Therefore, building tasks should
+ * be applied in the first place.
+ *
+ * List of tasks to be created:
+ *
+ *  1. [TaskContainer.stagePubPublication].
+ *  2. [TaskContainer.activateLocally].
+ *  3. [TaskContainer.publishToPub].
+ *
+ * Usage example:
+ *
+ * ```
+ * import io.spine.internal.gradle.dart.dart
+ * import io.spine.internal.gradle.dart.task.build
+ * import io.spine.internal.gradle.dart.task.publish
+ *
+ * // ...
+ *
+ * dart {
+ *     tasks {
+ *         build()
+ *         publish()
+ *     }
+ * }
+ * ```
+ */
+fun DartTasks.publish() {
+
+    stagePubPublication()
+    activateLocally()
+
+    publishToPub().also {
+        publish.configure {
+            dependsOn(it)
+        }
+    }
+}
+
+private val stagePubPublicationName = TaskName.of("stagePubPublication", Copy::class)
+
+/**
+ * Locates `stagePubPublication` in this [TaskContainer].
+ *
+ * The task prepares the Dart package for Pub publication in the
+ * [publication directory][io.spine.internal.gradle.dart.DartEnvironment.publicationDir].
+ */
+val TaskContainer.stagePubPublication: TaskProvider<Copy>
+    get() = named(stagePubPublicationName)
+
+private fun DartTasks.stagePubPublication(): TaskProvider<Copy> =
+    register(stagePubPublicationName) {
+
+        description = "Prepares the Dart package for Pub publication."
+        group = DartTasks.Group.publish
+
+        dependsOn(assemble)
+
+        // Beside `.dart` sources itself, `pub` package manager conventions require:
+        // 1. README.md and CHANGELOG.md to build a page at `pub.dev/packages/<your_package>;`.
+        // 2. `pubspec` file to fill out details about your package on the right side of your
+        //    package’s page.
+        // 3. LICENSE file.
+
+        from(project.projectDir) {
+            include("**/*.dart", "pubspec.yaml", "**/*.md")
+            exclude("proto/", "generated/", "build/", "**/.*")
+        }
+        from("${project.rootDir}/LICENSE")
+        into(publicationDir)
+
+        doLast {
+            logger.debug("Pub publication is prepared in directory `$publicationDir`.")
+        }
+    }
+
+private val publishToPubName = TaskName.of("publishToPub", Exec::class)
+
+/**
+ * Locates `publishToPub` task in this [TaskContainer].
+ *
+ * The task publishes the prepared publication to Pub using `pub publish` command.
+ */
+val TaskContainer.publishToPub: TaskProvider<Exec>
+    get() = named(publishToPubName)
+
+private fun DartTasks.publishToPub(): TaskProvider<Exec> =
+    register(publishToPubName) {
+
+        description = "Publishes the prepared publication to Pub."
+        group = DartTasks.Group.publish
+
+        dependsOn(stagePubPublication)
+
+        val sayYes = "y".byteInputStream()
+        standardInput = sayYes
+
+        workingDir(publicationDir)
+
+        pub("publish", "--trace")
+    }
+
+private val activateLocallyName = TaskName.of("activateLocally", Exec::class)
+
+/**
+ * Locates `activateLocally` task in this [TaskContainer].
+ *
+ * Makes this package available in the command line as an executable.
+ *
+ * The `dart run` command supports running a Dart program — located in a file, in the current
+ * package, or in one of the dependencies of the current package - from the command line.
+ * To run a program from an arbitrary location, the package should be "activated".
+ *
+ * See [dart pub global | Dart](https://dart.dev/tools/pub/cmd/pub-global)
+ */
+val TaskContainer.activateLocally: TaskProvider<Exec>
+    get() = named(activateLocallyName)
+
+private fun DartTasks.activateLocally(): TaskProvider<Exec> =
+    register(activateLocallyName) {
+
+        description = "Activates this package locally."
+        group = DartTasks.Group.publish
+
+        dependsOn(stagePubPublication)
+
+        workingDir(publicationDir)
+        pub(
+            "global",
+            "activate",
+            "--source",
+            "path",
+            publicationDir,
+            "--trace"
+        )
+    }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javac/Javac.kt
@@ -32,14 +32,10 @@ import org.gradle.process.CommandLineArgumentProvider
 /**
  * Configures the `javac` tool through this `JavaCompile` task.
  *
- * There are several steps performed:
+ * The following steps are performed:
  *
- *  1. Ensures JDK 8 is used for compilation;
- *  2. Passes a couple of arguments to the compiler. See [JavacConfig] for more details;
- *  3. Sets the UTF-8 encoding to be used when reading Java source files.
- *
- * Please note that Spine Event Engine can be built with JDK 8 only.
- * Supporting JDK 11 and above at build-time is planned in 2.0 release.
+ *  1. Passes a couple of arguments to the compiler. See [JavacConfig] for more details;
+ *  2. Sets the UTF-8 encoding to be used when reading Java source files.
  *
  * Here's an example of how to use it:
  *

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/kotlin/KotlinConfig.kt
@@ -33,13 +33,21 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
  * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
- * to the specified version (e.g. "11" or "8").
+ * to the specified version (e.g. 11 or 8).
  */
 fun KotlinJvmProjectExtension.applyJvmToolchain(version: Int) {
     jvmToolchain {
         (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(version))
     }
 }
+
+/**
+ * Sets [Java toolchain](https://kotlinlang.org/docs/gradle.html#gradle-java-toolchains-support)
+ * to the specified version (e.g. "11" or "8").
+ */
+@Suppress("unused")
+fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
+    applyJvmToolchain(version.toInt())
 
 /**
  * Opts-in to experimental features that we use in our codebase.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -1,23 +1,24 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.81`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
      * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.6.
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.8.0.
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -25,8 +26,8 @@
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 30.1.1-jre.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 31.0.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
@@ -36,11 +37,11 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -49,7 +50,7 @@
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.21.0.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
@@ -57,23 +58,23 @@
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -90,19 +91,19 @@
      * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
      * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
 
-1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.0.
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.1.
      * **Project URL:** [https://github.com/google/auto/tree/master/common](https://github.com/google/auto/tree/master/common)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.service. **Name** : auto-service. **Version** : 1.0.
+1.  **Group** : com.google.auto.service. **Name** : auto-service. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/auto/tree/master/service](https://github.com/google/auto/tree/master/service)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/auto/tree/master/service](https://github.com/google/auto/tree/master/service)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
      * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -114,29 +115,30 @@
      * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.6.
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.8.0.
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -144,11 +146,11 @@
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 30.1.1-jre.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 31.0.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 30.1.1-jre.
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 31.0.1-jre.
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
@@ -158,15 +160,15 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -183,7 +185,7 @@
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 9.1.
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 9.2.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
@@ -199,7 +201,7 @@
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.6.1.
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.6.2.
      * **Project URL:** [http://picocli.info](http://picocli.info)
      * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -224,10 +226,10 @@
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -238,7 +240,7 @@
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.9.2.
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.9.3.
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
@@ -246,7 +248,7 @@
      * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.1.
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -255,7 +257,7 @@
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.21.0.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
@@ -295,84 +297,84 @@
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.7.1.**No license information found**
-1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 1.3.8.
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.8.2.**No license information found**
+1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 1.5.0.
      * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -381,6 +383,11 @@
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -412,15 +419,15 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 29 20:41:19 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.80`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.81`
 
 ## Runtime
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
      * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -428,17 +435,18 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.6.
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.8.0.
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -446,11 +454,11 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 30.1.1-jre.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 31.0.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 30.1.1-jre.
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 31.0.1-jre.
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
@@ -460,11 +468,11 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
@@ -484,7 +492,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://junit.org](http://junit.org)
      * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
 
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.1.
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -493,7 +501,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.21.0.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
@@ -504,36 +512,36 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.jetbrains.org](http://www.jetbrains.org)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.7.1.**No license information found**
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.7.1.
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.8.2.**No license information found**
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -559,15 +567,15 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://www.github.com/KevinStern/software-and-algorithms](https://www.github.com/KevinStern/software-and-algorithms)
      * **License:** [MIT License](http://www.opensource.org/licenses/mit-license.php)
 
-1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.0.
+1.  **Group** : com.google.auto. **Name** : auto-common. **Version** : 1.2.1.
      * **Project URL:** [https://github.com/google/auto/tree/master/common](https://github.com/google/auto/tree/master/common)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.
+1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/auto/tree/master/service](https://github.com/google/auto/tree/master/service)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.8.
+1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
      * **Project URL:** [https://github.com/google/auto/tree/master/value](https://github.com/google/auto/tree/master/value)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -579,29 +587,30 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://findbugs.sourceforge.net/](http://findbugs.sourceforge.net/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.6.
+1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.8.9.
+     * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
+     * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.8.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.10.0.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.8.0.
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.6.
+1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -609,11 +618,11 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava. **Version** : 30.1.1-jre.
-     * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
+1.  **Group** : com.google.guava. **Name** : guava. **Version** : 31.0.1-jre.
+     * **Project URL:** [https://github.com/google/guava](https://github.com/google/guava)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 30.1.1-jre.
+1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 31.0.1-jre.
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : listenablefuture. **Version** : 9999.0-empty-to-avoid-conflict-with-guava.
@@ -623,15 +632,15 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.18.0.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -648,7 +657,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
 1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.3.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 9.1.
+1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 9.2.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
 
@@ -664,7 +673,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://commons.apache.org/proper/commons-io/](http://commons.apache.org/proper/commons-io/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.6.1.
+1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.6.2.
      * **Project URL:** [http://picocli.info](http://picocli.info)
      * **License:** [The Apache Software License, version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -689,10 +698,10 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.saxonica.com/](http://www.saxonica.com/)
      * **License:** [Mozilla Public License Version 2.0](http://www.mozilla.org/MPL/2.0/)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-core. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
-1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.36.0.
+1.  **Group** : net.sourceforge.pmd. **Name** : pmd-java. **Version** : 6.41.0.
      * **License:** [BSD-style](http://pmd.sourceforge.net/license.html)
 
 1.  **Group** : net.sourceforge.saxon. **Name** : saxon. **Version** : 9.1.0.8.
@@ -703,7 +712,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
-1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.9.2.
+1.  **Group** : org.antlr. **Name** : antlr4-runtime. **Version** : 4.9.3.
      * **Project URL:** [http://www.antlr.org](http://www.antlr.org)
      * **License:** [The BSD License](http://www.antlr.org/license.html)
 
@@ -711,7 +720,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [http://commons.apache.org/proper/commons-lang/](http://commons.apache.org/proper/commons-lang/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.1.
+1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -720,7 +729,7 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.12.0.
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.21.0.
      * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
@@ -760,84 +769,84 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-daemon-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-klib-commonizer-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-script-runtime. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-compiler-impl-embeddable. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-scripting-jvm. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.0.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.6.10.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.7.1.**No license information found**
-1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 1.3.8.
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.8.2.**No license information found**
+1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 1.5.0.
      * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.7.1.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.7.1.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.8.2.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -846,6 +855,11 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.1.
+     * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
+     * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
      * **License:** [BSD-3-Clause](https://asm.ow2.io/license.html)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -877,4 +891,4 @@ This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Dec 12 16:06:17 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 29 20:41:20 EET 2021** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.80</version>
+<version>2.0.0-SNAPSHOT.81</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -26,25 +26,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.flogger</groupId>
     <artifactId>flogger</artifactId>
-    <version>0.6</version>
+    <version>0.7.4</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava</artifactId>
-    <version>30.1.1-jre</version>
+    <version>31.0.1-jre</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,95 +68,95 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-reflect</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-stdlib-jdk8</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.10</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.flogger</groupId>
     <artifactId>flogger-system-backend</artifactId>
-    <version>0.6</version>
+    <version>0.7.4</version>
     <scope>runtime</scope>
   </dependency>
   <dependency>
     <groupId>com.google.guava</groupId>
     <artifactId>guava-testlib</artifactId>
-    <version>30.1.1-jre</version>
+    <version>31.0.1-jre</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.apiguardian</groupId>
     <artifactId>apiguardian-api</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit-pioneer</groupId>
     <artifactId>junit-pioneer</artifactId>
-    <version>1.3.8</version>
+    <version>1.5.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
-    <version>5.7.1</version>
+    <version>5.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.7.1</version>
+    <version>5.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-params</artifactId>
-    <version>5.7.1</version>
+    <version>5.8.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>com.google.auto.service</groupId>
     <artifactId>auto-service</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.auto.service</groupId>
     <artifactId>auto-service-annotations</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_annotations</artifactId>
-    <version>2.8.0</version>
+    <version>2.10.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_core</artifactId>
-    <version>2.8.0</version>
+    <version>2.10.0</version>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_type_annotations</artifactId>
-    <version>2.8.0</version>
+    <version>2.10.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.18.0</version>
+    <version>3.19.1</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>
     <artifactId>checkstyle</artifactId>
-    <version>9.1</version>
+    <version>9.2</version>
   </dependency>
   <dependency>
     <groupId>javax.annotation</groupId>
@@ -167,12 +167,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>net.sourceforge.pmd</groupId>
     <artifactId>pmd-java</artifactId>
-    <version>6.36.0</version>
+    <version>6.41.0</version>
   </dependency>
   <dependency>
     <groupId>org.checkerframework</groupId>
     <artifactId>checker-qual</artifactId>
-    <version>3.12.0</version>
+    <version>3.21.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
@@ -188,17 +188,17 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-compiler-embeddable</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.10</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-klib-commonizer-embeddable</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.10</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.10</version>
   </dependency>
 </dependencies>
 

--- a/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingExtensionTest.java
+++ b/testlib/src/test/java/io/spine/testing/logging/mute/MuteLoggingExtensionTest.java
@@ -37,6 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import java.io.IOException;
 import java.lang.reflect.AnnotatedElement;
@@ -206,6 +207,11 @@ class MuteLoggingExtensionTest extends SystemOutputTest {
         @Override
         public Store getStore(Namespace namespace) {
             return null;
+        }
+
+        @Override
+        public ExecutionMode getExecutionMode() {
+            return ExecutionMode.SAME_THREAD;
         }
     }
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.80"
+val base = "2.0.0-SNAPSHOT.81"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR adds support for glob patterns, adding the `Glob` data class the code of which was initially introduced in `ProtoData`.

This PR improves the original code by:
  * Making it `data class`.
  * Allowing leading dots when creating instances for filtering files by extensions.
  * Disallowing instances with empty patterns.

Latest `config` was also applied.