### PR TITLE
Detect logging class

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -59,7 +59,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/logging">spine-logging</a>
          */
-        const val logging = "2.0.0-SNAPSHOT.206"
+        const val logging = "2.0.0-SNAPSHOT.209"
 
         /**
          * The version of [Spine.testlib].

--- a/license-report.md
+++ b/license-report.md
@@ -787,4 +787,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 27 20:44:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 27 20:50:01 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -787,4 +787,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Aug 27 01:31:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 27 20:44:42 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/license-report.md
+++ b/license-report.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.188`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.189`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -787,4 +787,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Aug 22 19:18:28 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Aug 27 01:31:03 WEST 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.188</version>
+<version>2.0.0-SNAPSHOT.189</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <version>2.0.0-SNAPSHOT.209</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -68,7 +68,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-backend</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <version>2.0.0-SNAPSHOT.209</version>
     <scope>runtime</scope>
   </dependency>
   <dependency>
@@ -98,7 +98,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-smoke-test</artifactId>
-    <version>2.0.0-SNAPSHOT.206</version>
+    <version>2.0.0-SNAPSHOT.209</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/src/main/java/io/spine/code/proto/FileDescriptors.java
+++ b/src/main/java/io/spine/code/proto/FileDescriptors.java
@@ -48,7 +48,6 @@ import static io.spine.util.Predicates2.distinctBy;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
-import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * A utility class which allows to obtain Protobuf file descriptors.
@@ -56,8 +55,7 @@ import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 public final class FileDescriptors {
 
     // https://github.com/SpineEventEngine/logging/issues/33
-    private static final Logger<?> logger =
-            LoggingFactory.getLogger(getKotlinClass(FileDescriptors.class));
+    private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     /**
      * Extension of the descriptor set files.

--- a/src/main/java/io/spine/code/proto/FileDescriptors.java
+++ b/src/main/java/io/spine/code/proto/FileDescriptors.java
@@ -54,7 +54,6 @@ import static java.util.stream.Collectors.toSet;
  */
 public final class FileDescriptors {
 
-    // https://github.com/SpineEventEngine/logging/issues/33
     private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     /**

--- a/src/main/java/io/spine/code/proto/FileSet.java
+++ b/src/main/java/io/spine/code/proto/FileSet.java
@@ -65,7 +65,6 @@ import static java.util.stream.Collectors.toSet;
  */
 public final class FileSet {
 
-    // https://github.com/SpineEventEngine/logging/issues/33
     private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     private static final FileDescriptor[] EMPTY = {};

--- a/src/main/java/io/spine/code/proto/FileSet.java
+++ b/src/main/java/io/spine/code/proto/FileSet.java
@@ -59,7 +59,6 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
-import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * A set of proto files represented by their {@linkplain FileDescriptor descriptors}.
@@ -67,7 +66,7 @@ import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 public final class FileSet {
 
     // https://github.com/SpineEventEngine/logging/issues/33
-    private static final Logger<?> logger = LoggingFactory.getLogger(getKotlinClass(FileSet.class));
+    private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     private static final FileDescriptor[] EMPTY = {};
 

--- a/src/main/java/io/spine/code/proto/Linker.java
+++ b/src/main/java/io/spine/code/proto/Linker.java
@@ -46,7 +46,6 @@ import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
-import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * Builds a set of {@link FileDescriptor}s from a list of {@link FileDescriptorProto}.
@@ -54,7 +53,7 @@ import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 final class Linker {
 
     // https://github.com/SpineEventEngine/logging/issues/33
-    private static final Logger<?> logger = LoggingFactory.getLogger(getKotlinClass(Linker.class));
+    private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     private static final FileDescriptor[] NO_DEPENDENCIES = {};
 

--- a/src/main/java/io/spine/code/proto/Linker.java
+++ b/src/main/java/io/spine/code/proto/Linker.java
@@ -52,7 +52,6 @@ import static java.util.stream.Collectors.toList;
  */
 final class Linker {
 
-    // https://github.com/SpineEventEngine/logging/issues/33
     private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     private static final FileDescriptor[] NO_DEPENDENCIES = {};

--- a/src/main/java/io/spine/io/Delete.java
+++ b/src/main/java/io/spine/io/Delete.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.lang.String.format;
-import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * Utilities for delete operations on a file system.
@@ -43,7 +42,7 @@ import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 public final class Delete {
 
     // https://github.com/SpineEventEngine/logging/issues/33
-    private static final Logger<?> logger = LoggingFactory.getLogger(getKotlinClass(Delete.class));
+    private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     /** Prevents instantiation of this utility class. */
     private Delete() {

--- a/src/main/java/io/spine/io/Delete.java
+++ b/src/main/java/io/spine/io/Delete.java
@@ -41,7 +41,6 @@ import static java.lang.String.format;
  */
 public final class Delete {
 
-    // https://github.com/SpineEventEngine/logging/issues/33
     private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
     /** Prevents instantiation of this utility class. */

--- a/src/main/java/io/spine/type/KnownTypes.java
+++ b/src/main/java/io/spine/type/KnownTypes.java
@@ -57,7 +57,6 @@ import static java.lang.String.format;
 import static java.lang.System.lineSeparator;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toSet;
-import static kotlin.jvm.JvmClassMappingKt.getKotlinClass;
 
 /**
  * All Protobuf types known to the application.
@@ -312,8 +311,7 @@ public class KnownTypes implements Serializable {
     public static final class Holder {
 
         // https://github.com/SpineEventEngine/logging/issues/33
-        private static final Logger<?> logger =
-                LoggingFactory.getLogger(getKotlinClass(Holder.class));
+        private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
         /** The lock to synchronize the write access to the {@code KnownTypes} instance. */
         private static final Lock lock = new ReentrantLock(false);

--- a/src/main/java/io/spine/type/KnownTypes.java
+++ b/src/main/java/io/spine/type/KnownTypes.java
@@ -310,7 +310,6 @@ public class KnownTypes implements Serializable {
     @Internal
     public static final class Holder {
 
-        // https://github.com/SpineEventEngine/logging/issues/33
         private static final Logger<?> logger = LoggingFactory.forEnclosingClass();
 
         /** The lock to synchronize the write access to the {@code KnownTypes} instance. */

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.188")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.189")


### PR DESCRIPTION
This PR updates the version of Spine Logging, migrating statically initialized loggers to use `LoggingFactory.forEnclosingClass()`.
