### PR TITLE
Prototype optionality of `testJar` artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,24 +91,6 @@ spinePublishing {
             gitHub("base")
         )
     }
-    protoJar {
-        // disables `protoJar` generation for all published modules
-        disabled = true
-
-        // disables `protoJar` generation for the specified modules
-        exclusions = setOf(
-            "teslib"
-        )
-    }
-    testJar {
-        // enables `testJar` generation for all published modules
-        enabled = true
-
-        // enables `testJar` generation for the specified modules
-        inclusions = setOf(
-            "base"
-        )
-    }
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,8 +91,6 @@ spinePublishing {
             gitHub("base")
         )
     }
-    protoJar {
-    }
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,8 @@ spinePublishing {
             gitHub("base")
         )
     }
+    protoJar {
+    }
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,24 @@ spinePublishing {
             gitHub("base")
         )
     }
+    protoJar {
+        // disables `protoJar` generation for all published modules
+        disabled = true
+
+        // disables `protoJar` generation for the specified modules
+        exclusions = setOf(
+            "teslib"
+        )
+    }
+    testJar {
+        // enables `testJar` generation for all published modules
+        enabled = true
+
+        // enables `testJar` generation for the specified modules
+        inclusions = setOf(
+            "base"
+        )
+    }
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/Artifacts.kt
@@ -89,12 +89,12 @@ internal fun Project.protoJar() = tasks.getOrCreate("protoJar") {
 }
 
 /**
- * Locates or creates `testOutputJar` task in this [Project].
+ * Locates or creates `testJar` task in this [Project].
  *
  * The output of this task is a `jar` archive. The archive contains compilation output
  * of `test` source set.
  */
