### PR TITLE
Add Kotlin extension functions for selected Truth subjects

### DIFF
--- a/.github/workflows/build-on-ubuntu.yml
+++ b/.github/workflows/build-on-ubuntu.yml
@@ -23,7 +23,7 @@ jobs:
 
       # See: https://github.com/marketplace/actions/junit-report-action
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2.8.4
+        uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -24,7 +24,7 @@ jobs:
 
       # See: https://github.com/marketplace/actions/junit-report-action
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v2.8.4
+        uses: mikepenz/action-junit-report@v3.5.2
         if: always() # always run even if the previous step fails
         with:
           report_paths: '**/build/test-results/test/TEST-*.xml'

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -80,7 +80,7 @@ val guavaVersion = "31.1-jre"
  * @see <a href="https://github.com/tbroyer/gradle-errorprone-plugin/releases">
  *     Error Prone Gradle Plugin Releases</a>
  */
-val errorProneVersion = "2.0.2"
+val errorProneVersion = "3.0.1"
 
 /**
  * The version of Protobuf Gradle Plugin.

--- a/buildSrc/src/main/kotlin/deps-between-tasks.kt
+++ b/buildSrc/src/main/kotlin/deps-between-tasks.kt
@@ -62,6 +62,7 @@ fun Project.configureTaskDependencies() {
         "sourcesJar".dependOn("generateProto")
         "sourcesJar".dependOn("launchProtoDataMain")
         "sourcesJar".dependOn("createVersionFile")
+        "sourcesJar".dependOn("prepareProtocConfigVersions")
         "dokkaHtml".dependOn("generateProto")
         "dokkaHtml".dependOn("launchProtoDataMain")
         "dokkaJavadoc".dependOn("launchProtoDataMain")

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -26,6 +26,7 @@
 
 package io.spine.internal.dependency
 
+// https://pmd.github.io/
 object Pmd {
     const val version = "6.50.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -26,7 +26,6 @@
 
 package io.spine.internal.dependency
 
-// https://pmd.github.io/
 object Pmd {
     const val version = "6.50.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/testing/Tasks.kt
@@ -45,6 +45,12 @@ import org.gradle.kotlin.dsl.register
  */
 @Suppress("unused")
 fun TaskContainer.registerTestTasks() {
+    withType(Test::class.java).configureEach {
+        filter {
+            includeTestsMatching("*Test")
+            includeTestsMatching("*Spec")
+        }
+    }
     register<FastTest>("fastTest").let {
         register<SlowTest>("slowTest") {
             shouldRunAfter(it)
@@ -56,8 +62,10 @@ fun TaskContainer.registerTestTasks() {
  * Name of a tag for annotating a test class or method that is known to be slow and
  * should not normally be run together with the main test suite.
  *
- * @see [SlowTest](https://spine.io/base/reference/testlib/io/spine/testing/SlowTest.html)
- * @see [Tag](https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/Tag.html)
+ * @see <a href="https://spine.io/base/reference/testlib/io/spine/testing/SlowTest.html">
+ *     SlowTest</a>
+ * @see <a href="https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/api/Tag.html">
+ *     Tag</a>
  */
 private const val SLOW_TAG = "slow"
 

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.115`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.116`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -163,6 +163,10 @@
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.16.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
+     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
+
 1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -516,12 +520,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 23 15:09:06 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 24 15:55:08 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.115`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.116`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -732,6 +736,10 @@ This report was generated on **Sun Oct 23 15:09:06 TRT 2022** using [Gradle-Lice
 1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.16.
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
+     * **Project URL:** [https://github.com/google/error-prone-javac](https://github.com/google/error-prone-javac)
+     * **License:** [GNU General Public License, version 2, with the Classpath Exception](http://openjdk.java.net/legal/gplv2+ce.html)
+
 1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
      * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
      * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -1085,4 +1093,4 @@ This report was generated on **Sun Oct 23 15:09:06 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Oct 23 15:09:07 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 24 15:55:08 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.115</version>
+<version>2.0.0-SNAPSHOT.116</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -153,6 +153,11 @@ all modules and does not describe the project structure per-subproject.
     <artifactId>error_prone_type_annotations</artifactId>
     <version>2.16</version>
     <scope>provided</scope>
+  </dependency>
+  <dependency>
+    <groupId>com.google.errorprone</groupId>
+    <artifactId>javac</artifactId>
+    <version>9+181-r4173-1</version>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>

--- a/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
@@ -27,6 +27,29 @@
 package io.spine.testing
 
 import com.google.common.testing.NullPointerTester
+import com.google.common.truth.IterableSubject
+import com.google.common.truth.OptionalSubject
+import com.google.common.truth.StringSubject
+import com.google.common.truth.StringSubject.CaseInsensitiveStringComparison
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth8
+import java.util.*
+
+/**
+ * Extension functions for [Google Truth](https://truth.dev/).
+ *
+ * It is expected that these extensions would be implemented by Truth someday.
+ * Until then, we would use those implemented below.
+ *
+ * @see <a href="https://github.com/google/truth/milestone/12">
+ *     "First post-1.0 feature push" milestone at Truth GitHub</a>
+ * @see <a href="https://github.com/google/truth/issues/536">
+ *     Issue in Truth GitHub</a>
+ * @see <a href="https://github.com/google/truth/issues/572">
+ *     Another issue</a>
+ */
+@Suppress("unused") // is used for KDoc on this file.
+private const val ABOUT = ""
 
 /**
  * Allows to use generic parameter of the function instead of `MyType::class.java` as the first
@@ -34,3 +57,59 @@ import com.google.common.testing.NullPointerTester
  */
 public inline fun <reified T : Any> NullPointerTester.setDefault(value : T) : NullPointerTester =
     setDefault(T::class.java, value)
+
+/**
+ * Allows to write:
+ *
+ * ```kotlin
+ *  assertThat("foo bar") {
+ *      contains("foo")
+ *      contains("bar")
+ *  }
+ * ```
+ */
+public fun assertThat(string: String, assertions: StringSubject.() -> Unit) {
+    Truth.assertThat(string).run { assertions() }
+}
+
+/**
+ * Allows to write:
+ *
+ * ```kotlin
+ * assertThat("foo bar").ignoringCase() {
+ *    contains("BAR")
+ *    contains("FoO")
+ * }
+ * ```
+ */
+public fun StringSubject.ignoringCase(assertions: CaseInsensitiveStringComparison.() -> Unit) {
+    assertions(ignoringCase())
+}
+
+/**
+ * Allows to write:
+ *
+ * ```kotlin
+ * assertThat(listOf(1, 2, 3) {
+ *     contains(1)
+ *     contains(3)
+ *     doesNotContain(4)
+ * }
+ * ```
+ */
+public fun <T> assertThat(iterable: Iterable<T>, assertions: IterableSubject.() -> Unit) {
+    Truth.assertThat(iterable).run { assertions() }
+}
+
+/**
+ * Allows to write:
+ *
+ * ```kotlin
+ * assertThat(Optional.of("something") {
+ *     hasValue("something")
+ * }
+ * ```
+ */
+public fun <T> assertThat(optional: Optional<T>, assertions: OptionalSubject.() -> Unit) {
+    Truth8.assertThat(optional).run { assertions() }
+}

--- a/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
@@ -33,6 +33,14 @@ import com.google.common.truth.StringSubject
 import com.google.common.truth.StringSubject.CaseInsensitiveStringComparison
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth8
+import com.google.common.truth.extensions.proto.FieldScope
+import com.google.common.truth.extensions.proto.ProtoFluentAssertion
+import com.google.common.truth.extensions.proto.ProtoSubject
+import com.google.common.truth.extensions.proto.ProtoTruth
+import com.google.protobuf.Descriptors.FieldDescriptor
+import com.google.protobuf.ExtensionRegistry
+import com.google.protobuf.Message
+import com.google.protobuf.TypeRegistry
 import java.util.*
 
 /**
@@ -55,7 +63,7 @@ private const val ABOUT = ""
  * Allows to use generic parameter of the function instead of `MyType::class.java` as the first
  * parameter type.
  */
-public inline fun <reified T : Any> NullPointerTester.setDefault(value : T) : NullPointerTester =
+public inline fun <reified T : Any> NullPointerTester.setDefault(value: T): NullPointerTester =
     setDefault(T::class.java, value)
 
 /**
@@ -112,4 +120,364 @@ public fun <T> assertThat(iterable: Iterable<T>, assertions: IterableSubject.() 
  */
 public fun <T> assertThat(optional: Optional<T>, assertions: OptionalSubject.() -> Unit) {
     Truth8.assertThat(optional).run { assertions() }
+}
+
+/**
+ * Allows to write:
+ * ```kotlin
+ * assertThat(msg) {
+ *     comparingExpectedFieldsOnly() {
+ *         isEqualTo(...)
+ *     }
+ * }
+ * ```
+ */
+public fun <T : Message> assertThat(m: T, assertions: ProtoSubject.() -> Unit) {
+    ProtoTruth.assertThat(m).run { assertions() }
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldAbsence]
+ */
+public fun ProtoSubject.ignoringFieldAbsence(assertions: ProtoFluentAssertion.() -> Unit) {
+    assertions(ignoringFieldAbsence())
+}
+
+/**
+ * @see [ProtoSubject.comparingExpectedFieldsOnly]
+ */
+public fun ProtoSubject.comparingExpectedFieldsOnly(assertions: ProtoFluentAssertion.() -> Unit) {
+    assertions(comparingExpectedFieldsOnly())
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldAbsenceOfFields]
+ */
+public fun ProtoSubject.ignoringFieldAbsenceOfFields(
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldAbsenceOfFields(firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldAbsenceOfFields]
+ */
+public fun ProtoSubject.ignoringFieldAbsenceOfFields(
+    fieldNumbers: Iterable<Int>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldAbsenceOfFields(fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldAbsenceOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringFieldAbsenceOfFieldDescriptors(
+    firstFieldDescriptor: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldAbsenceOfFieldDescriptors(firstFieldDescriptor, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldAbsenceOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringFieldAbsenceOfFieldDescriptors(
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldAbsenceOfFieldDescriptors(fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.ignoringRepeatedFieldOrder]
+ */
+public fun ProtoSubject.ignoringRepeatedFieldOrder(assertions: ProtoFluentAssertion.() -> Unit) {
+    assertions(ignoringRepeatedFieldOrder())
+}
+
+/**
+ * @see [ProtoSubject.ignoringRepeatedFieldOrderOfFields]
+ */
+public fun ProtoSubject.ignoringRepeatedFieldOrderOfFields(
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringRepeatedFieldOrderOfFields(firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringRepeatedFieldOrderOfFields]
+ */
+public fun ProtoSubject.ignoringRepeatedFieldOrderOfFields(
+    fieldNumbers: Iterable<Int>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringRepeatedFieldOrderOfFields(fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.ignoringRepeatedFieldOrderOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringRepeatedFieldOrderOfFieldDescriptors(
+    firstFieldDescriptor: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringRepeatedFieldOrderOfFieldDescriptors(firstFieldDescriptor, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringRepeatedFieldOrderOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringRepeatedFieldOrderOfFieldDescriptors(
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringRepeatedFieldOrderOfFieldDescriptors(fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.ignoringExtraRepeatedFieldElements]
+ */
+public fun ProtoSubject.ignoringExtraRepeatedFieldElements(
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringExtraRepeatedFieldElements())
+}
+
+/**
+ * @see [ProtoSubject.ignoringExtraRepeatedFieldElementsOfFields]
+ */
+public fun ProtoSubject.ignoringExtraRepeatedFieldElementsOfFields(
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringExtraRepeatedFieldElementsOfFields(firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringExtraRepeatedFieldElementsOfFields]
+ */
+public fun ProtoSubject.ignoringExtraRepeatedFieldElementsOfFields(
+    fieldNumbers: Iterable<Int>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringExtraRepeatedFieldElementsOfFields(fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.ignoringExtraRepeatedFieldElementsOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringExtraRepeatedFieldElementsOfFieldDescriptors(
+    first: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringExtraRepeatedFieldElementsOfFieldDescriptors(first, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringExtraRepeatedFieldElementsOfFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringExtraRepeatedFieldElementsOfFieldDescriptors(
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringExtraRepeatedFieldElementsOfFieldDescriptors(fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.usingDoubleTolerance]
+ */
+public fun ProtoSubject.usingDoubleTolerance(
+    tolerance: Double,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingDoubleTolerance(tolerance))
+}
+
+/**
+ * @see [ProtoSubject.usingDoubleToleranceForFields]
+ */
+public fun ProtoSubject.usingDoubleToleranceForFields(
+    tolerance: Double,
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingDoubleToleranceForFields(tolerance, firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.usingDoubleToleranceForFields]
+ */
+public fun ProtoSubject.usingDoubleToleranceForFields(
+    tolerance: Double,
+    fieldNumbers: Iterable<Int>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingDoubleToleranceForFields(tolerance, fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.usingDoubleToleranceForFieldDescriptors]
+ */
+public fun ProtoSubject.usingDoubleToleranceForFieldDescriptors(
+    tolerance: Double,
+    firstFieldDescriptor: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingDoubleToleranceForFieldDescriptors(tolerance, firstFieldDescriptor, *rest))
+}
+
+/**
+ * @see [ProtoSubject.usingDoubleToleranceForFieldDescriptors]
+ */
+public fun ProtoSubject.usingDoubleToleranceForFieldDescriptors(
+    tolerance: Double,
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingDoubleToleranceForFieldDescriptors(tolerance, fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.usingFloatTolerance]
+ */
+public fun ProtoSubject.usingFloatTolerance(
+    tolerance: Float,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingFloatTolerance(tolerance))
+}
+
+/**
+ * @see ProtoSubject.usingFloatToleranceForFields
+ */
+public fun ProtoSubject.usingFloatToleranceForFields(
+    tolerance: Float,
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingFloatToleranceForFields(tolerance, firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.usingFloatToleranceForFields]
+ */
+public fun ProtoSubject.usingFloatToleranceForFields(
+    tolerance: Float, fieldNumbers: Iterable<Int>, assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingFloatToleranceForFields(tolerance, fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.usingFloatToleranceForFieldDescriptors]
+ */
+public fun ProtoSubject.usingFloatToleranceForFieldDescriptors(
+    tolerance: Float,
+    firstFieldDescriptor: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingFloatToleranceForFieldDescriptors(tolerance, firstFieldDescriptor, *rest))
+}
+
+/**
+ * @see [ProtoSubject.usingFloatToleranceForFieldDescriptors]
+ */
+public fun ProtoSubject.usingFloatToleranceForFieldDescriptors(
+    tolerance: Float,
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(usingFloatToleranceForFieldDescriptors(tolerance, fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.withPartialScope]
+ */
+public fun ProtoSubject.withPartialScope(
+    fieldScope: FieldScope,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(withPartialScope(fieldScope))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFields]
+ */
+public fun ProtoSubject.ignoringFields(
+    firstFieldNumber: Int,
+    vararg rest: Int,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFields(firstFieldNumber, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFields]
+ */
+public fun ProtoSubject.ignoringFields(
+    fieldNumbers: Iterable<Int>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFields(fieldNumbers))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringFieldDescriptors(
+    firstFieldDescriptor: FieldDescriptor,
+    vararg rest: FieldDescriptor,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldDescriptors(firstFieldDescriptor, *rest))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldDescriptors]
+ */
+public fun ProtoSubject.ignoringFieldDescriptors(
+    fieldDescriptors: Iterable<FieldDescriptor>,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldDescriptors(fieldDescriptors))
+}
+
+/**
+ * @see [ProtoSubject.ignoringFieldScope]
+ */
+public fun ProtoSubject.ignoringFieldScope(
+    fieldScope: FieldScope,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(ignoringFieldScope(fieldScope))
+}
+
+/**
+ * @see [ProtoSubject.reportingMismatchesOnly]
+ */
+public fun ProtoSubject.reportingMismatchesOnly(assertions: ProtoFluentAssertion.() -> Unit) {
+    assertions(reportingMismatchesOnly())
+}
+
+/**
+ * @see [ProtoSubject.unpackingAnyUsing]
+ */
+public fun ProtoSubject.unpackingAnyUsing(
+    typeRegistry: TypeRegistry,
+    extensionRegistry: ExtensionRegistry,
+    assertions: ProtoFluentAssertion.() -> Unit
+) {
+    assertions(unpackingAnyUsing(typeRegistry, extensionRegistry))
 }

--- a/testlib/src/test/kotlin/io/spine/testing/TruthExtensionsSpec.kt
+++ b/testlib/src/test/kotlin/io/spine/testing/TruthExtensionsSpec.kt
@@ -27,6 +27,9 @@
 package io.spine.testing
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.extensions.proto.ProtoTruth
+import com.google.protobuf.ExtensionRegistry
+import io.spine.type.KnownTypes
 import java.util.*
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -75,6 +78,39 @@ internal class TruthExtensionsSpec {
         assertThat(Optional.of("something")) {
             isPresent()
             hasValue("something")
+        }
+    }
+
+    @Test
+    fun `fun for 'ProtoSubject`() {
+        val msg = io.spine.base.error {
+            type = "Big bada boom"
+            code = 42
+        }
+
+        val expected = io.spine.base.error { code = 42 }
+
+        // Standard syntax.
+        ProtoTruth.assertThat(msg)
+            .comparingExpectedFieldsOnly()
+            .isEqualTo(expected)
+
+        // Kotlin, having fun.
+        assertThat(msg) {
+            comparingExpectedFieldsOnly {
+                isEqualTo(io.spine.base.error { code = 42 })
+            }
+        }
+
+        // Given just to show nested call example for `unpackingAnyUsing`.
+        assertThat(msg) {
+            val typeRegistry = KnownTypes.instance().typeRegistry()
+            val extensionRegistry = ExtensionRegistry.newInstance()
+            unpackingAnyUsing(typeRegistry, extensionRegistry) {
+                comparingExpectedFieldsOnly {
+                    isEqualTo(expected)
+                }
+            }
         }
     }
 }

--- a/testlib/src/test/kotlin/io/spine/testing/TruthExtensionsSpec.kt
+++ b/testlib/src/test/kotlin/io/spine/testing/TruthExtensionsSpec.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing
+
+import com.google.common.truth.Truth.assertThat
+import java.util.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Truth extensions for Kotlin should provide")
+internal class TruthExtensionsSpec {
+
+    @Nested
+    inner class `fun for 'StringSubject' allowing` {
+
+        @Test
+        fun `function block`() {
+            assertThat("   foo  bar") {
+                contains("foo")
+                contains("bar")
+            }
+        }
+
+        @Test
+        fun `nested 'ignoringCase()' calls`() {
+            assertThat("foo bar").ignoringCase() {
+                contains("FOo")
+                contains("BaR")
+                doesNotContain("  ")
+            }
+
+            // And plain Truth syntax works too.
+            assertThat("fiz baz").ignoringCase().contains("BaZ")
+        }
+    }
+
+    @Test
+    fun `fun for 'IterableSubject'`() {
+        assertThat(listOf(1, 2, 3)) {
+            contains(1)
+            contains(3)
+            doesNotContain(4)
+            containsAtLeastElementsIn(listOf(3, 2))
+            containsAtLeastElementsIn(listOf(1, 3)).inOrder()
+        }
+    }
+
+    @Test
+    fun `fun for 'OptionalSubject'`() {
+        assertThat(Optional.of("something")) {
+            isPresent()
+            hasValue("something")
+        }
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.115")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.116")


### PR DESCRIPTION
This PR provides Kotlin DSL for `StringSubject`, `IterableSubject`, `OptionalSubject`, and `ProtoSubject`.