### PR TITLE
Improve `Glob` API

### DIFF
--- a/base/src/main/kotlin/io/spine/io/Glob.kt
+++ b/base/src/main/kotlin/io/spine/io/Glob.kt
@@ -54,6 +54,7 @@ public data class Glob(val pattern: String) {
         /**
          * A pattern which matches any file.
          */
+        @JvmField
         public val any: Glob = Glob("**")
 
         /**
@@ -66,8 +67,21 @@ public data class Glob(val pattern: String) {
          * @see [extensionLowerAndUpper]
          */
         @JvmStatic
-        public fun extension(vararg extensions: CharSequence): Glob =
+        public fun extension(vararg extensions: String): Glob =
             create(extensions.toList(), false)
+
+        /**
+         * Creates a pattern which matches any file with the given extensions.
+         *
+         * @param extensions
+         *         file extensions with or without the leading dot.
+         *         If no extensions are specified, the created pattern will match
+         *         files without extensions.
+         * @see [extensionLowerAndUpper]
+         */
+        @JvmStatic
+        public fun extension(extensions: Iterable<String>): Glob =
+            create(extensions, false)
 
         /**
          * Creates a pattern which matches any file with the given extensions in lower- and
@@ -78,10 +92,24 @@ public data class Glob(val pattern: String) {
          *
          * @see [extension]
          */
-        public fun extensionLowerAndUpper(vararg extensions: CharSequence): Glob =
+        @JvmStatic
+        public fun extensionLowerAndUpper(vararg extensions: String): Glob =
             create(extensions.toList(), true)
 
-        private fun create(extensions: Iterable<CharSequence>, allowUpperCase: Boolean): Glob {
+        /**
+         * Creates a pattern which matches any file with the given extensions in lower- and
+         * uppercase versions of specified file extensions.
+         *
+         * Even if char sequences are in passed the `mIxeD` case, only `lower`- and `UPPER`- case
+         * versions of the sequences will be used.
+         *
+         * @see [extension]
+         */
+        @JvmStatic
+        public fun extensionLowerAndUpper(extensions: Iterable<String>): Glob =
+            create(extensions, true)
+
+        private fun create(extensions: Iterable<String>, allowUpperCase: Boolean): Glob {
             val ext: List<String> = extensions.withCaseOptions(allowUpperCase)
             if (ext.isEmpty()) {
                 return Glob("**.")
@@ -102,7 +130,7 @@ public data class Glob(val pattern: String) {
          *         if `true` each entry of the returned list would have lower- and uppercase
          *         version of the sequence. Otherwise, the sequences would be used as is.
          */
-        private fun Iterable<CharSequence>.withCaseOptions(allowUpperCase: Boolean): List<String> {
+        private fun Iterable<String>.withCaseOptions(allowUpperCase: Boolean): List<String> {
             if (!iterator().hasNext()) {
                 return listOf()
             }
@@ -125,10 +153,10 @@ public data class Glob(val pattern: String) {
         /**
          * Obtains the string without the leading dot, if present.
          */
-        private fun CharSequence.withoutLeadingDot(): String {
-            if (isEmpty()) return ""
+        private fun String.withoutLeadingDot(): String {
+            if (isEmpty()) return this
             return if (this[0] == '.') substring(1)
-            else toString()
+            else this
         }
     }
 }

--- a/base/src/test/java/io/spine/io/GlobTest.java
+++ b/base/src/test/java/io/spine/io/GlobTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.io;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Paths;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+@DisplayName("`Glob` Java API should expose")
+class GlobTest {
+
+    /** The test subject. */
+    private Glob glob;
+
+    @Test
+    @DisplayName("`any` pattern")
+    void anyPattern() {
+        assertThat(Glob.any.matches(Paths.get(".")))
+                .isTrue();
+    }
+
+    @Nested
+    @DisplayName("`extensions()` method with")
+    class ExtensionsMethod {
+
+        @Test
+        @DisplayName("`vararg` parameter")
+        void varArg() {
+            glob = Glob.extension(".bar", ".b");
+            assertMatches("f.bar");
+            assertMatches("baz.b");
+        }
+
+        @Test
+        @DisplayName("`Iterable` parameter")
+        void iterableArg() {
+            glob = Glob.extension(ImmutableList.of("cc", "h", "hpp", "cpp"));
+            assertMatches("format.cc");
+            assertMatches("sprintf.h");
+        }
+    }
+
+    @Nested
+    @DisplayName("`extensionLowerAndUpper()` method with")
+    class ExtensionLowerAndUpperMethod {
+
+        @Test
+        @DisplayName("`vararg` parameter")
+        void varArg() {
+            glob = Glob.extensionLowerAndUpper("high", "LOW");
+            assertMatches("1.high");
+            assertMatches("2.HIGH");
+            assertMatches("3.low");
+            assertMatches("4.LOW");
+        }
+
+        @Test
+        @DisplayName("`Iterable` parameter")
+        void iterableParam() {
+            glob = Glob.extensionLowerAndUpper(".snake", "CASE");
+            assertMatches("1.snake");
+            assertMatches("2.SNAKE");
+            assertMatches("3.case");
+            assertMatches("4.CASE");
+        }
+    }
+
+    private void assertMatches(String fileName) {
+        var p = Paths.get(fileName);
+        var matches = glob.matches(p);
+        assertWithMessage(
+                "The file `%s` should match the pattern `%s`.", fileName, glob.getPattern()
+        ).that(matches)
+         .isTrue();
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -425,12 +425,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 14:00:49 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 17:16:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.84`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.85`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -903,4 +903,4 @@ This report was generated on **Tue Jan 11 14:00:49 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 14:00:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 17:16:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -425,7 +425,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:16:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 18:56:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -903,4 +903,4 @@ This report was generated on **Tue Jan 11 17:16:03 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 17:16:05 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 11 18:56:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.84</version>
+<version>2.0.0-SNAPSHOT.85</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.84"
+val base = "2.0.0-SNAPSHOT.85"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR improves the `Glob` class in the following ways:
  * Adds overload method accepting `Iterable<String>` parameters.
  * Makes methods accept `String` instead of `CharSequence`. Working with `CharSequence` was a bit awkward in the implementation, and when using from Java too.
