### PR TITLE
Open a constructor of `UnpublishedLanguageException` which accepts a type name

### DIFF
--- a/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
+++ b/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
@@ -59,7 +59,13 @@ public class UnpublishedLanguageException extends RuntimeException {
         this(TypeName.of(requireInternal(msg)));
     }
 
-    private UnpublishedLanguageException(TypeName type) {
+    /**
+     * Creates an exception referencing the given type name.
+     *
+     * @param type
+     *         the name of the type to be used in the message of the exception.
+     */
+    public UnpublishedLanguageException(TypeName type) {
         super(formatMsg(type));
     }
 

--- a/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
+++ b/base/src/main/java/io/spine/type/UnpublishedLanguageException.java
@@ -63,7 +63,7 @@ public class UnpublishedLanguageException extends RuntimeException {
      * Creates an exception referencing the given type name.
      *
      * @param type
-     *         the name of the type to be used in the message of the exception.
+     *         the name of the type to be used in the message of the exception
      */
     public UnpublishedLanguageException(TypeName type) {
         super(formatMsg(type));

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -503,12 +503,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 11:34:33 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 16 20:32:51 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.95`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.96`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1059,4 +1059,4 @@ This report was generated on **Mon Aug 29 11:34:33 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Aug 29 11:34:35 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 16 20:32:52 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.95</version>
+<version>2.0.0-SNAPSHOT.96</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.95"
+val base = "2.0.0-SNAPSHOT.96"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR makes the constructor of `UnpublishedLanguageException` accepting a type name `public` so that users of the class don't have to create default instances of a message (knowing the type) just to create an exception.