### PR TITLE
Test overriding of `ValueHolder.value()` method

### DIFF
--- a/base/src/test/kotlin/io/spine/value/ValueHolderSpec.kt
+++ b/base/src/test/kotlin/io/spine/value/ValueHolderSpec.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.value
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`ValueHolder` should")
+internal class ValueHolderSpec {
+
+    /**
+     * This test ensures that [ValueHolder] has its method [ValueHolder.value] non-final.
+     *
+     * This is needed for casting of return type values in classes that derive
+     * from [ValueHolder] in `core-java`.
+     */
+    @Test
+    fun `have overridable 'value()' method`() {
+        @Suppress("serial")
+        val stub = object: ValueHolder<String>(javaClass.name) {
+            override fun value(): String {
+                return value
+            }
+        }
+        stub.value() shouldBe javaClass.name
+    }
+}

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -708,12 +708,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 26 18:01:37 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 26 23:56:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.160`
+# Dependencies of `io.spine.tools:spine-testlib:2.0.0-SNAPSHOT.161`
 
 ## Runtime
 1.  **Group** : com.google.auto.value. **Name** : auto-value-annotations. **Version** : 1.10.1.
@@ -1542,4 +1542,4 @@ This report was generated on **Sun Feb 26 18:01:37 WET 2023** using [Gradle-Lice
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Feb 26 18:01:37 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Feb 26 23:56:05 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>spine-base</artifactId>
-<version>2.0.0-SNAPSHOT.160</version>
+<version>2.0.0-SNAPSHOT.161</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/testlib/src/test/kotlin/io/spine/protobuf/GoogleTypesTest.kt
+++ b/testlib/src/test/kotlin/io/spine/protobuf/GoogleTypesTest.kt
@@ -40,7 +40,7 @@ internal class GoogleTypesTest {
 
          Starting from v3.22.0 Google Protobuf for Java (`protobuf-java-3.22.0.jar`) no longer
          contains the `plugin.proto`. The file is still present in the Protobuf source code tree
-         under `protobuf/src/google/protobuf/compiler/` directory, but it does not seem to
+         under `protobuf/src/google/protobuf/compiler/` directory, but it does not seem to be
          present in artifacts produced for Java.
 
          The references to `plugin.proto` are present in build files for C++. So, it could be an

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.160")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.161")


### PR DESCRIPTION
This PR adds test for `ValueHolder.value()` not being final. This is needed because some descendants in `core-java` override this method for casting return type values.

Also, it fixes the type [reported](https://github.com/SpineEventEngine/base/pull/780#pullrequestreview-1314716328) for the previous PR.
