### PR TITLE
Preserving system line separators

### DIFF
--- a/base/src/main/kotlin/io/spine/string/Indent.kt
+++ b/base/src/main/kotlin/io/spine/string/Indent.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.string
+
+/**
+ * An increment of an indentation to be used for formatting texts.
+ */
+public data class Indent(
+
+    /**
+     * A positive number of space characters to be used for the indentation increment.
+     */
+    public val size: Int = DEFAULT_SIZE
+) {
+
+    init {
+        require(size > 0) { "The `size` must be positive, but was $size."}
+    }
+
+    /**
+     * The value of the indentation increment.
+     */
+    public val value: String = " ".repeat(size)
+
+    /**
+     * Obtains the value of this indentation.
+     */
+    override fun toString(): String = value
+
+    public companion object {
+
+        /**
+         * The default indentation, which is primarily used in the generated Java code.
+         */
+        public const val DEFAULT_SIZE: Int = 4
+    }
+}
+
+/**
+ * Repeats this indentation [n] times.
+ *
+ * @throws [IllegalArgumentException] when [n] < 0.
+ */
+public fun Indent.repeat(n: Int): String {
+    require(size >= 0) { "Count `n` must be non-negative, but was $size."}
+    return value.repeat(n)
+}
+
+/**
+ * Same as [repeat].
+ */
+public fun Indent.atLevel(l: Int): String = repeat(l)

--- a/base/src/main/kotlin/io/spine/string/Separator.kt
+++ b/base/src/main/kotlin/io/spine/string/Separator.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.string
+
+/**
+ * Constants for line separators.
+ */
+public object Separator {
+
+    /**
+     * The line separator used by Unix-like systems (including Linux and macOS).
+     *
+     * This line separator is used by Kotlin string utilities in
+     * [String.trimIndent] and [String.replaceIndent].
+     */
+    public const val LF: String = "\n"
+
+    /**
+     * The line separator used by the Classic Mac OS.
+     */
+    public const val CR: String = "\r"
+
+    /**
+     * Windows line separator.
+     */
+    public const val CRLF: String = "\r\n"
+
+    /**
+     * The line separator used by the current operating system.
+     *
+     * Same as [System.lineSeparator].
+     */
+    public val NL: String = System.lineSeparator()
+}

--- a/base/src/main/kotlin/io/spine/string/Strings.kt
+++ b/base/src/main/kotlin/io/spine/string/Strings.kt
@@ -28,6 +28,8 @@
 
 package io.spine.string
 
