### PR TITLE
More Kotlin extensions

### DIFF
--- a/base/src/main/java/io/spine/string/Quoter.java
+++ b/base/src/main/java/io/spine/string/Quoter.java
@@ -56,7 +56,7 @@ abstract class Quoter extends Converter<String, String> {
     }
 
     /**
-     * Prepends quote characters in the passed string with two leading backslashes,
+     * Prepends quote characters in the given string with two leading backslashes,
      * and then wraps the string into quotes.
      */
     abstract String quote(String stringToQuote);

--- a/base/src/main/kotlin/io/spine/string/Strings.kt
+++ b/base/src/main/kotlin/io/spine/string/Strings.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+@file:JvmName("Strings")
+
+package io.spine.string
+
+/**
+ * Obtains the same string but with the first capital letter.
+ *
+ * If the first char of the string cannot be capitalized (e.g. is not a letter, is already
+ * capitalized, etc.), obtains the same string.
+ */
+public fun String.titleCase(): String =
+    replaceFirstChar { it.titlecase() }
+
+/**
+ * Obtains the same string but in camel case instead of snake case.
+ *
+ * The string will start with the first capital letter if possible.
+ *
+ * Examples:
+ *  - `"aaa"` becomes `"Aaa"`;
+ *  - `"field_name"` becomes `"FieldName"`;
+ *  - `"TypeName"` stays `"TypeName"`;
+ *  - `"___u_ri____"` becomes `"URi"`.
+ */
+public fun String.camelCase(): String =
+    split("_").camelCase()
+
+/**
+ * Joins these strings into a camel case string.
+ *
+ * The string will start with the first capital letter if possible.
+ *
+ * Each element is capitalized and joined in the order of appearance in this `Iterable`.
+ * The elements are never changed except for the first char.
+ */
+public fun Iterable<String>.camelCase(): String =
+    filter { it.isNotBlank() }.joinToString(separator = "") { it.titleCase() }
+
+/**
+ * Trims the common indent from all the lines, as well as the trailing whitespace.
+ *
+ * Same as [String.trimIndent] but also removes the trailing whitespace characters.
+ */
+internal fun String.trimWhitespace(): String {
+    val noIndent = trimIndent()
+    val lines = noIndent.lines()
+    val trimmedLines = lines.map {
+        it.trimEnd()
+    }
+    return trimmedLines.joinToString(System.lineSeparator())
+}

