### PR TITLE
Fix missing check for no separators in text lines

### DIFF
--- a/base/src/main/java/io/spine/util/Text.java
+++ b/base/src/main/java/io/spine/util/Text.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static java.lang.System.lineSeparator;
 
 /**
@@ -65,7 +66,16 @@ public final class Text implements Iterable<String> {
      */
     public Text(Iterable<String> lines) {
         checkNotNull(lines);
+        checkNoSeparators(lines);
         this.lines = ImmutableList.copyOf(lines);
+    }
+
+    private static void checkNoSeparators(Iterable<String> lines) {
+        lines.forEach(l -> {
+            if (containsSeparator(l)) {
+                throw newIllegalArgumentException("The line contains line separator: `%s`", l);
+            }
+        });
     }
 
     /**
@@ -123,9 +133,13 @@ public final class Text implements Iterable<String> {
      *          line separator}
      */
     public boolean contains(String s) {
-        checkArgument(!s.contains(lineSeparator()));
+        checkArgument(!containsSeparator(s));
         var result = lines.stream().anyMatch(line -> line.contains(s));
         return result;
+    }
+
+    private static boolean containsSeparator(String s) {
+        return s.contains(lineSeparator());
     }
 
     /**

--- a/base/src/main/java/io/spine/util/Text.java
+++ b/base/src/main/java/io/spine/util/Text.java
@@ -73,7 +73,7 @@ public final class Text implements Iterable<String> {
     private static void checkNoSeparators(Iterable<String> lines) {
         lines.forEach(l -> {
             if (containsSeparator(l)) {
-                throw newIllegalArgumentException("The line contains line separator: `%s`", l);
+                throw newIllegalArgumentException("The line contains line separator: `%s`.", l);
             }
         });
     }

--- a/base/src/test/kotlin/io/spine/util/TextTest.kt
+++ b/base/src/test/kotlin/io/spine/util/TextTest.kt
@@ -69,4 +69,10 @@ internal class TextTest {
         assertThat(text.contains("abra")).isTrue()
         assertThat(text.contains("kada")).isFalse()
     }
+
+    @Test
+    fun `must not accept lines with separators`() {
+        assertThrows<IllegalArgumentException> {  Text.of("un", "${nl}o") }
+        assertThrows<IllegalArgumentException> {  Text(listOf("dos", "tres${nl}")) }
+    }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.110`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.111`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -520,12 +520,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 08 11:17:12 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 08 11:41:31 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.110`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.111`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1093,4 +1093,4 @@ This report was generated on **Sat Oct 08 11:17:12 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 08 11:17:12 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 08 11:41:31 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.110</version>
+<version>2.0.0-SNAPSHOT.111</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.110"
+val base = "2.0.0-SNAPSHOT.111"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR fixes the missing check that was announced in Javadoc, but wasn't implemented in the past PR which introduced the `Text` utility.