### PR TITLE
Demote debug level for diag. messages when switching `Environment` type

### DIFF
--- a/base/src/main/java/io/spine/environment/Environment.java
+++ b/base/src/main/java/io/spine/environment/Environment.java
@@ -315,19 +315,19 @@ public final class Environment implements Logging {
         this.currentType = newCurrent;
         @SuppressWarnings("FloggerSplitLogStatement")
                 // See: https://github.com/SpineEventEngine/base/issues/612
-        var info = _info();
+        var debug = _debug();
         if (previous == null) {
             if (newCurrent != null) {
-                info.log("`Environment` set to `%s`.", newCurrent.getName());
+                debug.log("`Environment` set to `%s`.", newCurrent.getName());
             }
         } else {
             if (previous.equals(newCurrent)) {
-                info.log("`Environment` stays `%s`.", newCurrent.getName());
+                debug.log("`Environment` stays `%s`.", newCurrent.getName());
             } else {
                 var newType = newCurrent != null
                               ? backtick(newCurrent.getName())
                               : "undefined";
-                info.log("`Environment` turned from `%s` to %s.", previous.getName(), newType);
+                debug.log("`Environment` turned from `%s` to %s.", previous.getName(), newType);
             }
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -30,7 +30,7 @@ package io.spine.internal.dependency
 @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.19.2"
+    const val version       = "3.19.3"
     val libs = listOf(
         "${group}:protobuf-java:${version}",
         "${group}:protobuf-java-util:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/CheckVersionIncrement.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+import com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES
+import com.fasterxml.jackson.dataformat.xml.XmlMapper
+import io.spine.internal.gradle.Repository
+import java.io.FileNotFoundException
+import java.net.URL
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * A task which verifies that the current version of the library has not been published to the given
+ * Maven repository yet.
+ */
+open class CheckVersionIncrement : DefaultTask() {
+
+    /**
+     * The Maven repository in which to look for published artifacts.
+     *
+     * We check both the `releases` and `snapshots` repositories. Artifacts in either of these repos
+     * may not be overwritten.
+     */
+    @Input
+    lateinit var repository: Repository
+
+    @Input
+    val version: String = project.version as String
+
+    @TaskAction
+    private fun fetchAndCheck() {
+        val artifact = "${project.artifactPath()}/${MavenMetadata.FILE_NAME}"
+        checkInRepo(repository.snapshots, artifact)
+
+        if (repository.releases != repository.snapshots) {
+            checkInRepo(repository.releases, artifact)
+        }
+    }
+
+    private fun checkInRepo(repoUrl: String, artifact: String) {
+        val metadata = fetch(repoUrl, artifact)
+        val versions = metadata?.versioning?.versions
+        val versionExists = versions?.contains(version) ?: false
+        if (versionExists) {
+            throw GradleException("""
+                    Version `$version` is already published to maven repository `$repoUrl`.
+                    Try incrementing the library version.
+                    All available versions are: ${versions?.joinToString(separator = ", ")}. 
+                    
+                    To disable this check, run Gradle with `-x $name`. 
+                    """.trimIndent()
+            )
+        }
+    }
+
+    private fun fetch(repository: String, artifact: String): MavenMetadata? {
+        val url = URL("$repository/$artifact")
+        return MavenMetadata.fetchAndParse(url)
+    }
+
+    private fun Project.artifactPath(): String {
+        val group = this.group as String
+        val name = "spine-${this.name}"
+
+        val pathElements = ArrayList(group.split('.'))
+        pathElements.add(name)
+        val path = pathElements.joinToString(separator = "/")
+        return path
+    }
+}
+
+private data class MavenMetadata(var versioning: Versioning = Versioning()) {
+
+    companion object {
+
+        const val FILE_NAME = "maven-metadata.xml"
+
+        private val mapper = XmlMapper()
+
+        init {
+            mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false)
+        }
+
+        /**
+         * Fetches the metadata for the repository and parses the document.
+         *
+         * <p>If the document could not be found, assumes that the module was never
+         * released and thus has no metadata.
+         */
+        fun fetchAndParse(url: URL): MavenMetadata? {
+            return try {
+                val metadata = mapper.readValue(url, MavenMetadata::class.java)
+                metadata
+            } catch (e: FileNotFoundException) {
+                null
+            }
+        }
+    }
+}
+
+private data class Versioning(var versions: List<String> = listOf())

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:Suppress("unused")
+
+package io.spine.internal.gradle.publish
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+/**
+ * Gradle plugin which adds a [CheckVersionIncrement] task.
+ *
+ * The task is called `checkVersionIncrement` inserted before the `check` task.
+ */
+class IncrementGuard : Plugin<Project> {
+
+    companion object {
+        const val taskName = "checkVersionIncrement"
+    }
+
+    /**
+     * Adds the [CheckVersionIncrement] task to the project.
+     *
+     * Only adds the check if the project is built on Travis CI and the job is a pull request.
+     *
+     * The task only runs on non-master branches on GitHub Actions. This is done
+     * to prevent unexpected CI fails when re-building `master` multiple times, creating git
+     * tags, and in other cases that go outside of the "usual" development cycle.
+     */
+    override fun apply(target: Project) {
+        val tasks = target.tasks
+        tasks.register(taskName, CheckVersionIncrement::class.java) {
+            repository = PublishingRepos.cloudRepo
+            tasks.getByName("check").dependsOn(this)
+
+            shouldRunAfter("test")
+            if (!shouldCheckVersion()) {
+                logger.info(
+                    "The build does not represent a GitHub Actions feature branch job, " +
+                            "the `checkVersionIncrement` task is disabled."
+                )
+                this.enabled = false
+            }
+        }
+    }
+
+    /**
+     * Returns `true` if the current build is a GitHub Actions build which represents a push
+     * to a feature branch.
+     *
+     * Returns `false` if the associated reference is not a branch (e.g. a tag) or if it has
+     * the name which ends with `master`. So, on branches such as `master` and `2.x-jdk8-master`
+     * this method would return `false`.
+     *
+     * @see <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/environment-variables">
+     *     List of default environment variables provided for GitHub Actions builds</a>
+     */
+    private fun shouldCheckVersion(): Boolean {
+        val eventName = System.getenv("GITHUB_EVENT_NAME")
+        if ("push" != eventName) {
+            return false
+        }
+        val reference = System.getenv("GITHUB_REF") ?: return false
+        val matches = Regex("refs/heads/(.+)").matchEntire(reference) ?: return false
+        val branch = matches.groupValues[1]
+        return !branch.endsWith("master")
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishExtension.kt
@@ -40,6 +40,7 @@ abstract class PublishExtension @Inject constructor() {
     abstract val projectsToPublish: SetProperty<String>
     abstract val targetRepositories: SetProperty<Repository>
     abstract val spinePrefix: Property<Boolean>
+    abstract val customPrefix: Property<String>
 
     /**
      * The project to be published _instead_ of [projectsToPublish].
@@ -54,7 +55,7 @@ abstract class PublishExtension @Inject constructor() {
         const val name = "spinePublishing"
 
         /** The prefix to be used before the project name if [spinePrefix] is set to `true`. */
-        const val artifactPrefix = "spine-"
+        const val standardPrefix = "spine-"
 
         /**
          * Creates a new instance of the extension and adds it to the given project.
@@ -62,22 +63,32 @@ abstract class PublishExtension @Inject constructor() {
         fun createIn(project: Project): PublishExtension {
             val extension = project.extensions.create(name, PublishExtension::class.java)
             extension.spinePrefix.convention(true)
+            extension.customPrefix.convention("")
             return extension
         }
     }
 
     /**
      * Obtains an artifact ID of the given project, taking into account the value of
-     * the [spinePrefix] property. If the property is set to `true`, [artifactPrefix] will
+     * the [spinePrefix] and [customPrefix] properties.
+     *
+     * If the `customPrefix` property is set to a non-empty string, it will be used before
+     * the published project name. Otherwise, the [spinePrefix] property is taken into account.
+     *
+     * If the `spinePrefix` property is set to `true`, [standardPrefix] will
      * be used before the project name. Otherwise, just the name of the project will be
      * used as the artifact ID.
      */
-    fun artifactId(project: Project): String =
-        if (spinePrefix.get()) {
-            "$artifactPrefix${project.name}"
+    fun artifactId(project: Project): String {
+        val customPrefix = customPrefix.get()
+        return if (customPrefix.isNotEmpty()) {
+            "$customPrefix${project.name}"
+        } else if (spinePrefix.get()) {
+            "$standardPrefix${project.name}"
         } else {
             project.name
         }
+    }
 
     /**
      * Instructs to publish the passed project _instead_ of [projectsToPublish].

--- a/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
+++ b/buildSrc/src/main/kotlin/pmd-settings.gradle.kts
@@ -41,11 +41,9 @@ pmd {
     // Disable the default rule set to use the custom rules (see below).
     ruleSets = listOf()
 
-    // Load PMD settings from a file in `buildSrc/resources/`.
-    val classLoader = Pmd.javaClass.classLoader
-    val settingsResource = classLoader.getResource("pmd.xml")!!
-    val pmdSettings: String = settingsResource.readText()
-    val textResource: TextResource = resources.text.fromString(pmdSettings)
+    // Load PMD settings.
+    val pmdSettings = file("$rootDir/config/quality/pmd.xml")
+    val textResource: TextResource = resources.text.fromFile(pmdSettings)
     ruleSetConfig = textResource
 
     reportsDir = file("build/reports/pmd")

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -425,12 +425,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 17 19:26:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 17 19:51:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.85`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.86`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -903,4 +903,4 @@ This report was generated on **Mon Jan 17 19:26:33 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 17 19:26:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 17 19:51:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -425,7 +425,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 18:56:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 17 19:26:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -903,4 +903,4 @@ This report was generated on **Tue Jan 11 18:56:50 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 11 18:56:50 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Jan 17 19:26:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -37,15 +37,15 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.5.
@@ -163,18 +163,18 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -425,7 +425,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 17 19:51:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 18 15:26:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -474,15 +474,15 @@ This report was generated on **Mon Jan 17 19:51:47 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
@@ -641,18 +641,18 @@ This report was generated on **Mon Jan 17 19:51:47 EET 2022** using [Gradle-Lice
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.19.3.
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.2.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.19.3.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [3-Clause BSD License](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -903,4 +903,4 @@ This report was generated on **Mon Jan 17 19:51:47 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 17 19:51:48 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 18 15:26:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -38,19 +38,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-kotlin</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -157,7 +157,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.19.2</version>
+    <version>3.19.3</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.85</version>
+<version>2.0.0-SNAPSHOT.86</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.85"
+val base = "2.0.0-SNAPSHOT.86"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
It used to be `INFO`, but it's not very informative and is a bit noisy. This PR demotes it to the `_debug()` level, which is just `FINE`.