### PR TITLE
More on unpulished language

### DIFF
--- a/base/src/main/java/io/spine/annotation/Internal.java
+++ b/base/src/main/java/io/spine/annotation/Internal.java
@@ -65,7 +65,7 @@ import java.lang.annotation.Target;
  * @see SPI
  */
 @Internal
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({
         ElementType.ANNOTATION_TYPE,
         ElementType.CONSTRUCTOR,

--- a/base/src/main/java/io/spine/annotation/Internal.java
+++ b/base/src/main/java/io/spine/annotation/Internal.java
@@ -34,7 +34,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotates a program element (class, method, package, etc.) which is not a part of a public API,
- * and thus should not be used.
+ * and thus should not be used by people who are not members of the team developing the module
+ * containing this program element.
  *
  * <p>If the annotation is used for a constructor, a field, a method, or a package, it means
  * that corresponding element is internal to the Spine Event Engine and as such should

--- a/base/src/main/java/io/spine/annotation/Internal.java
+++ b/base/src/main/java/io/spine/annotation/Internal.java
@@ -33,8 +33,27 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates a program element (class, method, package, etc.) which is internal to Spine and is
- * not a part of the public API, and thus should not be used by users of the framework.
+ * Annotates a program element (class, method, package, etc.) which is not a part of a public API,
+ * and thus should not be used.
+ *
+ * <p>If the annotation is used for a constructor, a field, a method, or a package, it means
+ * that corresponding element is internal to the Spine Event Engine and as such should
+ * not be used programmers using the framework.
+ *
+ * <p>If the annotation is used for a type it may mean one of the following:
+ * <ol>
+ *     <li>This type is internal to the Spine Event Engine framework.
+ *
+ *     <li><p>The type is internal to a bounded context, artifact of which exposes the type to
+ *     the outside world (presumably for historical reasons).</p>
+ *
+ *     <p>The type with this annotation can be used only inside the bounded context
+ *     which declares it.</p>
+ *
+ *     <p>The type must not be used neither for inbound (i.e. being sent to the bounded context
+ *     which declares this type) nor for outbound communication (i.e. being sent by this bounded
+ *     context to another bounded context).</p>
+ * </ol>
  *
  * <p>If you plan to implement an extension which is going to be wired into the framework,
  * you may want to use the internal parts. Please consider consulting with the Spine

--- a/base/src/main/java/io/spine/annotation/Internal.java
+++ b/base/src/main/java/io/spine/annotation/Internal.java
@@ -37,29 +37,29 @@ import java.lang.annotation.Target;
  * and thus should not be used by people who are not members of the team developing the module
  * containing this program element.
  *
- * <p>If the annotation is used for a constructor, a field, a method, or a package, it means
+ * <p>If the annotation is used for a constructor, a <strong>field</strong>,
+ * a <strong>method</strong>, or a <strong>package</strong>, it means
  * that corresponding element is internal to the Spine Event Engine and as such should
  * not be used programmers using the framework.
  *
- * <p>If the annotation is used for a type it may mean one of the following:
- * <ol>
- *     <li>This type is internal to the Spine Event Engine framework.
+ * <p>If the annotation is used for a <strong>type</strong> it means one of the following.
  *
- *     <li><p>The type is internal to a bounded context, artifact of which exposes the type to
- *     the outside world (presumably for historical reasons).</p>
+ * <p><strong>First reason.</strong> This type is internal to the Spine Event Engine framework,
+ * and is not meant to be used directly by the framework users.</p>
  *
- *     <p>The type with this annotation can be used only inside the bounded context
- *     which declares it.</p>
+ * <p><strong>Second reason.</strong> The type is internal to a bounded context, artifact of which
+ * exposes the type to the outside world (presumably for historical reasons).</p>
  *
- *     <p>The type must not be used neither for inbound (i.e. being sent to the bounded context
- *     which declares this type) nor for outbound communication (i.e. being sent by this bounded
- *     context outside).</p>
- * </ol>
+ * <p>When so, the type with this annotation can be used only inside the bounded context
+ * which declares it.
  *
- * <p>If you plan to implement an extension which is going to be wired into the framework,
- * you may want to use the internal parts. Please consider consulting with the Spine
- * development team, as the internal APIs do not have the same stability API guarantee as
- * public ones.
+ * <p>The type must not be used neither for inbound (i.e. being sent to the bounded context
+ * which declares this type) nor for outbound communication (i.e. being sent by this bounded
+ * context outside). An attempt to use the type otherwise will cause runtime error.</p>
+ *
+ * @apiNote If you plan to implement an extension which is going to be wired into
+ * the framework, you may want to use the internal parts. Please consider consulting with the Spine
+ * development team, as the internal APIs do not have the same stability guarantee as public ones.
  *
  * <p>See {@link SPI} annotation if you plan to write an extension of the framework.
  *

--- a/base/src/main/java/io/spine/annotation/Internal.java
+++ b/base/src/main/java/io/spine/annotation/Internal.java
@@ -52,7 +52,7 @@ import java.lang.annotation.Target;
  *
  *     <p>The type must not be used neither for inbound (i.e. being sent to the bounded context
  *     which declares this type) nor for outbound communication (i.e. being sent by this bounded
- *     context to another bounded context).</p>
+ *     context outside).</p>
  * </ol>
  *
  * <p>If you plan to implement an extension which is going to be wired into the framework,

--- a/base/src/main/java/io/spine/query/AbstractQueryBuilder.java
+++ b/base/src/main/java/io/spine/query/AbstractQueryBuilder.java
@@ -49,6 +49,7 @@ import static io.spine.query.Direction.ASC;
 import static io.spine.query.Direction.DESC;
 import static io.spine.query.LogicalOperator.AND;
 import static io.spine.query.LogicalOperator.OR;
+import static io.spine.type.MessageExtensions.requirePublished;
 import static io.spine.util.Preconditions2.checkPositive;
 
 /**
@@ -92,7 +93,7 @@ abstract class AbstractQueryBuilder<I,
 
     AbstractQueryBuilder(Class<I> idType, Class<R> recordType) {
         this.idType = idType;
-        this.recordType = recordType;
+        this.recordType = requirePublished(recordType);
     }
 
     /**

--- a/base/src/main/java/io/spine/query/AbstractQueryBuilder.java
+++ b/base/src/main/java/io/spine/query/AbstractQueryBuilder.java
@@ -49,7 +49,6 @@ import static io.spine.query.Direction.ASC;
 import static io.spine.query.Direction.DESC;
 import static io.spine.query.LogicalOperator.AND;
 import static io.spine.query.LogicalOperator.OR;
-import static io.spine.type.MessageExtensions.requirePublished;
 import static io.spine.util.Preconditions2.checkPositive;
 
 /**
@@ -93,7 +92,7 @@ abstract class AbstractQueryBuilder<I,
 
     AbstractQueryBuilder(Class<I> idType, Class<R> recordType) {
         this.idType = idType;
-        this.recordType = requirePublished(recordType);
+        this.recordType = recordType;
     }
 
     /**

--- a/base/src/main/java/io/spine/type/UnexpectedTypeException.java
+++ b/base/src/main/java/io/spine/type/UnexpectedTypeException.java
@@ -29,7 +29,7 @@ package io.spine.type;
 import static java.lang.String.format;
 
 /**
- * Thrown when the content of {@link com.google.protobuf.Any Any} does not
+ * Thrown when the type packed into {@link com.google.protobuf.Any Any} does not
  * match one we expect when unpacking.
  *
  * <p>Typically this exception wraps

--- a/base/src/main/java/io/spine/type/UnexpectedTypeException.java
+++ b/base/src/main/java/io/spine/type/UnexpectedTypeException.java
@@ -29,7 +29,7 @@ package io.spine.type;
 import static java.lang.String.format;
 
 /**
- * Exception thrown when the content of {@link com.google.protobuf.Any Any} does not
+ * Thrown when the content of {@link com.google.protobuf.Any Any} does not
  * match one we expect when unpacking.
  *
  * <p>Typically this exception wraps

--- a/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
+++ b/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.type;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+/**
+ * Thrown when a Protobuf type having the {@code internal_type} option is sent
+ * to a bounded context which declares it. Or, when the declaring bounded context attempts
+ * to send this type outside.
+ *
+ * <p>A Java type corresponding to a Protobuf type with the {@code internal_type} option
+ * is expected to be annotated as {@link io.spine.annotation.Internal Internal}.
+ *
+ * @see io.spine.annotation.Internal
+ */
+public class UnpublishedLanguageException extends RuntimeException {
+
+    private static final long serialVersionUID = 0L;
+
+    public UnpublishedLanguageException(TypeName type) {
+        super(formatMsg(type));
+    }
+
+    private static String formatMsg(TypeName type) {
+        checkNotNull(type);
+        return format(
+                "The type `%s` is not a part of the published language" +
+                        " of its bounded context.", type
+        );
+    }
+}

--- a/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
+++ b/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
@@ -28,9 +28,8 @@ package io.spine.type;
 
 import com.google.protobuf.Message;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static io.spine.type.MessageExtensions.isInternal;
+import static io.spine.type.MessageExtensions.requireInternal;
 import static java.lang.String.format;
 
 /**
@@ -57,12 +56,7 @@ public class UnpublishedLanguageException extends RuntimeException {
      *         if the message is not annotated as internal
      */
     public UnpublishedLanguageException(Message msg) {
-        this(TypeName.of(checkInternal(msg)));
-    }
-
-    private static Message checkInternal(Message msg) {
-        checkArgument(isInternal(msg));
-        return msg;
+        this(TypeName.of(requireInternal(msg)));
     }
 
     private UnpublishedLanguageException(TypeName type) {

--- a/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
+++ b/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
@@ -26,7 +26,11 @@
 
 package io.spine.type;
 
+import com.google.protobuf.Message;
+
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.type.MessageExtensions.isInternal;
 import static java.lang.String.format;
 
 /**
@@ -43,7 +47,25 @@ public class UnpublishedLanguageException extends RuntimeException {
 
     private static final long serialVersionUID = 0L;
 
-    public UnpublishedLanguageException(TypeName type) {
+    /**
+     * Creates an exception referencing the proto type of the passed
+     * message instance annotated as {@link io.spine.annotation.Internal Internal}.
+     *
+     * @param msg
+     *         the message to report
+     * @throws IllegalArgumentException
+     *         if the message is not annotated as internal
+     */
+    public UnpublishedLanguageException(Message msg) {
+        this(TypeName.of(checkInternal(msg)));
+    }
+
+    private static Message checkInternal(Message msg) {
+        checkArgument(isInternal(msg));
+        return msg;
+    }
+
+    private UnpublishedLanguageException(TypeName type) {
         super(formatMsg(type));
     }
 
@@ -51,7 +73,8 @@ public class UnpublishedLanguageException extends RuntimeException {
         checkNotNull(type);
         return format(
                 "The type `%s` is not a part of the published language" +
-                        " of its bounded context.", type
+                        " of its bounded context." +
+                        " As such it cannot be sent to/from outside this bounded context.", type
         );
     }
 }

--- a/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
+++ b/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:JvmName("MessageExtensions")
+
+package io.spine.type
+
+import com.google.protobuf.Message
+import io.spine.annotation.Internal
+
+/**
+ * Tells if this message type is internal to a bounded context.
+ */
+public fun <T: Message> T.isInternal(): Boolean =
+    this::class.java.isAnnotationPresent(Internal::class.java)
+
+/**
+ * Obtains the name of this message type.
+ */
+public val <T: Message> T.typeName: TypeName
+    get() = TypeName.of(this)

--- a/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
+++ b/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
@@ -42,3 +42,32 @@ public fun <T: Message> T.isInternal(): Boolean =
  */
 public val <T: Message> T.typeName: TypeName
     get() = TypeName.of(this)
+
+/**
+ * Verifies that the given message instance is annotated with
+ * [io.spine.annotation.Internal] and if so, returns it.
+ *
+ * @throws IllegalArgumentException
+ *          if the message is not internal
+ */
+public fun requireInternal(msg: Message): Message {
+    require(msg.isInternal()) {
+        "The message class `${msg::class.java.canonicalName}` is not" +
+                "annotated as `${Internal::class.java.canonicalName}`."
+    }
+    return msg
+}
+
+/**
+ * Verifies if the given message is not internal to a bounded context,
+ * returning it if so.
+ *
+ * @throws UnpublishedLanguageException
+ *          if the given message is internal
+ */
+public fun requirePublished(msg: Message): Message {
+    if (msg.isInternal()) {
+        throw UnpublishedLanguageException(msg)
+    }
+    return msg
+}

--- a/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
+++ b/base/src/main/kotlin/io/spine/type/MessageExtensions.kt
@@ -28,14 +28,22 @@
 
 package io.spine.type
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue
 import com.google.protobuf.Message
 import io.spine.annotation.Internal
+import io.spine.protobuf.Messages.defaultInstance
 
 /**
  * Tells if this message type is internal to a bounded context.
  */
 public fun <T: Message> T.isInternal(): Boolean =
-    this::class.java.isAnnotationPresent(Internal::class.java)
+    this::class.java.isInternal()
+
+/**
+ * Tells if this class of messages is internal to a bounded context.
+ */
+public fun <T: Message> Class<T>.isInternal(): Boolean =
+    isAnnotationPresent(Internal::class.java)
 
 /**
  * Obtains the name of this message type.
@@ -50,10 +58,11 @@ public val <T: Message> T.typeName: TypeName
  * @throws IllegalArgumentException
  *          if the message is not internal
  */
+@CanIgnoreReturnValue
 public fun requireInternal(msg: Message): Message {
     require(msg.isInternal()) {
         "The message class `${msg::class.java.canonicalName}` is not" +
-                "annotated as `${Internal::class.java.canonicalName}`."
+                " annotated as `${Internal::class.java.canonicalName}`."
     }
     return msg
 }
@@ -65,9 +74,26 @@ public fun requireInternal(msg: Message): Message {
  * @throws UnpublishedLanguageException
  *          if the given message is internal
  */
+@CanIgnoreReturnValue
 public fun requirePublished(msg: Message): Message {
     if (msg.isInternal()) {
         throw UnpublishedLanguageException(msg)
     }
     return msg
+}
+
+/**
+ * Verifies if the given class of messages is a part of published language
+ * of a bounded context, returning it if so.
+ *
+ * @throws UnpublishedLanguageException
+ *          if the message class is internal to the bounded context
+ */
+@CanIgnoreReturnValue
+public fun <T: Message> requirePublished(clazz: Class<T>): Class<T> {
+    if (clazz.isInternal()) {
+        val msg = defaultInstance(clazz)
+        throw UnpublishedLanguageException(msg)
+    }
+    return clazz
 }

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -425,9 +425,9 @@ extend google.protobuf.MessageOptions {
     //
     // The type with such an option can be used only inside the bounded context which declares it.
     //
-    // The type must not be used neither for inbound (i.e. being sent to the bounded context) nor
-    // for outbound communication (i.e. being sent by this bounded context to another
-    // bounded context).
+    // The type must not be used neither for inbound (i.e. being sent to the bounded context
+    // which declares this type) nor for outbound communication (i.e. being sent by this
+    // bounded context to another bounded context).
     //
     // An attempt to violate these usage restrictions will result in a runtime error.
     //

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -427,7 +427,7 @@ extend google.protobuf.MessageOptions {
     //
     // The type must not be used neither for inbound (i.e. being sent to the bounded context
     // which declares this type) nor for outbound communication (i.e. being sent by this
-    // bounded context to another bounded context).
+    // bounded context outside).
     //
     // An attempt to violate these usage restrictions will result in a runtime error.
     //

--- a/base/src/test/java/io/spine/type/UnknownTypeExceptionTest.java
+++ b/base/src/test/java/io/spine/type/UnknownTypeExceptionTest.java
@@ -38,7 +38,7 @@ class UnknownTypeExceptionTest {
 
     @Test
     @DisplayName("have constructor with type name")
-    void have_ctor_with_type_name() {
+    void ctorWithTypeName() {
         var str = newUuid();
         var exception = new UnknownTypeException(str);
 
@@ -48,7 +48,7 @@ class UnknownTypeExceptionTest {
 
     @Test
     @DisplayName("have constructor with type name and cause")
-    void have_ctor_with_type_name_and_cause() {
+    void ctorWithTypeAndCause() {
         var str = newUuid();
         var cause = new RuntimeException("");
         var exception = new UnknownTypeException(str, cause);

--- a/base/src/test/java/io/spine/type/UnpublishedLanguageExceptionTest.java
+++ b/base/src/test/java/io/spine/type/UnpublishedLanguageExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.type;
+
+import com.google.protobuf.Any;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@DisplayName("`UnpublishedLanguageException` should")
+class UnpublishedLanguageExceptionTest {
+
+    @Test
+    @DisplayName("contain the name of the type in its message")
+    void containTypeName() {
+        var typeName = TypeName.of(Any.class);
+
+        var exception = new UnpublishedLanguageException(typeName);
+
+        assertThat(exception.getMessage()).contains(typeName.toString());
+    }
+}

--- a/base/src/test/java/io/spine/type/UnpublishedLanguageExceptionTest.java
+++ b/base/src/test/java/io/spine/type/UnpublishedLanguageExceptionTest.java
@@ -27,8 +27,20 @@
 package io.spine.type;
 
 import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import com.google.protobuf.UnknownFieldSet;
+import io.spine.annotation.Internal;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -38,10 +50,136 @@ class UnpublishedLanguageExceptionTest {
     @Test
     @DisplayName("contain the name of the type in its message")
     void containTypeName() {
-        var typeName = TypeName.of(Any.class);
+        var msg = new SecretMessage();
 
-        var exception = new UnpublishedLanguageException(typeName);
+        assertThat(SecretMessage.class.isAnnotationPresent(Internal.class))
+                .isTrue();
+
+        var typeName = TypeName.of(msg);
+        var exception = new UnpublishedLanguageException(msg);
 
         assertThat(exception.getMessage()).contains(typeName.toString());
+    }
+
+    /**
+     * A stub implementation of the {@code Message} interface, which is
+     * annotated as internal, and tries to pretend being {@code Any}
+     * so that its type name can be obtained.
+     */
+    @Internal
+    @SuppressWarnings("ReturnOfNull")
+    private static class SecretMessage implements Message {
+
+        private SecretMessage() {
+        }
+
+        @Override
+        public void writeTo(CodedOutputStream output) throws IOException {
+        }
+
+        @Override
+        public int getSerializedSize() {
+            return 0;
+        }
+
+        @Override
+        public Parser<? extends Message> getParserForType() {
+            return null;
+        }
+
+        @Override
+        public ByteString toByteString() {
+            return null;
+        }
+
+        @SuppressWarnings("ZeroLengthArrayAllocation")
+        @Override
+        public byte[] toByteArray() {
+            return new byte[0];
+        }
+
+        @Override
+        public void writeTo(OutputStream output) throws IOException {
+        }
+
+        @Override
+        public void writeDelimitedTo(OutputStream output) {
+        }
+
+        @Override
+        public Builder newBuilderForType() {
+            return null;
+        }
+
+        @Override
+        public Builder toBuilder() {
+            return null;
+        }
+
+        @Override
+        public Message getDefaultInstanceForType() {
+            return Any.getDefaultInstance();
+        }
+
+        @Override
+        public boolean isInitialized() {
+            return false;
+        }
+
+        @Override
+        public List<String> findInitializationErrors() {
+            return null;
+        }
+
+        @Override
+        public String getInitializationErrorString() {
+            return null;
+        }
+
+        @Override
+        public Descriptors.Descriptor getDescriptorForType() {
+            return Any.getDescriptor();
+        }
+
+        @Override
+        public Map<Descriptors.FieldDescriptor, Object> getAllFields() {
+            return null;
+        }
+
+        @Override
+        public boolean hasOneof(Descriptors.OneofDescriptor oneof) {
+            return false;
+        }
+
+        @Override
+        public Descriptors.FieldDescriptor getOneofFieldDescriptor(
+                Descriptors.OneofDescriptor oneof) {
+            return null;
+        }
+
+        @Override
+        public boolean hasField(Descriptors.FieldDescriptor field) {
+            return false;
+        }
+
+        @Override
+        public Object getField(Descriptors.FieldDescriptor field) {
+            return null;
+        }
+
+        @Override
+        public int getRepeatedFieldCount(Descriptors.FieldDescriptor field) {
+            return 0;
+        }
+
+        @Override
+        public Object getRepeatedField(Descriptors.FieldDescriptor field, int index) {
+            return null;
+        }
+
+        @Override
+        public UnknownFieldSet getUnknownFields() {
+            return null;
+        }
     }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -503,7 +503,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 24 18:01:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 24 19:55:56 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1059,4 +1059,4 @@ This report was generated on **Wed Aug 24 18:01:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 24 18:01:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 24 19:55:56 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -503,12 +503,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 21 20:01:50 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 24 18:01:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.92`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.93`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1059,4 +1059,4 @@ This report was generated on **Sun Aug 21 20:01:50 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 21 20:01:51 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Aug 24 18:01:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.92</version>
+<version>2.0.0-SNAPSHOT.93</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/src/main/java/io/spine/testing/StubMessage.java
+++ b/testlib/src/main/java/io/spine/testing/StubMessage.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedOutputStream;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.Message;
+import com.google.protobuf.Parser;
+import com.google.protobuf.UnknownFieldSet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An abstract base for stub classes implementing the {@link Message} interface.
+ *
+ * <p>Sometimes in tests it is not possible or inconvenient to have a real class generated after
+ * a Protobuf type. Such tests create stub classes implementing {@link Message}.
+ *
+ * <p>The problem with this approach is that it such stub classes are quite big, while doing almost
+ * nothing returning {@code null} in most of the methods that need to return something.
+ *
+ * <p>This class helps to "cut" most of such code in the derived classes.
+ */
+@SuppressWarnings({"ConstantConditions", "ReturnOfNull", "NoopMethodInAbstractClass"})
+public abstract class StubMessage implements Message {
+
+    @SuppressWarnings({"NoopMethodInAbstractClass", "PMD.UncommentedEmptyMethodBody"})
+    @Override
+    public void writeTo(CodedOutputStream output) throws IOException {
+    }
+
+    @Override
+    public int getSerializedSize() {
+        return 0;
+    }
+
+    @Override
+    public Parser<? extends Message> getParserForType() {
+        return null;
+    }
+
+    @Override
+    public ByteString toByteString() {
+        return null;
+    }
+
+    @SuppressWarnings("ZeroLengthArrayAllocation")
+    @Override
+    public byte[] toByteArray() {
+        return new byte[0];
+    }
+
+    @Override
+    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
+    public void writeTo(OutputStream output) throws IOException {
+    }
+
+    @SuppressWarnings({"RedundantThrows", "PMD.UncommentedEmptyMethodBody"})
+    @Override
+    public void writeDelimitedTo(OutputStream output) throws IOException {
+    }
+
+    @Override
+    public Builder newBuilderForType() {
+        return null;
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return null;
+    }
+
+    @Override
+    public Message getDefaultInstanceForType() {
+        return null;
+    }
+
+    @Override
+    public boolean isInitialized() {
+        return false;
+    }
+
+    @Override
+    public List<String> findInitializationErrors() {
+        return null;
+    }
+
+    @Override
+    public String getInitializationErrorString() {
+        return null;
+    }
+
+    @Override
+    public Descriptors.Descriptor getDescriptorForType() {
+        return null;
+    }
+
+    @Override
+    public Map<Descriptors.FieldDescriptor, Object> getAllFields() {
+        return null;
+    }
+
+    @Override
+    public boolean hasOneof(Descriptors.OneofDescriptor oneof) {
+        return false;
+    }
+
+    @Override
+    public Descriptors.FieldDescriptor getOneofFieldDescriptor(Descriptors.OneofDescriptor oneof) {
+        return null;
+    }
+
+    @Override
+    public boolean hasField(Descriptors.FieldDescriptor field) {
+        return false;
+    }
+
+    @Override
+    public Object getField(Descriptors.FieldDescriptor field) {
+        return null;
+    }
+
+    @Override
+    public int getRepeatedFieldCount(Descriptors.FieldDescriptor field) {
+        return 0;
+    }
+
+    @Override
+    public Object getRepeatedField(Descriptors.FieldDescriptor field, int index) {
+        return null;
+    }
+
+    @Override
+    public UnknownFieldSet getUnknownFields() {
+        return null;
+    }
+}

--- a/testlib/src/test/java/io/spine/testing/StubMessageTest.java
+++ b/testlib/src/test/java/io/spine/testing/StubMessageTest.java
@@ -24,51 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.type;
+package io.spine.testing;
 
-import com.google.protobuf.Any;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.Message;
-import io.spine.annotation.Internal;
-import io.spine.testing.StubMessage;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@DisplayName("`UnpublishedLanguageException` should")
-class UnpublishedLanguageExceptionTest {
+class StubMessageTest {
 
     @Test
-    @DisplayName("contain the name of the type in its message")
-    void containTypeName() {
-        var msg = new SecretMessage();
+    @DisplayName("can have derived classes with default constructor")
+    void derivedClass() {
+         var msg = new StubMessage() {
+         };
 
-        assertThat(SecretMessage.class.isAnnotationPresent(Internal.class))
-                .isTrue();
-
-        var typeName = TypeName.of(msg);
-        var exception = new UnpublishedLanguageException(msg);
-
-        assertThat(exception.getMessage()).contains(typeName.toString());
-    }
-
-    /**
-     * A stub implementation of the {@code Message} interface, which is
-     * annotated as internal, and tries to pretend being {@code Any}
-     * so that its type name can be obtained.
-     */
-    @Internal
-    private static class SecretMessage extends StubMessage {
-
-        @Override
-        public Message getDefaultInstanceForType() {
-            return Any.getDefaultInstance();
-        }
-
-        @Override
-        public Descriptors.Descriptor getDescriptorForType() {
-            return Any.getDescriptor();
-        }
+         assertThat(msg).isNotNull();
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.92"
+val base = "2.0.0-SNAPSHOT.93"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR continues extending usage of `internal_type` proto option and `@Internal` Java annotation for marking non-published language of a bounded context.

* Documentation of the `@Internal` annotation was updated accordingly.
* The retention policy of the annotation was changed from `SOURCE` to `RUNTIME` because we're going to check it then.
* `UnpublishedLanguageException` was introduced to be thrown when the user attempts to use a non-published message outside of the context.
* Several Kotlin-based extensions for `Message` types and utility functions related to published language were introduced.
* `StubMessage` class was introduced to simplify creation of stub message types in tests.
