### PR TITLE
Improve validation checks

### DIFF
--- a/base/src/main/java/io/spine/validate/Validate.java
+++ b/base/src/main/java/io/spine/validate/Validate.java
@@ -73,8 +73,8 @@ public final class Validate {
     }
 
     /**
-     * Validates the given message according to its definition and returns the constrain violations,
-     * if any.
+     * Validates the given message according to its definition and returns
+     * the constraint violations, if any.
      *
      * @return violations of the validation rules or an empty list if the message is valid
      */

--- a/base/src/main/java/io/spine/validate/Validate.java
+++ b/base/src/main/java/io/spine/validate/Validate.java
@@ -29,6 +29,7 @@ package io.spine.validate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.code.proto.FieldContext;
@@ -57,15 +58,18 @@ public final class Validate {
      * Validates the given message according to its definition and throws
      * {@code ValidationException} if any constraints are violated.
      *
-     * @throws ValidationException if the passed message does not satisfy the constraints
-     *                             set for it in its Protobuf definition
+     * @throws ValidationException
+     *         if the passed message does not satisfy the constraints
+     *         set for it in its Protobuf definition
      */
-    public static void checkValid(Message message) throws ValidationException {
+    @CanIgnoreReturnValue
+    public static <M extends Message> M checkValid(M message) throws ValidationException {
         checkNotNull(message);
         var violations = violationsOf(message);
         if (!violations.isEmpty()) {
             throw new ValidationException(violations);
         }
+        return message;
     }
 
     /**

--- a/base/src/test/kotlin/io/spine/validate/MessageExtensionsTest.kt
+++ b/base/src/test/kotlin/io/spine/validate/MessageExtensionsTest.kt
@@ -26,22 +26,32 @@
 
 package io.spine.validate
 
-import com.google.protobuf.Message
+import com.google.common.truth.Truth.assertThat
+import io.spine.test.validate.Meal
+import io.spine.test.validate.Meat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
-/**
- * Creates a copy of this message by copies of its properties and then applying
- * values of properties defined in the given block.
- */
-public fun <M: MessageWithConstraints, B: ValidatingBuilder<M>> M.copy(block: B.() -> Unit): M {
-    @Suppress("UNCHECKED_CAST") // ensured by the generated code
-    val builder = this.toBuilder() as B
-    builder.block()
-    return builder.vBuild()
+@DisplayName("Validation `Message` extensions should")
+internal class MessageExtensionsTest {
+
+    @Nested
+    inner class `Check if the message is valid` {
+
+        @Test
+        fun `returning 'this' if so`() {
+            val meal = Meal.newBuilder().setMeat(Meat.getDefaultInstance()).build()
+
+            assertThat(meal.checkValid()).isSameInstanceAs(meal)
+        }
+
+        @Test
+        fun `throwing 'ValidationException' if not`() {
+            assertThrows<ValidationException> {
+                Meal.getDefaultInstance().checkValid()
+            }
+        }
+    }
 }
-
-/**
- * Verifies of this message instance matched the validation constraints, and returns `this` if so.
- *
- * @throws ValidationException if this message is not valid.
- */
-public fun <M: Message> M.checkValid(): M = Validate.checkValid(this)

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -503,12 +503,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 16 20:32:51 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 21 18:37:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.96`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.97`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1059,4 +1059,4 @@ This report was generated on **Fri Sep 16 20:32:51 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 16 20:32:52 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Sep 21 18:37:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.96</version>
+<version>2.0.0-SNAPSHOT.97</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.96"
+val base = "2.0.0-SNAPSHOT.97"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR addresses the issue #60 and adds Kotlin extension for validating `Message` instance.
