### PR TITLE
Detection of OS family

### DIFF
--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2023, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -72,10 +72,15 @@ public enum OsFamily {
     private static final String DARWIN = "darwin";
 
     /**
+     * A lower-cased name of the OS family.
+     */
+    private final String signature;
+
+    /**
      * Obtains the family of the current operating system.
      */
     @NonNull
-    public static OsFamily current() {
+    public static OsFamily detect() {
         var current = Arrays.stream(values())
                 .filter(OsFamily::isCurrent)
                 .findFirst()
@@ -84,21 +89,6 @@ public enum OsFamily {
                 );
         return current;
     }
-
-    /**
-     * Obtains the value of the system property with the given name.
-     *
-     * <p>Added for brevity of the code.
-     */
-    @SuppressWarnings("AccessOfSystemProperties") // to get current OS props.
-    private static String prop(String name) {
-        return System.getProperty(name);
-    }
-
-    /**
-     * A lower-cased name of the OS family.
-     */
-    private final String signature;
 
     /**
      * Creates an instance with the signature taken as a lower-cased enum item name.
@@ -121,5 +111,15 @@ public enum OsFamily {
     public boolean isCurrent() {
         var result = OS_NAME.contains(signature);
         return result;
+    }
+
+    /**
+     * Obtains the value of the system property with the given name.
+     *
+     * <p>Added for brevity of the code.
+     */
+    @SuppressWarnings("AccessOfSystemProperties") // to get current OS props.
+    private static String prop(String name) {
+        return System.getProperty(name);
     }
 }

--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -56,7 +56,7 @@ public enum OsFamily {
             if (macOS.isCurrent()) {
                 return false;
             }
-            var separatorMatches = PATH_SEP.equals(":");
+            var separatorMatches = ":".equals(PATH_SEP);
             var darwinOrX = OS_NAME.endsWith("x") || OS_NAME.contains(DARWIN);
             var notVms = !OS_NAME.contains("openvms");
             return separatorMatches && notVms && darwinOrX;

--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2022, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.environment;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+/**
+ * Detects current operating system properties.
+ *
+ * <p>Based on {@code org.apache.tools.ant.taskdefs.condition.Os}.
+ */
+public enum OsFamily {
+
+    Windows,
+
+    macOS("mac") {
+        @Override
+        public boolean isCurrent() {
+            return super.isCurrent() || OS_NAME.contains(DARWIN);
+        }
+    },
+
+    Unix {
+        @Override
+        public boolean isCurrent() {
+            if (macOS.isCurrent()) {
+                return false;
+            }
+            var separatorMatches = ":".equals(PATH_SEP);
+            var darwinOrX = OS_NAME.endsWith("x") || OS_NAME.contains(DARWIN);
+            var notVms = !OS_NAME.contains("openvms");
+            return separatorMatches && notVms && darwinOrX;
+        }
+    };
+
+    /**
+     * Obtains the family of the current operating system.
+     */
+    @NonNull
+    public static OsFamily current() {
+        var current = Arrays.stream(values())
+                .filter(OsFamily::isCurrent)
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Unable to detect current operating system.")
+                );
+        return current;
+    }
+
+    private static final String OS_NAME = prop("os.name").toLowerCase(Locale.ENGLISH);
+    private static final String PATH_SEP = prop("path.separator");
+
+    /**
+     * OpenJDK is reported to call macOS "Darwin".
+     *
+     * @see <a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=44889">Bug 1</a>
+     * @see <a href="https://issues.apache.org/jira/browse/HADOOP-3318">Bug 2</a>
+     */
+    private static final String DARWIN = "darwin";
+
+    /**
+     * Obtains the value of the system property with the given name.
+     *
+     * <p>Added for brevity of the code.
+     */
+    @SuppressWarnings("AccessOfSystemProperties") // to get current OS props.
+    private static String prop(String name) {
+        return System.getProperty(name);
+    }
+
+    /**
+     * A lower-cased name of the OS family.
+     */
+    private final String signature;
+
+    /**
+     * Creates an instance with the signature taken as a lower-cased enum item name.
+     */
+    OsFamily() {
+        this.signature = name().toLowerCase(Locale.ENGLISH);
+    }
+
+    /**
+     * Creates an instance with the passed signature value.
+     */
+    OsFamily(String signature) {
+        this.signature = signature;
+    }
+
+    /**
+     * Tells if the operating system under which the code is executed belongs
+     * to this OS family.
+     */
+    public boolean isCurrent() {
+        var result = OS_NAME.contains(signature);
+        return result;
+    }
+}

--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -60,6 +60,17 @@ public enum OsFamily {
         }
     };
 