+import io.spine.string.Indent.Companion.DEFAULT_SIZE
+
 /**
  * Obtains the same string but with the first capital letter.
  *
@@ -38,7 +40,7 @@ public fun String.titleCase(): String =
     replaceFirstChar { it.titlecase() }
 
 /**
- * Obtains the same string but in camel case instead of snake case.
+ * Obtains the same string but in `CamelCase` instead of `snake_case`.
  *
  * The string will start with the first capital letter if possible.
  *
@@ -52,7 +54,7 @@ public fun String.camelCase(): String =
     split("_").camelCase()
 
 /**
- * Joins these strings into a camel case string.
+ * Joins these strings into a `CamelCase` string.
  *
  * The string will start with the first capital letter if possible.
  *
@@ -65,7 +67,9 @@ public fun Iterable<String>.camelCase(): String =
 /**
  * Trims the common indent from all the lines, as well as the trailing whitespace.
  *
- * Same as [String.trimIndent] but also removes the trailing whitespace characters.
+ * This method is similar to [String.trimIndent], but unlike it:
+ *    1) preserves system line separators;
+ *    2) also removes the trailing whitespace characters.
  */
 public fun String.trimWhitespace(): String {
     val noIndent = trimIndent()
@@ -73,5 +77,22 @@ public fun String.trimWhitespace(): String {
     val trimmedLines = lines.map {
         it.trimEnd()
     }
-    return trimmedLines.joinToString(System.lineSeparator())
+    return trimmedLines.joinToString(Separator.NL)
 }
+
+/**
+ * Replaces [Separator.LF] used by Kotlin string utilities for splitting by lines,
+ * with [Separator.NL] so that we don't have issues when writing generated texts under Windows.
+ */
+private fun String.fixLineEndings(): String = replace(Separator.LF, Separator.NL)
+
+/**
+ * Trims indentation similarly to [String.trimIndent] but preserving system line separators.
+ */
+public fun String.ti(): String = trimIndent().fixLineEndings()
+
+/**
+ *  Prepends indentation similarly to [String.prependIndent] but preserving system line separators.
+ */
+public fun String.pi(indent: String = Indent(DEFAULT_SIZE).value): String =
+    prependIndent(indent).fixLineEndings()

--- a/base/src/test/kotlin/io/spine/string/IndentSpec.kt
+++ b/base/src/test/kotlin/io/spine/string/IndentSpec.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.string
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Indent` should")
+internal class IndentSpec {
+
+    @Test
+    fun `have default size`() {
+        Indent().value.length shouldBe Indent.DEFAULT_SIZE
+    }
+
+    @Test
+    fun `return its value in 'toString'`() {
+        val indent = Indent(1)
+        indent.toString() shouldBe indent.value
+    }
+
+    @Test
+    fun `obtain indentation at given level`() {
+        Indent(2).atLevel(2) shouldBe " ".repeat(4)
+    }
+}

--- a/base/src/test/kotlin/io/spine/string/StringsSpec.kt
+++ b/base/src/test/kotlin/io/spine/string/StringsSpec.kt
@@ -26,7 +26,9 @@
 
 package io.spine.string
 
-import com.google.common.truth.Truth.assertThat
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldStartWith
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -38,15 +40,13 @@ class StringsSpec {
     @ParameterizedTest
     @CsvSource("aaa,Aaa", "field_name,Field_name", "TypeName,TypeName", "_uri,_uri")
     fun `produce a title case string`(initial: String, expected: String) {
-        assertThat(initial.titleCase())
-            .isEqualTo(expected)
+        initial.titleCase() shouldBe expected
     }
 
     @ParameterizedTest
     @CsvSource("aaa,Aaa", "field_name,FieldName", "TypeName,TypeName", "___u_ri____,URi")
     fun `produce a camel case string`(initial: String, expected: String) {
-        assertThat(initial.camelCase())
-            .isEqualTo(expected)
+        initial.camelCase() shouldBe expected
     }
 
     @Test
@@ -55,13 +55,36 @@ class StringsSpec {
             line one   
              line two 
         """
-        assertThat(value.trimIndent().lines()[0].last())
-            .isEqualTo(' ')
+        // Check that we have space char at the end after `trimIndent()`.
+        value.trimIndent().lines()[0].last() shouldBe ' '
+
         val trimmed = value.trimWhitespace()
-        assertThat(trimmed.lines()[0].last())
-            .isEqualTo('e')
-        assertThat(trimmed).isEqualTo(
-            "line one" + System.lineSeparator() + " line two"
-        )
+
+        trimmed.lines()[0].last() shouldBe 'e' // as in "one".
+
+        trimmed shouldBe "line one" + System.lineSeparator() + " line two"
+    }
+
+    @Test
+    fun `trim indent preserving system line separators`() {
+        val value = """
+            line 1
+            line 2
+        """.ti()
+
+        value shouldContain Separator.NL
+    }
+
+    @Test
+    fun `prepend indentation preserving system line separator`() {
+        val lines = """
+          a
+           b
+            c
+        """.trimIndent() // This splits lines with "\n"
+           .pi()         // This applies `Separator.NL` prepending with default indentation.
+
+        lines shouldStartWith "    a"
+        lines shouldContain Separator.NL
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -117,8 +117,6 @@ configurations.all {
             // Force Kotlin lib versions avoiding using those bundled with Gradle.
             "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
-            "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion",
             "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
         )
     }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -41,6 +41,11 @@ object Kotlin {
 
     const val stdLib       = "${group}:kotlin-stdlib:${version}"
     const val stdLibCommon = "${group}:kotlin-stdlib-common:${version}"
+
+    @Deprecated("Please use `stdLib` instead.")
+    const val stdLibJdk7   = "${group}:kotlin-stdlib-jdk7:${version}"
+
+    @Deprecated("Please use `stdLib` instead.")
     const val stdLibJdk8   = "${group}:kotlin-stdlib-jdk8:${version}"
 
     const val reflect    = "${group}:kotlin-reflect:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -67,14 +67,14 @@ class Spine(p: ExtensionAware) {
          * The default version of `base` to use.
          * @see [Spine.base]
          */
-        const val base = "2.0.0-SNAPSHOT.145"
+        const val base = "2.0.0-SNAPSHOT.150"
 
         /**
          * The default version of `core-java` to use.
          * @see [Spine.CoreJava.client]
          * @see [Spine.CoreJava.server]
          */
-        const val core = "2.0.0-SNAPSHOT.122"
+        const val core = "2.0.0-SNAPSHOT.141"
 
         /**
          * The version of `model-compiler` to use.
@@ -85,7 +85,7 @@ class Spine(p: ExtensionAware) {
         /**
          * The version of `mc-java` to use.
          */
-        const val mcJava = "2.0.0-SNAPSHOT.131"
+        const val mcJava = "2.0.0-SNAPSHOT.132"
 
         /**
          * The version of `base-types` to use.
@@ -116,7 +116,7 @@ class Spine(p: ExtensionAware) {
          * The version of `tool-base` to use.
          * @see [Spine.toolBase]
          */
-        const val toolBase = "2.0.0-SNAPSHOT.155"
+        const val toolBase = "2.0.0-SNAPSHOT.156"
 
         /**
          * The version of `validation` to use.

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/JavadocConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/JavadocConfig.kt
@@ -43,9 +43,9 @@ object JavadocConfig {
     /**
      * Link to the documentation for Java 11 Standard Library API.
      *
-     * OpenJDK SE 11 is used for the reference.
+     * Oracle JDK SE 11 is used for the reference.
      */
-    private const val standardLibraryAPI = "https://cr.openjdk.java.net/~iris/se/11/latestSpec/api/"
+    private const val standardLibraryAPI = "https://docs.oracle.com/en/java/javase/11/docs/api/"
 
     @Suppress("MemberVisibilityCanBePrivate") // opened to be visible from docs.
     val tags = listOf(

--- a/license-report.md
+++ b/license-report.md
@@ -712,7 +712,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 17 14:53:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 17 18:07:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1550,4 +1550,4 @@ This report was generated on **Fri Feb 17 14:53:16 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 17 14:53:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 17 18:07:25 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.150`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.151`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -712,12 +712,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 26 16:37:30 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 17 14:53:16 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.150`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.151`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1550,4 +1550,4 @@ This report was generated on **Thu Jan 26 16:37:30 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jan 26 16:37:31 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 17 14:53:17 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.150</version>
+<version>2.0.0-SNAPSHOT.151</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.150")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.151")


### PR DESCRIPTION
This PR:
  * Adds extensions functions for `String` which work similarly to `trimIndent()` and `prependIndent()` from Kotlin, but unlike them preserve system line separators.
  * Add the `Indent` class for working with indentation. The new class is going to replace its Java namesake from `tool-base`.
