### PR TITLE
Bump dependencies

### DIFF
--- a/.github/workflows/build-on-windows.yml
+++ b/.github/workflows/build-on-windows.yml
@@ -18,6 +18,9 @@ jobs:
           distribution: zulu
           cache: gradle
 
+      - name: Configure Pagefile
+        uses: al-cheb/configure-pagefile-action@v1.2
+
       - name: Build project and run tests
         shell: cmd
         # For the reason on `--no-daemon` see https://github.com/actions/cache/issues/454

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="EntryPointsManager">
-    <list size="6">
+    <list size="7">
       <item index="0" class="java.lang.String" itemvalue="com.google.auto.service.AutoService" />
       <item index="1" class="java.lang.String" itemvalue="io.spine.core.Subscribe" />
       <item index="2" class="java.lang.String" itemvalue="io.spine.server.aggregate.Apply" />
       <item index="3" class="java.lang.String" itemvalue="io.spine.server.command.Assign" />
       <item index="4" class="java.lang.String" itemvalue="io.spine.server.command.Command" />
       <item index="5" class="java.lang.String" itemvalue="io.spine.server.event.React" />
+      <item index="6" class="java.lang.String" itemvalue="io.spine.server.route.Route" />
     </list>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -38,14 +38,18 @@ import io.spine.internal.dependency.FindBugs
 import io.spine.internal.dependency.Flogger
 import io.spine.internal.dependency.Gson
 import io.spine.internal.dependency.Guava
+import io.spine.internal.dependency.Hamcrest
 import io.spine.internal.dependency.J2ObjC
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.Jackson
+import io.spine.internal.dependency.JavaDiffUtils
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Kotlin
 import io.spine.internal.dependency.Okio
+import io.spine.internal.dependency.OpenTest4J
 import io.spine.internal.dependency.Plexus
 import io.spine.internal.dependency.Protobuf
+import io.spine.internal.dependency.Slf4J
 import io.spine.internal.dependency.Truth
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.artifacts.Configuration
@@ -85,17 +89,17 @@ private fun ResolutionStrategy.forceProductionDependencies() {
         Dokka.BasePlugin.lib,
         ErrorProne.annotations,
         ErrorProne.core,
-        Guava.lib,
         FindBugs.annotations,
-        Flogger.lib,
         Flogger.Runtime.systemBackend,
+        Flogger.lib,
+        Guava.lib,
         Kotlin.reflect,
         Kotlin.stdLib,
         Kotlin.stdLibCommon,
         Kotlin.stdLibJdk8,
-        Protobuf.libs,
         Protobuf.GradlePlugin.lib,
-        io.spine.internal.dependency.Slf4J.lib
+        Protobuf.libs,
+        Slf4J.lib
     )
 }
 
@@ -119,22 +123,26 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
     force(
         Asm.lib,
         AutoValue.annotations,
-        Gson.lib,
-        J2ObjC.annotations,
-        Plexus.utils,
-        Okio.lib,
         CommonsCli.lib,
         CommonsLogging.lib,
+        Gson.lib,
+        Hamcrest.core,
+        J2ObjC.annotations,
         JUnit.Platform.engine,
         JUnit.Platform.suiteApi,
-        Jackson.databind,
+        JUnit.runner,
+        Jackson.annotations,
+        Jackson.bom,
         Jackson.core,
+        Jackson.databind,
         Jackson.dataformatXml,
         Jackson.dataformatYaml,
         Jackson.moduleKotlin,
-        Jackson.bom,
-        Jackson.annotations,
-        Kotlin.jetbrainsAnnotations
+        JavaDiffUtils.lib,
+        Kotlin.jetbrainsAnnotations,
+        Okio.lib,
+        OpenTest4J.lib,
+        Plexus.utils,
     )
 }
 

--- a/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
+++ b/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
@@ -32,7 +32,6 @@ plugins {
     id("com.google.protobuf")
 }
 