+    private static final String OS_NAME = prop("os.name").toLowerCase(Locale.ENGLISH);
+    private static final String PATH_SEP = prop("path.separator");
+
+    /**
+     * OpenJDK is reported to call macOS "Darwin".
+     *
+     * @see <a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=44889">Bug 1</a>
+     * @see <a href="https://issues.apache.org/jira/browse/HADOOP-3318">Bug 2</a>
+     */
+    private static final String DARWIN = "darwin";
+
     /**
      * Obtains the family of the current operating system.
      */
@@ -73,17 +84,6 @@ public enum OsFamily {
                 );
         return current;
     }
-
-    private static final String OS_NAME = prop("os.name").toLowerCase(Locale.ENGLISH);
-    private static final String PATH_SEP = prop("path.separator");
-
-    /**
-     * OpenJDK is reported to call macOS "Darwin".
-     *
-     * @see <a href="https://issues.apache.org/bugzilla/show_bug.cgi?id=44889">Bug 1</a>
-     * @see <a href="https://issues.apache.org/jira/browse/HADOOP-3318">Bug 2</a>
-     */
-    private static final String DARWIN = "darwin";
 
     /**
      * Obtains the value of the system property with the given name.

--- a/base/src/main/java/io/spine/environment/OsFamily.java
+++ b/base/src/main/java/io/spine/environment/OsFamily.java
@@ -31,6 +31,9 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import java.util.Arrays;
 import java.util.Locale;
 
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
 /**
  * Detects current operating system properties.
  *
@@ -53,7 +56,7 @@ public enum OsFamily {
             if (macOS.isCurrent()) {
                 return false;
             }
-            var separatorMatches = ":".equals(PATH_SEP);
+            var separatorMatches = PATH_SEP.equals(":");
             var darwinOrX = OS_NAME.endsWith("x") || OS_NAME.contains(DARWIN);
             var notVms = !OS_NAME.contains("openvms");
             return separatorMatches && notVms && darwinOrX;
@@ -118,8 +121,11 @@ public enum OsFamily {
      *
      * <p>Added for brevity of the code.
      */
+    @NonNull
     @SuppressWarnings("AccessOfSystemProperties") // to get current OS props.
     private static String prop(String name) {
-        return System.getProperty(name);
+        var property = System.getProperty(name);
+        checkState(property != null, "Unable to obtain the system property `%s`", name);
+        return requireNonNull(property);
     }
 }

--- a/base/src/test/kotlin/io/spine/environment/OsFamilySpec.kt
+++ b/base/src/test/kotlin/io/spine/environment/OsFamilySpec.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.environment
+
+import io.kotest.matchers.shouldBe
+import io.spine.environment.OsFamily.Unix
+import io.spine.environment.OsFamily.Windows
+import io.spine.environment.OsFamily.macOS
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+
+@DisplayName("`OsFamily` should")
+internal class OsFamilySpec {
+
+    @Test
+    fun `detect current OS`() {
+        assertDoesNotThrow {
+            OsFamily.current()
+        }
+    }
+
+    @Test
+    fun `tell if it is not current`() {
+        when (OsFamily.current()) {
+            Windows -> macOS.isCurrent shouldBe false
+            macOS -> Unix.isCurrent shouldBe false
+            Unix -> macOS.isCurrent shouldBe false
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/environment/OsFamilySpec.kt
+++ b/base/src/test/kotlin/io/spine/environment/OsFamilySpec.kt
@@ -40,13 +40,13 @@ internal class OsFamilySpec {
     @Test
     fun `detect current OS`() {
         assertDoesNotThrow {
-            OsFamily.current()
+            OsFamily.detect()
         }
     }
 
     @Test
     fun `tell if it is not current`() {
-        when (OsFamily.current()) {
+        when (OsFamily.detect()) {
             Windows -> macOS.isCurrent shouldBe false
             macOS -> Unix.isCurrent shouldBe false
             Unix -> macOS.isCurrent shouldBe false

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.151`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.152`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -712,12 +712,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 17 18:07:24 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 18 00:53:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.151`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.152`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1550,4 +1550,4 @@ This report was generated on **Fri Feb 17 18:07:24 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Feb 17 18:07:25 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 18 00:53:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -712,7 +712,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 18 00:53:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 18 01:34:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
@@ -1550,4 +1550,4 @@ This report was generated on **Sat Feb 18 00:53:05 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 18 00:53:06 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 18 01:34:56 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.151</version>
+<version>2.0.0-SNAPSHOT.152</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.151")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.152")


### PR DESCRIPTION
This PR brings `OsFamily` enum which was a part of `tool-base` into this code tree. The ability to detect current OS is needed only for tools, but for libraries that may need to deal with system specifics. For example, tests of the Text library already need to be able current OS because line separators are OS-specific.

It is expected that `tool-base` would migrate to `OsFamily` becauses it fixes an issue with detecting Unix (non-macOS) systems.
