### PR TITLE
Fix validation check

### DIFF
--- a/base/src/main/java/io/spine/validate/Validate.java
+++ b/base/src/main/java/io/spine/validate/Validate.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.flogger.FluentLogger;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
+import com.google.errorprone.annotations.InlineMe;
 import com.google.protobuf.Message;
 import io.spine.annotation.Internal;
 import io.spine.code.proto.FieldContext;
@@ -61,9 +62,23 @@ public final class Validate {
      * @throws ValidationException
      *         if the passed message does not satisfy the constraints
      *         set for it in its Protobuf definition
+     * @deprecated please use {@link #check(Message)}
+     */
+    @Deprecated
+    @InlineMe(replacement = "Validate.check(message)", imports = "io.spine.validate.Validate")
+    public static void checkValid(Message message) throws ValidationException {
+        check(message);
+    }
+
+    /**
+     * Validates the given message according to its definition and returns it if so.
+     *
+     * @throws ValidationException
+     *         if the passed message does not satisfy the constraints
+     *         set for it in its Protobuf definition
      */
     @CanIgnoreReturnValue
-    public static <M extends Message> M checkValid(M message) throws ValidationException {
+    public static <M extends Message> M check(M message) throws ValidationException {
         checkNotNull(message);
         var violations = violationsOf(message);
         if (!violations.isEmpty()) {

--- a/base/src/main/java/io/spine/validate/ValidatingBuilder.java
+++ b/base/src/main/java/io/spine/validate/ValidatingBuilder.java
@@ -73,7 +73,7 @@ public interface ValidatingBuilder<M extends Message> extends Message.Builder {
      */
     default @Validated M vBuild() throws ValidationException {
         var message = build();
-        Validate.checkValid(message);
+        Validate.check(message);
         return message;
     }
 }

--- a/base/src/main/kotlin/io/spine/validate/MessageExtensions.kt
+++ b/base/src/main/kotlin/io/spine/validate/MessageExtensions.kt
@@ -44,4 +44,4 @@ public fun <M: MessageWithConstraints, B: ValidatingBuilder<M>> M.copy(block: B.
  *
  * @throws ValidationException if this message is not valid.
  */
-public fun <M: Message> M.checkValid(): M = Validate.checkValid(this)
+public fun <M: Message> M.checkValid(): M = Validate.check(this)

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -503,12 +503,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 21 18:37:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 23 14:22:56 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.97`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.98`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1059,4 +1059,4 @@ This report was generated on **Wed Sep 21 18:37:59 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Sep 21 18:37:59 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Sep 23 14:22:56 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.97</version>
+<version>2.0.0-SNAPSHOT.98</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.97"
+val base = "2.0.0-SNAPSHOT.98"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR restores the `Validate.checkValid()` method returning `void` (to fix the broken API) and deprecates it in favor of the one returning the passed message.