-internal fun Project.testOutputJar() = tasks.getOrCreate("testOutputJar") {
+internal fun Project.testJar() = tasks.getOrCreate("testJar") {
     archiveClassifier.set("test")
     from(sourceSets["test"].output)
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
@@ -27,17 +27,18 @@
 package io.spine.internal.gradle.publish
 
 /**
- * Allows disabling publication of [protoJar] artifact, containing all the `.proto` definitions
- * from `sourceSets.main.proto`.
+ * A DSL element of [SpinePublishing] extension which allows disabling publication
+ * of [protoJar] artifact.
  *
- * This artifact is published by default.
+ * This artifact contains all the `.proto` definitions from `sourceSets.main.proto`. By default,
+ * it is published.
  *
  * @see [registerArtifacts]
  */
 class ProtoJar {
 
     /**
-     * Set of modules, for which a proto JAR will NOT be published.
+     * Set of modules, for which a proto JAR will not be published.
      */
     var exclusions: Set<String> = emptySet()
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
@@ -27,11 +27,13 @@
 package io.spine.internal.gradle.publish
 
 /**
- * A DSL element of [SpinePublishing] extension which allows disabling publication
+ * A DSL element of [SpinePublishing] extension which allows disabling publishing
  * of [protoJar] artifact.
  *
  * This artifact contains all the `.proto` definitions from `sourceSets.main.proto`. By default,
  * it is published.
+ *
+ * Take a look on [SpinePublishing.protoJar] for a usage example.
  *
  * @see [registerArtifacts]
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/ProtoJar.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+/**
+ * Allows disabling publication of [protoJar] artifact, containing all the `.proto` definitions
+ * from `sourceSets.main.proto`.
+ *
+ * This artifact is published by default.
+ *
+ * @see [registerArtifacts]
+ */
+class ProtoJar {
+
+    /**
+     * Set of modules, for which a proto JAR will NOT be published.
+     */
+    var exclusions: Set<String> = emptySet()
+
+    /**
+     * Disables proto JAR publishing for all published modules.
+     */
+    var disabled = false
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -85,7 +85,7 @@ private fun PublishingConfig.createPublication(project: Project) {
  *  1. [sourcesJar] – Java, Kotlin and Proto source files.
  *  2. [javadocJar] – documentation, generated upon Java files.
  *
- *  Optionally, the following artifacts can also be registered:
+ * Optionally, the following artifacts can also be registered:
  *
  *  1. [testJar] – compilation output of "test" source set.
  *  2. [protoJar] – only Proto source files.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -36,15 +36,15 @@ import org.gradle.kotlin.dsl.apply
  * Information, required to set up publishing of a project using `maven-publish` plugin.
  *
  * @param artifactId a name that a project is known by.
+ * @param destinations set of repositories, to which the resulting artifacts will be sent.
  * @param includeProtoJar tells whether [protoJar] artifact should be published.
  * @param includeTestJar tells whether [testJar] artifact should be published.
- * @param destinations set of repositories, to which the resulting artifacts will be sent.
  */
 internal class PublishingConfig(
     val artifactId: String,
+    val destinations: Collection<Repository>,
     val includeProtoJar: Boolean = true,
     val includeTestJar: Boolean = false,
-    val destinations: Collection<Repository>,
 )
 
 /**
@@ -80,12 +80,15 @@ private fun PublishingConfig.createPublication(project: Project) {
  * By default, only a jar with java compilation output is included into publication. This method
  * registers tasks which produce additional artifacts.
  *
- * The list of additional artifacts:
+ * The list of default artifacts:
  *
  *  1. [sourcesJar] – Java, Kotlin and Proto source files.
  *  2. [javadocJar] – documentation, generated upon Java files.
- *  3. [testJar] – compilation output of "test" source set.
- *  4. [protoJar] – only Proto sources. It is an optional artifact.
+ *
+ *  Optionally, the following artifacts can also be registered:
+ *
+ *  1. [testJar] – compilation output of "test" source set.
+ *  2. [protoJar] – only Proto source files.
  *
  * @return the list of the registered tasks.
  */
@@ -99,12 +102,13 @@ private fun Project.registerArtifacts(
         javadocJar(),
     )
 
-    // We don't want to have an empty "proto.jar",
-    // when a project doesn't have any Proto files at all.
-
+    // We don't want to have an empty "proto.jar" when a project doesn't have any Proto files.
     if (hasProto() && includeProtoJar) {
         artifacts.add(protoJar())
     }
+
+    // We don't have the corresponding `hasTests()` check, since this artifact is disabled
+    // by default. And turning it on means "We have tests and need them to be published."
     if (includeTestJar) {
         artifacts.add(testJar())
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/PublishingConfig.kt
@@ -80,7 +80,7 @@ private fun PublishingConfig.createPublication(project: Project) {
  * By default, only a jar with java compilation output is included into publication. This method
  * registers tasks which produce additional artifacts.
  *
- * The list of default artifacts:
+ * The list of additional artifacts:
  *
  *  1. [sourcesJar] – Java, Kotlin and Proto source files.
  *  2. [javadocJar] – documentation, generated upon Java files.
@@ -107,7 +107,7 @@ private fun Project.registerArtifacts(
         artifacts.add(protoJar())
     }
 
-    // We don't have the corresponding `hasTests()` check, since this artifact is disabled
+    // Here, we don't have the corresponding `hasTests()` check, since this artifact is disabled
     // by default. And turning it on means "We have tests and need them to be published."
     if (includeTestJar) {
         artifacts.add(testJar())

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/SpinePublishing.kt
@@ -72,7 +72,7 @@ import org.gradle.kotlin.dsl.findByType
  *
  * In Gradle, in order to publish something somewhere one should create a publication. In each
  * of published modules, the extension will create a [publication][MavenJavaPublication]
- * named "mavenJava".
+ * named "mavenJava". All artifacts, published by this extension belong to this publication.
  *
  * By default, along with the compilation output of "main" source set, the extension publishes
  * the following artifacts:
@@ -99,9 +99,8 @@ import org.gradle.kotlin.dsl.findByType
  *   Proto files are actually present in the source set. Publication of this artifact is optional
  *   and can be disabled via [SpinePublishing.protoJar].
  *
- * Additionally, [testJar] artifact can be added to the publication. This artifact contains
- * compilation output of "test" source set. It is not published by default. Use
- * [SpinePublishing.testJar] to enable publishing of this artifact.
+ * Additionally, [testJar] artifact can be published. This artifact contains compilation output
+ * of "test" source set. Use [SpinePublishing.testJar] to enable its publishing.
  *
  * @see [registerArtifacts]
  */

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
@@ -27,11 +27,13 @@
 package io.spine.internal.gradle.publish
 
 /**
- * A DSL element of [SpinePublishing] extension which allows enabling publication
+ * A DSL element of [SpinePublishing] extension which allows enabling publishing
  * of [testJar] artifact.
  *
- * The artifact contains compilation output of `test` source set. By default, it is not published.
+ * This artifact contains compilation output of `test` source set. By default, it is not published.
  *
+ * Take a look on [SpinePublishing.testJar] for a usage example.
+
  * @see [registerArtifacts]
  */
 class TestJar {

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.internal.gradle.publish
+
+/**
+ * Allows enabling publication of [testJar] artifact, containing compilation output
+ * of `test` source set.
+ *
+ * This artifact is not published by default.
+ *
+ * @see [registerArtifacts]
+ */
+class TestJar {
+
+    /**
+     * Set of modules, for which a test JAR will be published.
+     */
+    var inclusions: Set<String> = emptySet()
+
+    /**
+     * Enables test JAR publishing for all published modules.
+     */
+    var enabled = false
+}

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/TestJar.kt
@@ -27,10 +27,10 @@
 package io.spine.internal.gradle.publish
 
 /**
- * Allows enabling publication of [testJar] artifact, containing compilation output
- * of `test` source set.
+ * A DSL element of [SpinePublishing] extension which allows enabling publication
+ * of [testJar] artifact.
  *
- * This artifact is not published by default.
+ * The artifact contains compilation output of `test` source set. By default, it is not published.
  *
  * @see [registerArtifacts]
  */

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.88`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -421,12 +421,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 22 18:43:13 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 15:54:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.87`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.88`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -895,4 +895,4 @@ This report was generated on **Tue Mar 22 18:43:13 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 22 18:43:14 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Mar 28 15:54:34 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.87</version>
+<version>2.0.0-SNAPSHOT.88</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.87"
+val base = "2.0.0-SNAPSHOT.88"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
It is a staging PR for prototyping changes to `config` repository.
It is NOT going to be merged.

---

This changeset makes `testJar` artifact optional. This artifact contains compilation output of `test` source test. As for now, we already have one optional `protoJar` artifact.

First option. API is similar to `protoJar`. With one significant difference. `protoJar` tends to be included for most published modules, while `testJar` tends to be excluded for most published modules.

```kotlin
spinePublishing {
    modules = setOf(...)
    destinations = setOf(...)
    protoJar {
        // disables `protoJar` generation for the specified modules
        exclusions = setOf(
            "base",
            "testlib",
        )
        // disables `protoJar` generation for all published modules
        disabled = true
    }
    testJar {
        // enables `testJar` generation for the specified modules
        inclusions = setOf(
            "base",
            "testlib",
        )
        // enables `testJar` generation for all published modules
        enabled = true
    }
}
```

Second option. All non-default artifacts are custom ones. They can be "enabled" within `customArtifacts` scope.

```kotlin
spinePublishing {
    modules = setOf(...)
    destinations = setOf(...)
    customArtifacts {
        // enables `protoJar` generation for the specified modules
        protoJar().forModules("base", "testlib")
        // enables `protoJar` generation for all published modules
        protoJar()

        // enables `testJar` generation for the specified modules
        testJar().forModules("base", "testlib")
        // enables `testJar` generation for all published modules
        testJar()
    }
}
```

Third option. Similar to the second, but takes into account that `protoJar` is mostly included while `testJar` is mostly excluded. It is reflected in methods' naming.

```kotlin
spinePublishing {
    modules = setOf(...)
    destinations = setOf(...)
    artifacts {
        // disables `protoJar` generation for the specified modules
        disableProtoJar().forModules("base", "testlib")
        // disables `protoJar` generation for all published modules
        disableProtoJar()

        // enables `testJar` generation for the specified modules
        enableTestJar().forModules("base", "testlib")
        // enables `testJar` generation for all published modules
        enableTestJar()
    }
}
```