-
 // For generating test fixtures. See `src/test/proto`.
 protobuf {
     configurations.excludeProtobufLite()

--- a/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
+++ b/buildSrc/src/main/kotlin/compile-protobuf.gradle.kts
@@ -32,6 +32,7 @@ plugins {
     id("com.google.protobuf")
 }
 
+
 // For generating test fixtures. See `src/test/proto`.
 protobuf {
     configurations.excludeProtobufLite()

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AnimalSniffer.kt
@@ -27,6 +27,7 @@
 package io.spine.internal.dependency
 
 // https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/
+@Suppress("unused", "ConstPropertyName")
 object AnimalSniffer {
     private const val version = "1.21"
     const val lib = "org.codehaus.mojo:animal-sniffer-annotations:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ApacheHttp.kt
@@ -26,7 +26,7 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object ApacheHttp {
 
     // https://hc.apache.org/downloads.cgi

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AppEngine.kt
@@ -27,10 +27,10 @@
 package io.spine.internal.dependency
 
 // https://cloud.google.com/java/docs/reference
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object AppEngine {
     private const val version = "1.9.82"
-    const val sdk          = "com.google.appengine:appengine-api-1.0-sdk:${version}"
+    const val sdk = "com.google.appengine:appengine-api-1.0-sdk:${version}"
 
     object GradlePlugin {
         private const val version = "2.2.0"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Asm.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://asm.ow2.io/
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Asm {
     private const val version = "9.2"
     const val lib = "org.ow2.asm:asm:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/AssertK.kt
@@ -31,8 +31,8 @@ package io.spine.internal.dependency
  *
  * [AssertK](https://github.com/willowtreeapps/assertk)
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object AssertK {
-    private const val version = "0.25"
+    private const val version = "0.26.1"
     const val libJvm = "com.willowtreeapps.assertk:assertk-jvm:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Auto.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Auto.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("unused", "ConstPropertyName")
+
 package io.spine.internal.dependency
 
 // https://github.com/google/auto

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/BouncyCastle.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://www.bouncycastle.org/java.html
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object BouncyCastle {
     const val libPkcsJdk15 = "org.bouncycastle:bcpkix-jdk15on:1.68"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckStyle.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://checkstyle.sourceforge.io/
 // See `io.spine.internal.gradle.checkstyle.CheckStyleConfig`.
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object CheckStyle {
     const val version = "10.3.4"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CheckerFramework.kt
@@ -27,8 +27,9 @@
 package io.spine.internal.dependency
 
 // https://checkerframework.org/
+@Suppress("unused", "ConstPropertyName")
 object CheckerFramework {
-    private const val version = "3.27.0"
+    private const val version = "3.36.0"
     const val annotations = "org.checkerframework:checker-qual:${version}"
     @Suppress("unused")
     val dataflow = listOf(

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCli.kt
@@ -32,6 +32,7 @@ package io.spine.internal.dependency
  *
  * [Commons CLI](https://commons.apache.org/proper/commons-cli/)
  */
+@Suppress("unused", "ConstPropertyName")
 object CommonsCli {
     private const val version = "1.5.0"
     const val lib = "commons-cli:commons-cli:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsCodec.kt
@@ -27,8 +27,8 @@
 package io.spine.internal.dependency
 
 // https://commons.apache.org/proper/commons-codec/changes-report.html
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object CommonsCodec {
-    private const val version = "1.15"
+    private const val version = "1.16.0"
     const val lib = "commons-codec:commons-codec:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/CommonsLogging.kt
@@ -30,6 +30,7 @@ package io.spine.internal.dependency
  * [Commons Logging](https://commons.apache.org/proper/commons-logging/) is a transitive
  * dependency which we don't use directly. This object is used for forcing the version.
  */
+@Suppress("unused", "ConstPropertyName")
 object CommonsLogging {
     // https://commons.apache.org/proper/commons-logging/
     private const val version = "1.2"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Dokka.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/Kotlin/dokka
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Dokka {
     private const val group = "org.jetbrains.dokka"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ErrorProne.kt
@@ -27,10 +27,10 @@
 package io.spine.internal.dependency
 
 // https://errorprone.info/
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object ErrorProne {
     // https://github.com/google/error-prone
-    private const val version = "2.18.0"
+    private const val version = "2.20.0"
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/FindBugs.kt
@@ -33,6 +33,7 @@ package io.spine.internal.dependency
  * but no alternatives are known for some of them so far.  Please see
  * [this issue](https://github.com/SpineEventEngine/base/issues/108) for more details.
  */
+@Suppress("unused", "ConstPropertyName")
 object FindBugs {
     private const val version = "3.0.2"
     const val annotations = "com.google.code.findbugs:jsr305:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Firebase.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://firebase.google.com/docs/admin/setup#java
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Firebase {
     private const val adminVersion = "8.1.0"
     const val admin = "com.google.firebase:firebase-admin:${adminVersion}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Flogger.kt
@@ -27,10 +27,11 @@
 package io.spine.internal.dependency
 
 // https://github.com/google/flogger
+@Suppress("unused", "ConstPropertyName")
 object Flogger {
     internal const val version = "0.7.4"
-    const val lib     = "com.google.flogger:flogger:${version}"
-    @Suppress("unused")
+    const val lib = "com.google.flogger:flogger:${version}"
+
     object Runtime {
         const val systemBackend = "com.google.flogger:flogger-system-backend:${version}"
         const val log4j2Backend = "com.google.flogger:flogger-log4j2-backend:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleApis.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 /**
  * Provides dependencies on [GoogleApis projects](https://github.com/googleapis/).
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object GoogleApis {
 
     // https://github.com/googleapis/google-api-java-client

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GoogleCloud.kt
@@ -26,7 +26,7 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object GoogleCloud {
 
     // https://github.com/googleapis/java-core

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/GradleDoctor.kt
@@ -31,6 +31,7 @@ package io.spine.internal.dependency
  *
  * See [plugin site](https://runningcode.github.io/gradle-doctor) for features and usage.
  */
+@Suppress("unused", "ConstPropertyName")
 object GradleDoctor {
     const val version = "0.8.1"
     const val pluginId = "com.osacky.doctor"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Grpc.kt
@@ -27,10 +27,10 @@
 package io.spine.internal.dependency
 
 // https://github.com/grpc/grpc-java
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
-    const val version        = "1.53.0"
+    const val version        = "1.57.0"
     const val api            = "io.grpc:grpc-api:${version}"
     const val auth           = "io.grpc:grpc-auth:${version}"
     const val core           = "io.grpc:grpc-core:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Gson.kt
@@ -32,6 +32,7 @@ package io.spine.internal.dependency
  *
  * [Gson](https://github.com/google/gson)
  */
+@Suppress("unused", "ConstPropertyName")
 object Gson {
     private const val version = "2.9.0"
     const val lib = "com.google.code.gson:gson:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Guava.kt
@@ -32,8 +32,10 @@ package io.spine.internal.dependency
  * When changing the version, also change the version used in the `build.gradle.kts`. We need
  * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
  * Gradle plugins, errors may occur due to version clashes.
+ *
+ * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
  */
-// https://github.com/google/guava
+@Suppress("unused", "ConstPropertyName")
 object Guava {
     private const val version = "32.1.1-jre"
     const val lib     = "com.google.guava:guava:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Hamcrest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Hamcrest.kt
@@ -27,18 +27,14 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on ProtoData modules.
+ * The dependency on the Hamcrest, which is transitive for us.
  *
- * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
+ * If you need assertions in Java, please use Google [Truth] instead.
+ * For Kotlin, please use [Kotest].
  */
 @Suppress("unused", "ConstPropertyName")
-object ProtoData {
-    const val version = "0.9.9"
-    const val group = "io.spine.protodata"
-    const val compiler = "$group:protodata-compiler:$version"
-
-    const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
-
-    const val pluginId = "io.spine.protodata"
-    const val pluginLib = "${Spine.group}:protodata:$version"
+object Hamcrest {
+    // https://github.com/hamcrest/JavaHamcrest/releases
+    private const val version = "2.2"
+    const val core = "org.hamcrest:hamcrest-core:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/HttpClient.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 /**
  * Google implementations of [HTTP client](https://github.com/googleapis/google-http-java-client).
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object HttpClient {
     // https://github.com/googleapis/google-http-java-client
     const val version  = "1.41.5"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/J2ObjC.kt
@@ -30,6 +30,7 @@ package io.spine.internal.dependency
  * [J2ObjC](https://developers.google.com/j2objc) is a transitive dependency
  * which we don't use directly. This object is used for forcing the version.
  */
+@Suppress("unused", "ConstPropertyName")
 object J2ObjC {
     // https://github.com/google/j2objc/releases
     // `1.3.` is the latest version available from Maven Central.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JUnit.kt
@@ -27,15 +27,16 @@
 package io.spine.internal.dependency
 
 // https://junit.org/junit5/
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object JUnit {
-    const val version                    = "5.9.3"
-    private const val legacyVersion      = "4.13.1"
+    const val version = "5.10.0"
+    private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
     private const val apiGuardianVersion = "1.1.2"
+
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion     = "2.0.1"
+    private const val pioneerVersion = "2.0.1"
 
     const val legacy = "junit:junit:${legacyVersion}"
 
@@ -44,22 +45,16 @@ object JUnit {
         "org.junit.jupiter:junit-jupiter-api:${version}",
         "org.junit.jupiter:junit-jupiter-params:${version}"
     )
-    const val bom     = "org.junit:junit-bom:${version}"
+    const val bom = "org.junit:junit-bom:${version}"
 
-    const val runner  = "org.junit.jupiter:junit-jupiter-engine:${version}"
-    const val params  = "org.junit.jupiter:junit-jupiter-params:${version}"
+    const val runner = "org.junit.jupiter:junit-jupiter-engine:${version}"
+    const val params = "org.junit.jupiter:junit-jupiter-params:${version}"
 
     const val pioneer = "org.junit-pioneer:junit-pioneer:${pioneerVersion}"
 
-    @Deprecated("Please use `Platform.commons`.")
-    const val platformCommons = "${Platform.group}:junit-platform-commons:${Platform.version}"
-
-    @Deprecated("Please use `Platform.launcher`.")
-    const val platformLauncher = "${Platform.group}:junit-platform-launcher:${Platform.version}"
-
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.9.3"
+        const val version = "1.10.0"
         internal const val group = "org.junit.platform"
         const val commons = "$group:junit-platform-commons:$version"
         const val launcher = "$group:junit-platform-launcher:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Jackson.kt
@@ -26,10 +26,11 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+// https://github.com/FasterXML/jackson/wiki/Jackson-Releases
+@Suppress("unused", "ConstPropertyName")
 object Jackson {
-    const val version = "2.13.4"
-    private const val databindVersion = "2.13.4.2"
+    const val version = "2.15.2"
+    private const val databindVersion = "2.15.2"
 
     private const val coreGroup = "com.fasterxml.jackson.core"
     private const val dataformatGroup = "com.fasterxml.jackson.dataformat"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaDiffUtils.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaDiffUtils.kt
@@ -27,18 +27,16 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on ProtoData modules.
+ * The dependency on the `java-diff-utils` library, which is transitive for us at the time
+ * of writing.
  *
- * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
+ * It might become our dependency as a part of
+ * the [Spine Text](https://github.com/SpineEventEngine/text) library.
  */
 @Suppress("unused", "ConstPropertyName")
-object ProtoData {
-    const val version = "0.9.9"
-    const val group = "io.spine.protodata"
-    const val compiler = "$group:protodata-compiler:$version"
+object JavaDiffUtils {
 
-    const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
-
-    const val pluginId = "io.spine.protodata"
-    const val pluginLib = "${Spine.group}:protodata:$version"
+    // https://github.com/java-diff-utils/java-diff-utils/releases
+    private const val version = "4.12"
+    const val lib = "io.github.java-diff-utils:java-diff-utils:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaJwt.kt
@@ -31,8 +31,16 @@ package io.spine.internal.dependency
  *
  * [Java JWT](https://github.com/auth0/java-jwt)
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object JavaJwt {
-    private const val version = "3.19.1"
+
+    /**
+     * The last version in the v3.x.x series.
+     *
+     * There's a v4.x.x series (e.g. https://github.com/auth0/java-jwt/releases/tag/4.4.0), but
+     * it introduces breaking changes. Consider upgrading to it when we're ready to migrate.
+     */
+    private const val version = "3.19.4"
+
     const val lib = "com.auth0:java-jwt:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaPoet.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/square/javapoet
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object JavaPoet {
     private const val version = "1.13.0"
     const val lib = "com.squareup:javapoet:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/JavaX.kt
@@ -26,7 +26,7 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object JavaX {
     // This artifact which used to be a part of J2EE moved under Eclipse EE4J project.
     // https://github.com/eclipse-ee4j/common-annotations-api

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Klaxon.kt
@@ -27,11 +27,11 @@
 package io.spine.internal.dependency
 
 /**
- * A JSON parser in Kotlin
+ * A JSON parser in Kotlin.
  *
  * [Klaxon](https://github.com/cbeust/klaxon)
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Klaxon {
     private const val version = "5.6"
     const val lib = "com.beust:klaxon:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotest.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-@file:Suppress("unused", "ConstPropertyName")
+@file:Suppress("unused")
 
 package io.spine.internal.dependency
 
@@ -33,6 +33,7 @@ package io.spine.internal.dependency
  *
  * @see <a href="https://kotest.io/">Kotest site</a>
  */
+@Suppress("unused", "ConstPropertyName")
 object Kotest {
     const val version = "5.6.2"
     const val group = "io.kotest"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -28,7 +28,7 @@ package io.spine.internal.dependency
 
 // https://github.com/JetBrains/kotlin
 // https://github.com/Kotlin
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Kotlin {
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinSemver.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinSemver.kt
@@ -27,8 +27,8 @@
 package io.spine.internal.dependency
 
 // https://github.com/z4kn4fein/kotlin-semver
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object KotlinSemver {
-    private const val version = "1.2.1"
+    private const val version = "1.4.2"
     const val lib     = "io.github.z4kn4fein:semver:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kover.kt
@@ -27,7 +27,7 @@
 package io.spine.internal.dependency
 
 // https://github.com/Kotlin/kotlinx-kover
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Kover {
     const val version = "0.7.2"
     const val id = "org.jetbrains.kotlinx.kover"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Netty.kt
@@ -26,10 +26,10 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Netty {
     // https://github.com/netty/netty/releases
-    private const val version = "4.1.72.Final"
+    private const val version = "4.1.95.Final"
     const val common = "io.netty:netty-common:${version}"
     const val buffer = "io.netty:netty-buffer:${version}"
     const val transport = "io.netty:netty-transport:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Okio.kt
@@ -30,6 +30,7 @@ package io.spine.internal.dependency
  * Okio is a transitive dependency which we don't use directly.
  * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
  */
+@Suppress("unused", "ConstPropertyName")
 object Okio {
 
     // This is the last version before next major.

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/OpenTest4J.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/OpenTest4J.kt
@@ -27,18 +27,12 @@
 package io.spine.internal.dependency
 
 /**
- * Dependencies on ProtoData modules.
- *
- * See [`SpineEventEngine/ProtoData`](https://github.com/SpineEventEngine/ProtoData/).
+ * The dependency on the OpenTest4j library, which is transitive for us.
  */
 @Suppress("unused", "ConstPropertyName")
-object ProtoData {
-    const val version = "0.9.9"
-    const val group = "io.spine.protodata"
-    const val compiler = "$group:protodata-compiler:$version"
+object OpenTest4J {
 
-    const val codegenJava = "io.spine.protodata:protodata-codegen-java:$version"
-
-    const val pluginId = "io.spine.protodata"
-    const val pluginLib = "${Spine.group}:protodata:$version"
+    // https://github.com/ota4j-team/opentest4j/releases
+    private const val version = "1.3.0"
+    const val lib = "org.opentest4j:opentest4j:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
@@ -26,10 +26,10 @@
 
 package io.spine.internal.dependency
 
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object OsDetector {
     // https://github.com/google/osdetector-gradle-plugin
-    const val version = "1.7.0"
+    const val version = "1.7.3"
     const val id = "com.google.osdetector"
     const val lib = "com.google.gradle:osdetector-gradle-plugin:${version}"
     const val classpath = lib

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/OsDetector.kt
@@ -28,6 +28,7 @@ package io.spine.internal.dependency
 
 @Suppress("unused", "ConstPropertyName")
 object OsDetector {
+
     // https://github.com/google/osdetector-gradle-plugin
     const val version = "1.7.3"
     const val id = "com.google.osdetector"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Plexus.kt
@@ -24,15 +24,26 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("MaxLineLength")
+
 package io.spine.internal.dependency
 
 /**
  * Plexus Utils is a transitive dependency which we don't use directly.
  * We `force` it in [forceVersions] (see `DependencyResolution.kt`).
  *
- * [Plexus Utils](https://codehaus-plexus.github.io/plexus-utils/)
+ * [Plexus Utils](https://github.com/codehaus-plexus/plexus-utils)
  */
+@Suppress("unused", "ConstPropertyName")
 object Plexus {
-    private const val version = "3.4.0"
+
+    /**
+     * This is the last version in the 3.x series.
+     *
+     * There's a major update to 4.x.
+     *
+     * @see <a href="https://github.com/codehaus-plexus/plexus-utils/releases/tag/plexus-utils-4.0.0">plexus-utils-4.0.0</a>
+     */
+    private const val version = "3.5.1"
     const val utils = "org.codehaus.plexus:plexus-utils:${version}"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -24,9 +24,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("MaxLineLength")
+
 package io.spine.internal.dependency
 
-// https://pmd.github.io/
+// https://github.com/pmd/pmd/releases
+@Suppress("unused", "ConstPropertyName")
 object Pmd {
+    /**
+     * This is the last version in the 6.x series.
+     *
+     * There's a major update to 7.x series.
+     *
+     * @see <a href="https://docs.pmd-code.org/pmd-doc-7.0.0-rc3/pmd_release_notes_pmd7.html>PMD 7.0.0 release notes</a>
+     */
     const val version = "6.55.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Pmd.kt
@@ -31,6 +31,7 @@ package io.spine.internal.dependency
 // https://github.com/pmd/pmd/releases
 @Suppress("unused", "ConstPropertyName")
 object Pmd {
+
     /**
      * This is the last version in the 6.x series.
      *

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Slf4J.kt
@@ -37,7 +37,7 @@ package io.spine.internal.dependency
  * Thus, we specify this version and force it via [forceVersions].
  * Please see `DependencyResolution.kt` for details.
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object Slf4J {
     private const val version = "2.0.7"
     const val lib = "org.slf4j:slf4j-api:${version}"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.184"
+        const val base = "2.0.0-SNAPSHOT.186"
 
         /**
          * The version of [Spine.reflect].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.150"
+        const val core = "2.0.0-SNAPSHOT.153"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,21 +89,21 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.163"
+        const val mcJava = "2.0.0-SNAPSHOT.166"
 
         /**
          * The version of [Spine.baseTypes].
          *
          * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.123"
+        const val baseTypes = "2.0.0-SNAPSHOT.124"
 
         /**
          * The version of [Spine.time].
          *
          * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
          */
-        const val time = "2.0.0-SNAPSHOT.131"
+        const val time = "2.0.0-SNAPSHOT.133"
 
         /**
          * The version of [Spine.change].
@@ -178,7 +178,9 @@ object Spine {
         const val pluginLib = "$toolsGroup:spine-mc-java-plugins:${version}:all"
     }
 
+    @Deprecated("Please use `javadocFilter` instead.", ReplaceWith("javadocFilter"))
     const val javadocTools = "$toolsGroup::${ArtifactVersion.javadocTools}"
+    const val javadocFilter = "$toolsGroup:spine-javadoc-filter:${ArtifactVersion.javadocTools}"
 
     const val client = CoreJava.client // Added for brevity.
     const val server = CoreJava.server // Added for brevity.
@@ -189,9 +191,10 @@ object Spine {
      * See [`SpineEventEngine/core-java`](https://github.com/SpineEventEngine/core-java/).
      */
     object CoreJava {
-        const val core = "$group:spine-core:${ArtifactVersion.core}"
-        const val client = "$group:spine-client:${ArtifactVersion.core}"
-        const val server = "$group:spine-server:${ArtifactVersion.core}"
-        const val testUtilServer = "$toolsGroup:spine-testutil-server:${ArtifactVersion.core}"
+        const val version = ArtifactVersion.core
+        const val core = "$group:spine-core:$version"
+        const val client = "$group:spine-client:$version"
+        const val server = "$group:spine-server:$version"
+        const val testUtilServer = "$toolsGroup:spine-testutil-server:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.198"
+        const val logging = "2.0.0-SNAPSHOT.202"
 
         /**
          * The version of [Spine.testlib].
@@ -122,7 +122,7 @@ object Spine {
         /**
          * The version of [Spine.toolBase].
          */
-        const val toolBase = "2.0.0-SNAPSHOT.172"
+        const val toolBase = "2.0.0-SNAPSHOT.181"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/TestKitTruth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/TestKitTruth.kt
@@ -24,19 +24,18 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("MaxLineLength")
+
 package io.spine.internal.dependency
 
 /**
  * Gradle TestKit extension for Google Truth.
  *
- * Source code:
- * https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/tree/main/testkit-truth
- *
- * Usage description:
- * https://dev.to/autonomousapps/gradle-all-the-way-down-testing-your-gradle-plugin-with-gradle-testkit-2hmc
+ * @see <a href="https://github.com/autonomousapps/dependency-analysis-android-gradle-plugin/tree/main/testkit-truth">TestKit source code</a>
+ * @see <a href="https://dev.to/autonomousapps/gradle-all-the-way-down-testing-your-gradle-plugin-with-gradle-testkit-2hmc">Usage description</a>
  */
-@Suppress("unused")
+@Suppress("unused", "ConstPropertyName")
 object TestKitTruth {
-    private const val version = "1.1"
+    private const val version = "1.20.0"
     const val lib = "com.autonomousapps:testkit-truth:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Truth.kt
@@ -27,8 +27,9 @@
 package io.spine.internal.dependency
 
 // https://github.com/google/truth
+@Suppress("unused", "ConstPropertyName")
 object Truth {
-    private const val version = "1.1.3"
+    private const val version = "1.1.5"
     val libs = listOf(
         "com.google.truth:truth:${version}",
         "com.google.truth.extensions:truth-java8-extension:${version}",

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Validation.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
  */
 @Suppress("unused", "ConstPropertyName")
 object Validation {
-    const val version = "2.0.0-SNAPSHOT.97"
+    const val version = "2.0.0-SNAPSHOT.99"
     const val group = "io.spine.validation"
     const val runtime = "$group:spine-validation-java-runtime:$version"
     const val java = "$group:spine-validation-java:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/ExcludeInternalDoclet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/javadoc/ExcludeInternalDoclet.kt
@@ -26,6 +26,7 @@
 
 package io.spine.internal.gradle.javadoc
 
+import io.spine.internal.dependency.Spine
 import io.spine.internal.gradle.javadoc.ExcludeInternalDoclet.Companion.taskName
 import io.spine.internal.gradle.sourceSets
 import org.gradle.api.Project
@@ -36,9 +37,13 @@ import org.gradle.external.javadoc.StandardJavadocDocletOptions
 /**
  * The doclet which removes Javadoc for `@Internal` things in the Java code.
  */
-class ExcludeInternalDoclet(val version: String) {
+@Suppress("ConstPropertyName")
+class ExcludeInternalDoclet(
+    @Deprecated("`Spine.ArtifactVersion.javadocTools` is used instead.")
+    val version: String = Spine.ArtifactVersion.javadocTools
+) {
 
-    private val dependency = "io.spine.tools:spine-javadoc-filter:${version}"
+    private val dependency = Spine.javadocFilter
 
     companion object {
 

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -28,7 +28,6 @@ import BuildSettings.javaVersion
 import io.spine.internal.dependency.CheckerFramework
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
-import io.spine.internal.dependency.Flogger
 import io.spine.internal.dependency.Guava
 import io.spine.internal.dependency.JUnit
 import io.spine.internal.dependency.JavaX

--- a/license-report.md
+++ b/license-report.md
@@ -11,10 +11,12 @@
      * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
@@ -41,8 +43,8 @@
 1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.23.4.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.27.0.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.36.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 23.0.0.
@@ -75,6 +77,10 @@
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 ## Compile, tests, and tooling
+1.  **Group** : aopalliance. **Name** : aopalliance. **Version** : 1.0.
+     * **Project URL:** [http://aopalliance.sourceforge.net](http://aopalliance.sourceforge.net)
+     * **License:** Public Domain
+
 1.  **Group** : com.beust. **Name** : jcommander. **Version** : 1.48.
      * **Project URL:** [http://beust.com/jcommander](http://beust.com/jcommander)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -83,32 +89,32 @@
      * **Project URL:** [https://jcommander.org](https://jcommander.org)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.13.4.**No license information found**
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.13.4.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.15.2.**No license information found**
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-annotations. **Version** : 2.15.2.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.13.4.
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-core. **Version** : 2.15.2.
      * **Project URL:** [https://github.com/FasterXML/jackson-core](https://github.com/FasterXML/jackson-core)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.13.4.2.
-     * **Project URL:** [http://github.com/FasterXML/jackson](http://github.com/FasterXML/jackson)
+1.  **Group** : com.fasterxml.jackson.core. **Name** : jackson-databind. **Version** : 2.15.2.
+     * **Project URL:** [https://github.com/FasterXML/jackson](https://github.com/FasterXML/jackson)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.13.4.
+1.  **Group** : com.fasterxml.jackson.dataformat. **Name** : jackson-dataformat-xml. **Version** : 2.15.2.
      * **Project URL:** [https://github.com/FasterXML/jackson-dataformat-xml](https://github.com/FasterXML/jackson-dataformat-xml)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.13.4.
+1.  **Group** : com.fasterxml.jackson.module. **Name** : jackson-module-kotlin. **Version** : 2.15.2.
      * **Project URL:** [https://github.com/FasterXML/jackson-module-kotlin](https://github.com/FasterXML/jackson-module-kotlin)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.3.1.
+1.  **Group** : com.fasterxml.woodstox. **Name** : woodstox-core. **Version** : 6.5.1.
      * **Project URL:** [https://github.com/FasterXML/woodstox](https://github.com/FasterXML/woodstox)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -153,19 +159,24 @@
      * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_check_api. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_check_api](https://errorprone.info/error_prone_check_api)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_core. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_core](https://errorprone.info/error_prone_core)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.18.0.
+1.  **Group** : com.google.errorprone. **Name** : error_prone_type_annotations. **Version** : 2.20.0.
+     * **Project URL:** [https://errorprone.info/error_prone_type_annotations](https://errorprone.info/error_prone_type_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.errorprone. **Name** : javac. **Version** : 9+181-r4173-1.
@@ -192,6 +203,10 @@
 1.  **Group** : com.google.guava. **Name** : guava-testlib. **Version** : 32.1.1-jre.
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : com.google.inject. **Name** : guice. **Version** : 5.1.0.
+     * **Project URL:** [https://github.com/google/guice](https://github.com/google/guice)
+     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : com.google.j2objc. **Name** : j2objc-annotations. **Version** : 1.3.
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -212,16 +227,16 @@
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.3.
+1.  **Group** : com.google.truth. **Name** : truth. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.3.
+1.  **Group** : com.google.truth.extensions. **Name** : truth-java8-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.3.
+1.  **Group** : com.google.truth.extensions. **Name** : truth-liteproto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.3.
+1.  **Group** : com.google.truth.extensions. **Name** : truth-proto-extension. **Version** : 1.1.5.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.3.4.
@@ -261,9 +276,9 @@
      * **Project URL:** [https://detekt.github.io/detekt](https://detekt.github.io/detekt)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.0.
-     * **Project URL:** [https://github.com/java-diff-utils/java-diff-utils](https://github.com/java-diff-utils/java-diff-utils)
-     * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+1.  **Group** : io.github.eisop. **Name** : dataflow-errorprone. **Version** : 3.34.0-eisop1.
+     * **Project URL:** [https://eisop.github.io/](https://eisop.github.io/)
+     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
 
 1.  **Group** : io.github.java-diff-utils. **Name** : java-diff-utils. **Version** : 4.12.
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -491,28 +506,26 @@
      * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
-1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.27.0.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
+1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.36.0.
+     * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
      * **License:** [The MIT License](http://opensource.org/licenses/MIT)
-
-1.  **Group** : org.checkerframework. **Name** : dataflow-errorprone. **Version** : 3.27.0.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
 
 1.  **Group** : org.codehaus.woodstox. **Name** : stax2-api. **Version** : 4.2.1.
      * **Project URL:** [http://github.com/FasterXML/stax2-api](http://github.com/FasterXML/stax2-api)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
      * **License:** [The BSD License](http://www.opensource.org/licenses/bsd-license.php)
 
-1.  **Group** : org.eclipse.jgit. **Name** : org.eclipse.jgit. **Version** : 4.4.1.201607150455-r.
-     * **License:** Eclipse Distribution License (New BSD License)
-
 1.  **Group** : org.freemarker. **Name** : freemarker. **Version** : 2.3.31.
      * **Project URL:** [https://freemarker.apache.org/](https://freemarker.apache.org/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 1.3.
-     * **License:** [New BSD License](http://www.opensource.org/licenses/bsd-license.php)
+1.  **Group** : org.hamcrest. **Name** : hamcrest. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
+
+1.  **Group** : org.hamcrest. **Name** : hamcrest-core. **Version** : 2.2.
+     * **Project URL:** [http://hamcrest.org/JavaHamcrest/](http://hamcrest.org/JavaHamcrest/)
+     * **License:** [BSD License 3](http://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : org.jacoco. **Name** : org.jacoco.agent. **Version** : 0.8.10.
      * **License:** [Eclipse Public License 2.0](https://www.eclipse.org/legal/epl-2.0/)
@@ -696,42 +709,42 @@
      * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
      * **License:** [The MIT License](https://jsoup.org/license)
 
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.9.3.**No license information found**
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.**No license information found**
 1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 2.0.1.
      * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.9.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.9.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.9.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.9.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.9.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.9.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-suite-api. **Version** : 1.9.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-suite-api. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.2.0.
+1.  **Group** : org.opentest4j. **Name** : opentest4j. **Version** : 1.3.0.
      * **Project URL:** [https://github.com/ota4j-team/opentest4j](https://github.com/ota4j-team/opentest4j)
-     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+     * **License:** [The Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : org.ow2.asm. **Name** : asm. **Version** : 9.2.
      * **Project URL:** [http://asm.ow2.io/](http://asm.ow2.io/)
@@ -768,4 +781,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Aug 03 18:06:53 EEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 11 16:30:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -781,4 +781,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 11 16:30:43 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 11 16:39:21 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.186`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.187`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -781,4 +781,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Aug 11 16:39:21 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Aug 11 16:45:50 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -122,19 +122,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
-    <version>5.9.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.9.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-params</artifactId>
-    <version>5.9.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -152,18 +152,18 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_annotations</artifactId>
-    <version>2.18.0</version>
+    <version>2.20.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_core</artifactId>
-    <version>2.18.0</version>
+    <version>2.20.0</version>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_type_annotations</artifactId>
-    <version>2.18.0</version>
+    <version>2.20.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
@@ -205,7 +205,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.checkerframework</groupId>
     <artifactId>checker-qual</artifactId>
-    <version>3.27.0</version>
+    <version>3.36.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.186</version>
+<version>2.0.0-SNAPSHOT.187</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.198</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,7 +68,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-backend</artifactId>
-    <version>2.0.0-SNAPSHOT.198</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>runtime</scope>
   </dependency>
   <dependency>
@@ -98,7 +98,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-smoke-test</artifactId>
-    <version>2.0.0-SNAPSHOT.198</version>
+    <version>2.0.0-SNAPSHOT.202</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/src/main/java/io/spine/code/proto/SourceFile.java
+++ b/src/main/java/io/spine/code/proto/SourceFile.java
@@ -32,7 +32,7 @@ import com.google.protobuf.Descriptors.FileDescriptor;
 import io.spine.base.RejectionType;
 import io.spine.code.fs.AbstractSourceFile;
 import io.spine.code.java.SimpleClassName;
-import io.spine.logging.Logging;
+import io.spine.logging.WithLogging;
 import io.spine.type.MessageType;
 
 import java.nio.file.Path;
@@ -43,11 +43,12 @@ import java.util.function.Predicate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 
 /**
  * A Protobuf file which also gives access to its {@link FileDescriptor descriptor}.
  */
-public class SourceFile extends AbstractSourceFile implements Logging {
+public class SourceFile extends AbstractSourceFile implements WithLogging {
 
     private final FileDescriptor descriptor;
 
@@ -129,7 +130,8 @@ public class SourceFile extends AbstractSourceFile implements Logging {
         ImmutableList.Builder<MessageType> result = ImmutableList.builder();
         for (var messageType : descriptor.getMessageTypes()) {
             var declaration = new MessageType(messageType);
-            _debug().log("Testing `%s` to match `%s`.", declaration, predicate);
+            logger().atDebug().log(() -> format(
+                "Testing `%s` to match `%s`.", declaration, predicate));
             if (predicate.test(messageType.toProto())) {
                 result.add(declaration);
             }

--- a/src/main/java/io/spine/environment/Environment.java
+++ b/src/main/java/io/spine/environment/Environment.java
@@ -30,7 +30,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.annotation.SPI;
-import io.spine.logging.Logging;
 import io.spine.logging.WithLogging;
 import org.checkerframework.checker.nullness.qual.Nullable;
 

--- a/src/main/java/io/spine/environment/Environment.java
+++ b/src/main/java/io/spine/environment/Environment.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import io.spine.annotation.SPI;
 import io.spine.logging.Logging;
+import io.spine.logging.WithLogging;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.function.Consumer;
@@ -40,6 +41,7 @@ import static io.spine.reflect.Invokables.callParameterlessCtor;
 import static io.spine.string.Diags.backtick;
 import static io.spine.util.Exceptions.newIllegalArgumentException;
 import static io.spine.util.Exceptions.newIllegalStateException;
+import static java.lang.String.format;
 
 /**
  * Provides information about the environment (current platform used, etc.).
@@ -122,7 +124,7 @@ import static io.spine.util.Exceptions.newIllegalStateException;
  * @see DefaultMode
  */
 @SPI
-public final class Environment implements Logging {
+public final class Environment implements WithLogging {
 
     private static final ImmutableList<StandardEnvironmentType<?>> STANDARD_TYPES =
             ImmutableList.of(Tests.type(), DefaultMode.type());
@@ -366,21 +368,21 @@ public final class Environment implements Logging {
     private void setCurrentType(@Nullable Class<? extends EnvironmentType<?>> newCurrent) {
         @Nullable Class<? extends EnvironmentType<?>> previous = this.currentType;
         this.currentType = newCurrent;
-        @SuppressWarnings("FloggerSplitLogStatement")
-                // See: https://github.com/SpineEventEngine/base/issues/612
-        var debug = _debug();
         if (previous == null) {
             if (newCurrent != null) {
-                debug.log("`Environment` set to `%s`.", newCurrent.getName());
+                logger().atDebug().log(() -> format(
+                        "`Environment` set to `%s`.", newCurrent.getName()));
             }
         } else {
             if (previous.equals(newCurrent)) {
-                debug.log("`Environment` stays `%s`.", newCurrent.getName());
+                logger().atDebug().log(() -> format(
+                        "`Environment` stays `%s`.", newCurrent.getName()));
             } else {
                 var newType = newCurrent != null
                               ? backtick(newCurrent.getName())
                               : "undefined";
-                debug.log("`Environment` turned from `%s` to %s.", previous.getName(), newType);
+                logger().atDebug().log(() -> format(
+                        "`Environment` turned from `%s` to %s.", previous.getName(), newType));
             }
         }
     }

--- a/src/main/java/io/spine/type/MessageType.java
+++ b/src/main/java/io/spine/type/MessageType.java
@@ -40,7 +40,7 @@ import io.spine.code.proto.FieldName;
 import io.spine.code.proto.FileDescriptors;
 import io.spine.code.proto.LocationPath;
 import io.spine.code.proto.TypeSet;
-import io.spine.logging.Logging;
+import io.spine.logging.WithLogging;
 import io.spine.option.OptionsProto;
 
 import java.util.Deque;
@@ -65,7 +65,7 @@ import static java.lang.String.format;
  */
 @Immutable
 @SuppressWarnings("ClassWithTooManyMethods")
-public class MessageType extends Type<Descriptor, DescriptorProto> implements Logging {
+public class MessageType extends Type<Descriptor, DescriptorProto> implements WithLogging {
 
     private final ImmutableList<FieldDeclaration> fields;
 
@@ -381,7 +381,7 @@ public class MessageType extends Type<Descriptor, DescriptorProto> implements Lo
     }
 
     private void warnNoSourceCodeInfoIn(FileDescriptorProto file) {
-        var msg = format(
+        logger().atWarning().log(() -> format(
                 "Unable to obtain proto source code info for the message type `%s`" +
                         " declared in the file `%s`.%n" +
                         "Please configure the Gradle Protobuf plugin as follows:" +
@@ -392,8 +392,8 @@ public class MessageType extends Type<Descriptor, DescriptorProto> implements Lo
                         "    }%n" +
                         '}',
                 name(),
-                file.getName());
-        _warn().log(msg);
+                file.getName())
+        );
     }
 
     /**

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.186")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.187")


### PR DESCRIPTION
This PR updates dependencies, with primary focus on the Logging library, which recently introduced breaking API changes.

Also deprecations from the Logging library were addressed.
