### PR TITLE
Fix duplicated input for `sourcesJar` task

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -49,12 +49,30 @@ dependencies {
 }
 
 protobuf {
-    val generatedDir by project.extra("$projectDir/generated")
     generateProtoTasks.all().configureEach {
-        setup(generatedDir)
+        setup("$projectDir/generated")
     }
 }
 
 tasks {
     excludeGoogleProtoFromArtifacts()
+}
+
+/**
+ * Make the `sourcesJar` task accept duplicated input which seems to occur
+ * somewhere inside under Protobuf Kotlin plugin.
+ *
+ * The suspect is Protobuf Kotlin plugin because of the following error message
+ * produced during publishing:
+ * ```
+ * Caused by: org.gradle.api.InvalidUserCodeException: Entry io/spine/base/ListOfAnysKt.kt is
+ * a duplicate but no duplicate handling strategy has been set.
+ * ```
+ */
+project.afterEvaluate {
+    @Suppress("UNUSED_VARIABLE")
+    val sourcesJar by tasks.getting {
+        this as Jar
+        duplicatesStrategy = DuplicatesStrategy.INCLUDE
+    }
 }

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -57,22 +57,3 @@ protobuf {
 tasks {
     excludeGoogleProtoFromArtifacts()
 }
-
-/**
- * Make the `sourcesJar` task accept duplicated input which seems to occur
- * somewhere inside under Protobuf Kotlin plugin.
- *
- * The suspect is Protobuf Kotlin plugin because of the following error message
- * produced during publishing:
- * ```
- * Caused by: org.gradle.api.InvalidUserCodeException: Entry io/spine/base/ListOfAnysKt.kt is
- * a duplicate but no duplicate handling strategy has been set.
- * ```
- */
-project.afterEvaluate {
-    @Suppress("UNUSED_VARIABLE")
-    val sourcesJar by tasks.getting {
-        this as Jar
-        duplicatesStrategy = DuplicatesStrategy.INCLUDE
-    }
-}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -227,14 +227,12 @@ fun Subproject.applyGeneratedDir(generatedDir: String) {
 
     sourceSets {
         main {
-            java.srcDir(generatedKotlinDir)
             resources.srcDirs(
                 "$generatedDir/main/resources",
                 "$buildDir/descriptors/main"
             )
         }
         test {
-            java.srcDir(generatedTestJavaDir)
             resources.srcDirs(
                 "$generatedDir/test/resources",
                 "$buildDir/descriptors/test"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-rc-4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:11`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -708,12 +708,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 24 17:04:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 26 23:31:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:11`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.142`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1542,4 +1542,4 @@ This report was generated on **Thu Nov 24 17:04:33 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Nov 24 17:04:33 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 26 23:31:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -708,7 +708,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 26 23:31:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 26 23:38:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1542,4 +1542,4 @@ This report was generated on **Sat Nov 26 23:31:03 EET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Nov 26 23:31:03 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Nov 26 23:38:47 EET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.141</version>
+<version>2.0.0-SNAPSHOT.142</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.141")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.142")


### PR DESCRIPTION
This PR removes the unnecessary configuration of Java source sets, which caused duplicated input for the `sourcesJar` task, which in turns [failed publishing](https://github.com/SpineEventEngine/base/actions/runs/3541486560).