### PR TITLE
Fix Javadoc and tests for `GenericTypeIndex`

### DIFF
--- a/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
+++ b/base/src/main/java/io/spine/reflect/GenericTypeIndex.java
@@ -31,12 +31,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Base interface for enumerations on generic parameters of types.
  *
+ * <p>Such enumeration are convenient when it is needed to obtain generic arguments
+ * of a class on runtime.
+ *
  * <p>Example of implementing an enumeration for generic parameters:
  * <pre>
  * {@code
  * public abstract class Tuple<K, V> {
  *     ...
- *     public enum GenericParameter extends GenericTypeIndex<Tuple> {
+ *     public enum GenericParameter implements GenericTypeIndex<Tuple> {
  *
  *         // <K> param has index 0
  *         KEY(0),
@@ -54,7 +57,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * }
  * }
  * </pre>
- * @param <C> the type for which class the generic index is declared
+ *
+ * <p>Then the usage of these enum entries would be like this:
+ * <pre>
+ *    var keyClass = Tuple.GenericParameter.argumentIn(ClassExtendingTuple.class);
+ *    var valueClass = Tuple.GenericParameter.argumentIn(ClassExtendingTuple.class);
+ * </pre>
+ *
+ * @param <C>
+ *         the type for which class the generic index is declared
  */
 public interface GenericTypeIndex<C> {
 

--- a/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
+++ b/base/src/test/java/io/spine/reflect/GenericTypeIndexTest.java
@@ -29,30 +29,41 @@ package io.spine.reflect;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static com.google.common.truth.Truth.assertThat;
 
 @DisplayName("`GenericTypeIndex` should")
 class GenericTypeIndexTest {
 
     @Test
-    @DisplayName("obtain generic argument assuming generic superclass")
-    void obtain_generic_argument_assuming_generic_superclass() {
-        var val = new Parametrized<Long, String>() {};
-        assertEquals(Long.class, Types.argumentIn(val.getClass(), Base.class, 0));
-        assertEquals(String.class, Types.argumentIn(val.getClass(), Base.class, 1));
-    }
-
-    @Test
-    @DisplayName("obtain generic argument via superclass")
-    void obtain_generic_argument_via_superclass() {
-        assertEquals(String.class, Types.argumentIn(Leaf.class, Base.class, 0));
-        assertEquals(Float.class, Types.argumentIn(Leaf.class, Base.class, 1));
+    @DisplayName("allow obtaining generic arguments via enums")
+    void obtainGenericsViaEnums() {
+        assertThat(Pair.GenericParam.FIRST.argumentIn(Tango.class))
+                .isEqualTo(Float.class);
+        assertThat(Pair.GenericParam.SECOND.argumentIn(Tango.class))
+                .isEqualTo(Double.class);
     }
 
     @SuppressWarnings({"EmptyClass", "unused"})
-    private static class Base<T, K> {}
+    private static class Pair<A, B> {
 
-    private static class Parametrized<T, K> extends Base<T, K> {}
+        @SuppressWarnings("rawtypes")
+        private enum GenericParam implements GenericTypeIndex<Pair> {
+            FIRST(0),
+            SECOND(1);
 
-    private static class Leaf extends Base<String, Float> {}
+            private final int index;
+
+            GenericParam(int index) {
+                this.index = index;
+            }
+
+            @Override
+            public int index() {
+                return index;
+            }
+        }
+    }
+
+    private static class Tango extends Pair<Float, Double> {
+    }
 }

--- a/base/src/test/java/io/spine/reflect/TypesTest.java
+++ b/base/src/test/java/io/spine/reflect/TypesTest.java
@@ -34,6 +34,7 @@ import io.spine.reflect.given.TypesTestEnv.ListOfMessages;
 import io.spine.reflect.given.TypesTestEnv.TaskStatus;
 import io.spine.testing.UtilityClassTest;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -77,7 +78,6 @@ class TypesTest extends UtilityClassTest<Types> {
     @Test
     @DisplayName("tell if the type is an enum class")
     void tellIfIsEnumClass() {
-
         assertThat(isEnumClass(TaskStatus.class))
                 .isTrue();
         assertThat(isEnumClass(Message.class))
@@ -87,7 +87,6 @@ class TypesTest extends UtilityClassTest<Types> {
     @Test
     @DisplayName("tell if the type is a message class")
     void tellIfIsMessageClass() {
-
         assertThat(isMessageClass(StringValue.class))
                 .isTrue();
         assertThat(isMessageClass(TaskStatus.class))
@@ -110,12 +109,40 @@ class TypesTest extends UtilityClassTest<Types> {
         assertThat(types).isEmpty();
     }
 
-    @Test
-    @DisplayName("obtain a type argument value from the inheritance chain")
-    void getTypeArgument() {
-        var argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
-        assertEquals(argument, Message.class);
+    @Nested
+    @DisplayName("obtain a generic type argument")
+    class TypeArguments {
+
+        @Test
+        @DisplayName("from the inheritance chain")
+        void getTypeArgument() {
+            var argument = argumentIn(ListOfMessages.class, Iterable.class, 0);
+            assertEquals(argument, Message.class);
+        }
+
+        @Test
+        @DisplayName("assuming generic superclass")
+        void assumingGenericSuperclass() {
+            var val = new Parametrized<Long, String>() {};
+            assertEquals(Long.class, Types.argumentIn(val.getClass(), Base.class, 0));
+            assertEquals(String.class, Types.argumentIn(val.getClass(), Base.class, 1));
+        }
+
+        @Test
+        @DisplayName("obtain generic argument via superclass")
+        void viaSuperclass() {
+            assertEquals(String.class, Types.argumentIn(Leaf.class, Base.class, 0));
+            assertEquals(Float.class, Types.argumentIn(Leaf.class, Base.class, 1));
+        }
     }
+
+
+    @SuppressWarnings({"EmptyClass", "unused"})
+    private static class Base<T, K> {}
+
+    private static class Parametrized<T, K> extends Base<T, K> {}
+
+    private static class Leaf extends Base<String, Float> {}
 
     @Override
     protected void configure(NullPointerTester tester) {

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -503,12 +503,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 24 18:01:32 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 21:58:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.93`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.94`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1059,4 +1059,4 @@ This report was generated on **Wed Aug 24 18:01:32 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Aug 24 18:01:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 21:58:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -503,7 +503,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 28 21:58:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:05:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1059,4 +1059,4 @@ This report was generated on **Sun Aug 28 21:58:40 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 28 21:58:40 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 28 22:05:46 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.93</version>
+<version>2.0.0-SNAPSHOT.94</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.93"
+val base = "2.0.0-SNAPSHOT.94"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR:
  * Fixes Javadoc of `GenericTypeIndex` which previously misused the word `extends` where `implements` should be said.
  * Extends the Javadoc with the code example of using enum members for obtaining generic type arguments.
  * Fixes the placement of `Types` utility class.
  * Adds test for enum-based type access.
