### PR TITLE
Extensions for `NullPointerTester`

### DIFF
--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.120`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.121`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -650,12 +650,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 28 13:25:47 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 06 12:24:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.120`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.121`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.9.
@@ -1353,4 +1353,4 @@ This report was generated on **Fri Oct 28 13:25:47 EEST 2022** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Oct 28 13:25:48 EEST 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Nov 06 12:24:54 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.120</version>
+<version>2.0.0-SNAPSHOT.121</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/src/main/kotlin/io/spine/testing/GuavaExtensions.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/GuavaExtensions.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.testing
+
+import com.google.common.testing.NullPointerTester
+
+/**
+ * Creates [NullPointerTester] and runs the [block] on it.
+ */
+public fun nullPointerTester(block: NullPointerTester.() -> NullPointerTester): NullPointerTester {
+    val tester = NullPointerTester()
+    tester.block()
+    return tester
+}
+
+/**
+ * Allows to use generic parameter of the function instead of `MyType::class.java` as the first
+ * parameter type.
+ */
+public inline fun <reified T : Any> NullPointerTester.setDefault(value: T): NullPointerTester =
+    setDefault(T::class.java, value)
+

--- a/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
+++ b/testlib/src/main/kotlin/io/spine/testing/TruthExtensions.kt
@@ -26,7 +26,6 @@
 
 package io.spine.testing
 
-import com.google.common.testing.NullPointerTester
 import com.google.common.truth.IterableSubject
 import com.google.common.truth.OptionalSubject
 import com.google.common.truth.StringSubject
@@ -58,13 +57,6 @@ import java.util.*
  */
 @Suppress("unused") // is used for KDoc on this file.
 private const val ABOUT = ""
-
-/**
- * Allows to use generic parameter of the function instead of `MyType::class.java` as the first
- * parameter type.
- */
-public inline fun <reified T : Any> NullPointerTester.setDefault(value: T): NullPointerTester =
-    setDefault(T::class.java, value)
 
 /**
  * Allows to write:

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.120")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.121")


### PR DESCRIPTION
This PR:
  * Adds block function for `NullPointerTester`.
  * Consolidates all extensions for this class under `GuavaExtensions.kt` for better visibility.