### PR TITLE
Bump internal dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -61,20 +61,20 @@ class Spine(p: ExtensionAware) {
          *
          * @see [ProtoData]
          */
-        const val protoData = "0.3.0"
+        const val protoData = "0.5.1"
 
         /**
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.143"
+        const val base = "2.0.0-SNAPSHOT.144"
 
         /**
          * The default version of `core-java` to use.
          * @see [Spine.CoreJava.client]
          * @see [Spine.CoreJava.server]
          */
-        const val core = "2.0.0-SNAPSHOT.119"
+        const val core = "2.0.0-SNAPSHOT.122"
 
         /**
          * The version of `model-compiler` to use.
@@ -85,44 +85,44 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.106"
+        const val mcJava = "2.0.0-SNAPSHOT.122"
 
         /**
          * The version of `base-types` to use.
          * @see [Spine.baseTypes]
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.112"
+        const val baseTypes = "2.0.0-SNAPSHOT.113"
 
         /**
          * The version of `time` to use.
          * @see [Spine.time]
          */
-        const val time = "2.0.0-SNAPSHOT.120"
+        const val time = "2.0.0-SNAPSHOT.121"
 
         /**
          * The version of `change` to use.
          * @see [Spine.change]
          */
-        const val change = "2.0.0-SNAPSHOT.117"
+        const val change = "2.0.0-SNAPSHOT.118"
 
         /**
          * The version of `text` to use.
          *
          * @see Spine.text
          */
-        const val text = "2.0.0-SNAPSHOT.1"
+        const val text = "2.0.0-SNAPSHOT.2"
 
         /**
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.121"
+        const val toolBase = "2.0.0-SNAPSHOT.140"
 
         /**
          * The version of `validation` to use.
          * @see [Spine.validation]
          */
-        const val validation = "2.0.0-SNAPSHOT.61"
+        const val validation = "2.0.0-SNAPSHOT.71"
 
         /**
          * The version of Javadoc Tools to use.

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -708,12 +708,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 15 15:25:49 CET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 15 17:59:52 CET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.144`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.145`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1542,4 +1542,4 @@ This report was generated on **Thu Dec 15 15:25:49 CET 2022** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 15 15:25:50 CET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 15 17:59:52 CET 2022** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.144</version>
+<version>2.0.0-SNAPSHOT.145</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.144")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.145")


### PR DESCRIPTION
This PR updates `Spine` dependency to set latest versions of the internal dependencies.

Most of dependencies declared in the `Spine` object are not used by `base` (because of the nature of this project).The aim of this PR is to be the reference point of propagation of these version information in addition to `config`, which will be updated following resolution of this PR.