### PR TITLE
Allow more than one extension per `Glob`

### DIFF
--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -106,8 +106,8 @@ public data class Glob(val pattern: String) {
             if (!iterator().hasNext()) {
                 return listOf()
             }
-            val values: MutableSet<String> = mutableSetOf()
-            val result: MutableList<String> = mutableListOf()
+            val values = mutableSetOf<String>()
+            val result = mutableListOf<String>()
             for (seq in this) {
                 val dotless = seq.withoutLeadingDot()
                 if (allowUpperCase) {

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -57,11 +57,19 @@ public data class Glob(val pattern: String) {
          *
          * @param extension
          *         a file extension with or without the leading dot.
+         * @param allowUpperCase
+         *         If `true` the pattern would match both lowercase and uppercase versions of
+         *         the specified extension. Otherwise, the passed extension will be used as is.
          */
         @JvmStatic
-        public fun extension(extension: CharSequence): Glob {
-            val ext = if (extension.isEmpty()) extension
-            else if (extension[0] == '.') extension.substring(1) else extension
+        @JvmOverloads
+        public fun extension(extension: CharSequence, allowUpperCase: Boolean = false): Glob {
+            val ext: String = if (extension.isEmpty()) ""
+            else if (extension[0] == '.') extension.substring(1) else extension.toString()
+
+            if (allowUpperCase) {
+                return Glob("**.{${ext.lowercase()},${ext.uppercase()}}")
+            }
             return Glob("**.$ext")
         }
     }

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -86,11 +86,12 @@ public data class Glob(val pattern: String) {
             if (ext.isEmpty()) {
                 return Glob("**.")
             }
-            if (ext.size > 1) {
+            return if (ext.size > 1) {
                 val commaSeparated = ext.joinToString(",")
-                return Glob("**.{$commaSeparated}")
+                Glob("**.{$commaSeparated}")
+            } else {
+                Glob("**.${ext[0]}")
             }
-            return Glob("**.${ext[0]}")
         }
 
         /**

--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -64,13 +64,21 @@ public data class Glob(val pattern: String) {
         @JvmStatic
         @JvmOverloads
         public fun extension(extension: CharSequence, allowUpperCase: Boolean = false): Glob {
-            val ext: String = if (extension.isEmpty()) ""
-            else if (extension[0] == '.') extension.substring(1) else extension.toString()
+            val ext: String = extension.withoutDot()
 
             if (allowUpperCase) {
                 return Glob("**.{${ext.lowercase()},${ext.uppercase()}}")
             }
             return Glob("**.$ext")
+        }
+
+        /**
+         * Obtains the string without the leading dot, if present.
+         */
+        private fun CharSequence.withoutDot(): String {
+            if (isEmpty()) return ""
+            return if (this[0] == '.') substring(1)
+            else toString()
         }
     }
 

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -27,6 +27,7 @@
 package io.spine.io
 
 import com.google.common.truth.Truth.assertThat
+import java.nio.file.Path
 import java.nio.file.Paths
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -63,5 +64,25 @@ class `'Glob' should` {
             val matches = g.matches(p)
             assertThat(matches).isTrue()
         }
+    }
+
+    @Test
+    fun `allow both lowercase and uppercase values`() {
+        val g = Glob.extension("hey", true)
+        val lower = Paths.get("file.hey")
+        val upper = Paths.get("another.HEY")
+        val mixed = Paths.get("mix.Hey")
+
+        fun assertMatches(p: Path) {
+            assertThat(g.matches(p)).isTrue()
+        }
+        
+        fun assertDoesNotMatch(p: Path) {
+            assertThat(g.matches(p)).isFalse()
+        }
+
+        assertMatches(lower)
+        assertMatches(upper)
+        assertDoesNotMatch(mixed)
     }
 }

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -27,6 +27,7 @@
 package io.spine.io
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import java.nio.file.Paths
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -71,12 +72,16 @@ class `'Glob' should` {
 
         fun assertMatches(file: String) {
             val p = Paths.get(file)
-            assertThat(g.matches(p)).isTrue()
+            assertWithMessage("The file `%s` should match the pattern `%s`.", file, g.pattern)
+                .that(g.matches(p))
+                .isTrue()
         }
         
         fun assertDoesNotMatch(file: String) {
             val p = Paths.get(file)
-            assertThat(g.matches(p)).isFalse()
+            assertWithMessage("The file `%s` should NOT match the pattern `%s`.", file, g.pattern)
+                .that(g.matches(p))
+                .isFalse()
         }
 
         assertMatches("1.hey")

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -91,7 +91,11 @@ class `'Glob' should` {
         assertMatches("5.mix")
         assertMatches("6.MIX")
 
-        assertDoesNotMatch("X.Hey")
+        assertDoesNotMatch("hey")
+        assertDoesNotMatch("jude.")
+        assertDoesNotMatch("mix")
+        assertDoesNotMatch("mIx")
+        assertDoesNotMatch("miX")
     }
 
     @Test

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -27,7 +27,6 @@
 package io.spine.io
 
 import com.google.common.truth.Truth.assertThat
-import java.nio.file.Path
 import java.nio.file.Paths
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -68,26 +67,32 @@ class `'Glob' should` {
 
     @Test
     fun `allow both lowercase and uppercase values`() {
-        val g = Glob.extensionLowerAndUpper("hey", "jude")
-        val lower = Paths.get("file.hey")
-        val upper = Paths.get("another.HEY")
-        val more = Paths.get("more.JUDE")
-        val another = Paths.get("yet.jude")
-        val mixed = Paths.get("mix.Hey")
+        val g = Glob.extensionLowerAndUpper("hey", "jude", "mIx")
 
-        fun assertMatches(p: Path) {
+        fun assertMatches(file: String) {
+            val p = Paths.get(file)
             assertThat(g.matches(p)).isTrue()
         }
         
-        fun assertDoesNotMatch(p: Path) {
+        fun assertDoesNotMatch(file: String) {
+            val p = Paths.get(file)
             assertThat(g.matches(p)).isFalse()
         }
 
-        assertMatches(lower)
-        assertMatches(upper)
-        assertMatches(more)
-        assertMatches(another)
+        assertMatches("1.hey")
+        assertMatches("2.HEY")
+        assertMatches("3.jude")
+        assertMatches("4.JUDE")
+        assertMatches("5.mix")
+        assertMatches("6.MIX")
 
-        assertDoesNotMatch(mixed)
+        assertDoesNotMatch("X.Hey")
+    }
+
+    @Test
+    fun `create pattern matching files without extensions`() {
+        val noExtensions = Glob.extension()
+        val p = Paths.get("my_file.")
+        assertThat(noExtensions.matches(p)).isTrue()
     }
 }

--- a/base/src/test/kotlin/io/spine/io/GlobTest.kt
+++ b/base/src/test/kotlin/io/spine/io/GlobTest.kt
@@ -68,9 +68,11 @@ class `'Glob' should` {
 
     @Test
     fun `allow both lowercase and uppercase values`() {
-        val g = Glob.extension("hey", true)
+        val g = Glob.extensionLowerAndUpper("hey", "jude")
         val lower = Paths.get("file.hey")
         val upper = Paths.get("another.HEY")
+        val more = Paths.get("more.JUDE")
+        val another = Paths.get("yet.jude")
         val mixed = Paths.get("mix.Hey")
 
         fun assertMatches(p: Path) {
@@ -83,6 +85,9 @@ class `'Glob' should` {
 
         assertMatches(lower)
         assertMatches(upper)
+        assertMatches(more)
+        assertMatches(another)
+
         assertDoesNotMatch(mixed)
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -425,12 +425,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 16:27:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 10 20:16:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.83`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.84`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -903,4 +903,4 @@ This report was generated on **Mon Jan 10 16:27:05 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 16:27:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 10 20:16:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -425,7 +425,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 20:16:06 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 14:00:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -903,4 +903,4 @@ This report was generated on **Mon Jan 10 20:16:06 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 10 20:16:07 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 14:00:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.83</version>
+<version>2.0.0-SNAPSHOT.84</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.83"
+val base = "2.0.0-SNAPSHOT.84"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR extends the `Glob` class to allow having more than one file extension per instance (using the `**.{ext1,ext2}` syntax. 

Also the class got the `extensionLowerAndUpper()` method which allows having both lower- and uppercase versions of extensions for handling unusual cases of seasoned source code files coming with uppercase names.