--- a/base/src/main/kotlin/io/spine/util/MoreCollections.kt
+++ b/base/src/main/kotlin/io/spine/util/MoreCollections.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util
+
+import com.google.common.collect.Iterables
+
+/**
+ * Obtains the only element in the receiver `Iterable`.
+ *
+ * @throws NoSuchElementException
+ *          if the iterable is empty.
+ * @throws IllegalArgumentException
+ *          if the iterable contains multiple elements.
+ */
+public fun <E> Iterable<E>.theOnly(): E = Iterables.getOnlyElement(this)
+
+/**
+ * Builds a `Sequence` which consists of the elements of this `Iterable` and
+ * the given [infix] between them.
+ *
+ * Example:
+ *  - `listOf(0, 1, 2).interlaced(42)` -> `[0, 42, 1, 42, 2]`;
+ *  - `listOf("sea", "Moon", "Earth", "Sun").interlaced("of")` ->
+ *    `["sea", "of", "Moon", "of", "Earth", "of", "Sun"]`;
+ *  - `listOf<String>().interlaced("")` -> `[]`.
+ */
+internal fun <T> Iterable<T>.interlaced(infix: T): Sequence<T> = sequence {
+    forEachIndexed { index, element ->
+        if (index != 0) {
+            yield(infix)
+        }
+        yield(element)
+    }
+}

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -825,19 +825,25 @@ message EntityOption {
 
     // A type of an entity for state of which the message is defined.
     enum Kind {
+        option allow_alias = true;
+        
         // Reserved for errors.
         KIND_UNKNOWN = 0;
 
         // The message is an aggregate state.
         AGGREGATE = 1;
 
-        // The message is a state of a projection.
+        // The message is a state of a projection (same as "view").
         PROJECTION = 2;
+
+        // The message is a state of a view (same as "projection").
+        VIEW = 2;
 
         // The message is a state of a process manager.
         PROCESS_MANAGER = 3;
 
-        // The message is a state of an entity.
+        // The message is a state of an entity, which is not of the type
+        // defined by other members of this enumeration.
         ENTITY = 4;
     }
 

--- a/base/src/test/kotlin/io/spine/string/StringsSpec.kt
+++ b/base/src/test/kotlin/io/spine/string/StringsSpec.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.string
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+@DisplayName("Extensions for `String` should")
+class StringsSpec {
+
+    @ParameterizedTest
+    @CsvSource("aaa,Aaa", "field_name,Field_name", "TypeName,TypeName", "_uri,_uri")
+    fun `produce a title case string`(initial: String, expected: String) {
+        assertThat(initial.titleCase())
+            .isEqualTo(expected)
+    }
+
+    @ParameterizedTest
+    @CsvSource("aaa,Aaa", "field_name,FieldName", "TypeName,TypeName", "___u_ri____,URi")
+    fun `produce a camel case string`(initial: String, expected: String) {
+        assertThat(initial.camelCase())
+            .isEqualTo(expected)
+    }
+
+    @Test
+    fun `trim whitespace`() {
+        val value = """
+            line one   
+             line two 
+        """
+        assertThat(value.trimIndent().lines()[0].last())
+            .isEqualTo(' ')
+        val trimmed = value.trimWhitespace()
+        assertThat(trimmed.lines()[0].last())
+            .isEqualTo('e')
+        assertThat(trimmed).isEqualTo(
+            "line one" + System.lineSeparator() + " line two"
+        )
+    }
+}

--- a/base/src/test/kotlin/io/spine/util/MoreCollectionsSpec.kt
+++ b/base/src/test/kotlin/io/spine/util/MoreCollectionsSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util
+
+import com.google.common.truth.Truth.assertThat
+import java.util.stream.Stream
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@DisplayName("Extensions for collections should")
+class MoreCollectionsSpec {
+
+    @Test
+    fun `obtain the only element of a collection`() {
+        val list = listOf(42)
+        assertThat(list.theOnly())
+            .isEqualTo(42)
+    }
+
+    @Test
+    fun `fail to obtain the only element if collection is empty`() {
+        val set = setOf<Any>()
+        assertThrows<NoSuchElementException> { set.theOnly() }
+    }
+
+    @Test
+    fun `fail to obtain the only element if collection has many elements`() {
+        val set = setOf<Any>("foo", "bar")
+        assertThrows<IllegalArgumentException> { set.theOnly() }
+    }
+
+    @ParameterizedTest
+    @MethodSource("interlaceCollections")
+    fun `interlace a collection`(elements: List<Any>, separator: Any, expected: List<Any>) {
+        assertThat(elements.interlaced(separator).toList())
+            .isEqualTo(expected)
+    }
+
+    companion object {
+
+        @Suppress("unused") // Used by JUnit.
+        @JvmStatic
+        fun interlaceCollections(): Stream<Arguments> = Stream.of(
+            arguments(listOf(0, 1, 2), 42, listOf(0, 42, 1, 42, 2)),
+            arguments(
+                listOf("sea", "Moon", "Earth", "Sun"),
+                "of",
+                listOf("sea", "of", "Moon", "of", "Earth", "of", "Sun")
+            ),
+            arguments(listOf<String>(), "doesn't matter", listOf<String>()),
+        )
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.116`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.117`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -520,12 +520,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 24 15:55:08 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 26 15:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.116`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.117`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1093,4 +1093,4 @@ This report was generated on **Mon Oct 24 15:55:08 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Oct 24 15:55:08 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 26 15:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -520,7 +520,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 26 15:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 26 21:37:20 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1093,4 +1093,4 @@ This report was generated on **Wed Oct 26 15:54:36 TRT 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Oct 26 15:54:36 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 26 21:37:21 TRT 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.116</version>
+<version>2.0.0-SNAPSHOT.117</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.116")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.117")


### PR DESCRIPTION
This PR:
  * Adds `VIEW` alias for `PROJECTION` in the `Enum.Kind` enumeration. This is to allow writing `option (entity.kind)=VIEW` which plays nicer with `View` types in ProtoData (which is hopefully would be added to `core-java` soon).
  * Moves general purpose Kotlin extensions from ProtoData.