### PR TITLE
Remember `Text` value

### DIFF
--- a/base/src/main/java/io/spine/util/Text.java
+++ b/base/src/main/java/io/spine/util/Text.java
@@ -53,6 +53,7 @@ public final class Text implements Iterable<String> {
     private static final Joiner JOINER = Joiner.on(lineSeparator());
 
     private final ImmutableList<String> lines;
+    private final String value;
 
     /**
      * Creates a new instance with the given lines.
@@ -68,6 +69,7 @@ public final class Text implements Iterable<String> {
         checkNotNull(lines);
         checkNoSeparators(lines);
         this.lines = ImmutableList.copyOf(lines);
+        this.value = join(lines);
     }
 
     private static void checkNoSeparators(Iterable<String> lines) {
@@ -122,6 +124,17 @@ public final class Text implements Iterable<String> {
     }
 
     /**
+     * Obtains the text as joined lines.
+     *
+     * <p>This method always returns same object, so repeated calls have no performance effect.
+     *
+     * @see #toString()
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
      * Tells if the given string is contained by any of the text lines.
      *
      * @param s
@@ -148,7 +161,7 @@ public final class Text implements Iterable<String> {
      */
     @Override
     public String toString() {
-        return join(lines);
+        return value;
     }
 
     @Override
@@ -165,12 +178,12 @@ public final class Text implements Iterable<String> {
             return false;
         }
         var strings = (Text) o;
-        return Objects.equals(lines, strings.lines);
+        return Objects.equals(value, strings.value);
     }
 
     @Override
     public int hashCode() {
-        return lines.hashCode();
+        return value.hashCode();
     }
 
     /**

--- a/base/src/test/kotlin/io/spine/util/TextTest.kt
+++ b/base/src/test/kotlin/io/spine/util/TextTest.kt
@@ -75,4 +75,12 @@ internal class TextTest {
         assertThrows<IllegalArgumentException> {  Text.of("un", "${nl}o") }
         assertThrows<IllegalArgumentException> {  Text(listOf("dos", "tres${nl}")) }
     }
+
+    @Test
+    fun `always return the same value`() {
+        val text = Text.of("donna", "be", "la", "mare")
+
+        val value = text.value()
+        assertThat(value).isSameInstanceAs(text.value())
+    }
 }

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -520,12 +520,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 08 11:41:31 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 08 12:22:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.111`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.112`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1093,4 +1093,4 @@ This report was generated on **Sat Oct 08 11:41:31 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Oct 08 11:41:31 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Oct 08 12:22:37 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.111</version>
+<version>2.0.0-SNAPSHOT.112</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -38,7 +38,7 @@
  */
 
 /** The version of this library. */
-val base = "2.0.0-SNAPSHOT.111"
+val base = "2.0.0-SNAPSHOT.112"
 
 val spineVersion: String by extra(base)
 val spineBaseVersion: String by extra(base) // Used by `filter-internal-javadoc.gradle`.


### PR DESCRIPTION
This PR teaches the `Text` class to remember its value so that users do not have to merge lines to work with the text as a whole thing.