### PR TITLE
[1.x] Publishing with Validating Builders

### DIFF
--- a/.github/workflows/publish-v1.yml
+++ b/.github/workflows/publish-v1.yml
@@ -59,7 +59,7 @@ jobs:
         # Also, we don't want to update the GitHub Pages content, as it may be already
         # updated with the contents of 2.x branch. So this operation should be performed
         # manually, if really needed.
-        run: ./gradlew publish -x test -x updateGitHubPages --stacktrace
+        run: ./gradlew clean build publish -x test -x updateGitHubPages --stacktrace --console=plain
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORMAL_GIT_HUB_PAGES_AUTHOR: developers@spine.io


### PR DESCRIPTION
This PR attempts to re-publish the artifacts with the Validating Builders assembled properly.

Also, the latest `config/1.x` now allows to properly detect whether the published artifact is a snapshot.