### PR TITLE
Make `*-sources.jar` and `*-javadoc.jar` artifacts aware about generated code 

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -32,6 +32,7 @@ import io.spine.internal.dependency.Protobuf
 import io.spine.internal.gradle.IncrementGuard
 import io.spine.internal.gradle.excludeProtobufLite
 import io.spine.internal.gradle.publish.Publish.Companion.publishProtoArtifact
+import io.spine.internal.gradle.publish.Publish.Companion.attachProtoToJavaSources
 import io.spine.internal.gradle.testing.exposeTestArtifacts
 
 plugins {
@@ -53,8 +54,8 @@ dependencies {
 }
 
 val generatedDir by extra("$projectDir/generated")
-val generatedSpineDir by extra("$generatedDir/main/spine")
-val generatedTestSpineDir by extra("$generatedDir/test/spine")
+val generatedSpineDir by extra("$generatedDir/main/java")
+val generatedTestSpineDir by extra("$generatedDir/test/java")
 
 sourceSets {
     main {
@@ -94,7 +95,9 @@ protobuf {
                 classes that duplicate those coming from Protobuf library JARs.
             */
             task.doLast {
+                println("Called deleting")
                 delete("${generatedRoot}/${ssn}/java/${googlePackagePrefix}")
+                delete("${generatedRoot}/${ssn}/java/com")
             }
         }
     }
@@ -116,3 +119,4 @@ tasks.withType(Jar::class) {
 }
 
 publishProtoArtifact(project)
+attachProtoToJavaSources(project)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,7 +84,7 @@ spinePublishing {
         targetRepositories.addAll(
             cloudRepo,
             cloudArtifactRegistry,
-             gitHub("base")
+            gitHub("base")
         )
     }
     projectsToPublish.addAll(subprojects.map { it.path })

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProjectExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProjectExtensions.kt
@@ -49,7 +49,6 @@ import org.gradle.kotlin.dsl.getByType
 @Suppress("unused")
 fun Project.spinePublishing(action: PublishExtension.() -> Unit) {
     apply<Publish>()
-
     val extension = extensions.getByType(PublishExtension::class)
     extension.action()
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publish.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Publish.kt
@@ -30,6 +30,10 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
 import io.spine.internal.gradle.publish.proto.AssembleProto
+import io.spine.internal.gradle.publish.proto.isProtoFileOrDir
+import io.spine.internal.gradle.publish.proto.protoFiles
+import org.gradle.jvm.tasks.Jar
+import org.gradle.kotlin.dsl.named
 
 /**
  * This plugin allows publishing artifacts to remote Maven repositories.
@@ -50,7 +54,7 @@ import io.spine.internal.gradle.publish.proto.AssembleProto
  *     }
  * ```
  * When applied to a multi-module project, the plugin should be applied to the root project.
- * The sub-projects to be published are specified by their names:
+ * The subprojects to be published are specified by their names:
  * ```
  *     import io.spine.gradle.internal.PublishingRepos
  *     import io.spine.gradle.internal.spinePublishing
@@ -119,6 +123,17 @@ class Publish : Plugin<Project> {
             val task = AssembleProto.registerIn(project)
             project.artifacts {
                 add("archives", task)
+            }
+        }
+
+        fun attachProtoToJavaSources(project: Project) {
+            println("Called attachProtoToJavaSources")
+            project.tasks.named<Jar>("sourceJar") {
+                from(project.protoFiles()) {
+                    include {
+                        it.file.isProtoFileOrDir()
+                    }
+                }
             }
         }
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/proto/AssembleProto.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/proto/AssembleProto.kt
@@ -45,8 +45,8 @@ object AssembleProto {
      */
     fun registerIn(project: Project): TaskProvider<Jar> {
         val task = project.tasks.register(taskName, Jar::class.java) {
-            description =
-                "Assembles a JAR artifact with all Proto definitions from the classpath."
+            description = "Assembles a JAR artifact with all Proto definitions from the classpath."
+            println("Called AssembleProto.registerIn")
             from(project.protoFiles())
             include {
                 it.file.isProtoFileOrDir()

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/proto/ProtoLocators.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/proto/ProtoLocators.kt
@@ -48,6 +48,7 @@ import org.gradle.api.file.SourceDirectorySet
  * except those included into the returned `Collection`.
  */
 internal fun Project.protoFiles(): Collection<File> {
+    println("Called Project.protoFiles()")
     val files = this.configurations.findByName("runtimeClasspath")!!.files
     val jarFiles = files.map { JarFileName(it.name) }
     val result = mutableListOf<File>()
@@ -87,6 +88,10 @@ internal fun Project.protoFiles(): Collection<File> {
     val mainSourceSet = this.sourceSets.findByName("main")!!
     val protoSourceDirs = mainSourceSet.extensions.getByName("proto") as SourceDirectorySet
     result.addAll(protoSourceDirs.srcDirs)
+    println("Result of Project.protoFiles(): ${result.size}")
+    result.forEach {
+        println("$it   ---- ${it.isProtoFileOrDir()}")
+    }
     return result
 }
 
@@ -95,7 +100,7 @@ internal fun Project.protoFiles(): Collection<File> {
  *
  * If this file is a directory, scans its children recursively.
  *
- * @return `true` if the this [is a Protobuf file][isProto], or
+ * @return `true` if this [is a Protobuf file][isProto], or
  *         a directory containing at least one Protobuf file,
  *         `false` otherwise
  */

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.8666`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -425,12 +425,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 18 15:26:00 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 07 15:41:10 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.86`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.8666`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -903,4 +903,4 @@ This report was generated on **Tue Jan 18 15:26:00 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 18 15:26:01 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Feb 07 15:41:11 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.86</version>
+<version>2.0.0-SNAPSHOT.8666</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.86"
+val base = "2.0.0-SNAPSHOT.8666"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This one is not going to be merged.
It is a staging PR for changes into `config` repository.