### PR TITLE
Remove Dokka multimodule functionality

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,7 +102,6 @@ allprojects {
         plugin("jacoco")
         plugin("idea")
         plugin("project-report")
-        plugin("dokka-for-java")
     }
 
     group = "io.spine"
@@ -136,6 +135,7 @@ subprojects {
     // Apply custom Kotlin script plugins.
     apply {
         plugin("pmd-settings")
+        plugin("dokka-for-java")
     }
 
     CheckStyleConfig.applyTo(project)

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -520,12 +520,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Apr 23 22:58:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 26 09:41:38 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.90`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.91`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1093,4 +1093,4 @@ This report was generated on **Sat Apr 23 22:58:50 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Apr 23 22:58:51 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 26 09:41:43 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.90</version>
+<version>2.0.0-SNAPSHOT.91</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -198,27 +198,12 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
-    <artifactId>all-modules-page-plugin</artifactId>
-    <version>1.6.20</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.dokka</groupId>
     <artifactId>dokka-base</artifactId>
     <version>1.6.20</version>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
     <artifactId>dokka-core</artifactId>
-    <version>1.6.20</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.dokka</groupId>
-    <artifactId>gfm-template-processing-plugin</artifactId>
-    <version>1.6.20</version>
-  </dependency>
-  <dependency>
-    <groupId>org.jetbrains.dokka</groupId>
-    <artifactId>jekyll-template-processing-plugin</artifactId>
     <version>1.6.20</version>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.90"
+val base = "2.0.0-SNAPSHOT.91"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR removes tasks for generating multi-module documentation by Dokka. It is done by moving the application of `dokka-for-java` plugin from `allprojects{}` to `subprojects{}` block. The reasons behind these changes are the following:
- we do not need this functionality;
- custom `dokka-for-java` plugin does not configure multi-module Dokka tasks.