### PR TITLE
Improve generation of descriptor set files 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,14 @@ version = rootProject.extra["versionToPublish"]!!
 repositories.standardToSpineSdk()
 configurations.forceVersions()
 
+configurations.all {
+    resolutionStrategy {
+        // Forcing `reflect` explicitly here,
+        // as this is a direct dependency of this module.
+        force(Spine.reflect)
+    }
+}
+
 dependencies {
     annotationProcessor(AutoService.processor)
     compileOnly(AutoService.annotations)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -169,49 +169,54 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
 }
 
 dependencies {
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    api("com.github.jk1:gradle-license-report:$licenseReportVersion")
+    dependOnAuthCommon()
 
-    @Suppress(
-        "VulnerableLibrariesLocal", "RedundantSuppression" /*
-        `artifactregistry-auth-common` has transitive dependency on Gson and Apache `commons-codec`.
+    listOf(
+        "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion",
+        "com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion",
+        "com.github.jk1:gradle-license-report:$licenseReportVersion",
+        "com.google.guava:guava:$guavaVersion",
+        "com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion",
+        "gradle.plugin.com.github.johnrengelman:shadow:${shadowVersion}",
+        "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion",
+        "io.kotest:kotest-gradle-plugin:$kotestJvmPluginVersion",
+        // https://github.com/srikanth-lingala/zip4j
+        "net.lingala.zip4j:zip4j:2.10.0",
+        "net.ltgt.gradle:gradle-errorprone-plugin:${errorPronePluginVersion}",
+        "org.ajoberstar.grgit:grgit-core:${grGitVersion}",
+        "org.jetbrains.dokka:dokka-base:${dokkaVersion}",
+        "org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}",
+        "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion",
+        "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
+        "org.jetbrains.kotlinx:kover-gradle-plugin:$koverVersion"
+    ).forEach {
+        implementation(it)
+    }
+}
 
-        Gson from version `2.8.6` until `2.8.9` is vulnerable to Deserialization of Untrusted Data
-         (https://devhub.checkmarx.com/cve-details/CVE-2022-25647/).
-
-        Apache `commons-codec` before 1.13 is vulnerable to information exposure
-        (https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/).
-
-        We use Gson `2.10.1`and we force it in `forceProductionDependencies()`.
-        We use `commons-code` with version `1.16.0`, forcing it in `forceProductionDependencies()`.
-
-        So, we should be safe with the current version `artifactregistry-auth-common` until
-        we migrate to a later version. */
-    )
+/**
+ * Includes the `implementation` dependency on `artifactregistry-auth-common`,
+ * with the version defined in [googleAuthToolVersion].
+ *
+ * `artifactregistry-auth-common` has transitive dependency on Gson and Apache `commons-codec`.
+ * Gson from version `2.8.6` until `2.8.9` is vulnerable to Deserialization of Untrusted Data
+ * (https://devhub.checkmarx.com/cve-details/CVE-2022-25647/).
+ *
+ *  Apache `commons-codec` before 1.13 is vulnerable to information exposure
+ * (https://devhub.checkmarx.com/cve-details/Cxeb68d52e-5509/).
+ *
+ * We use Gson `2.10.1` and we force it in `forceProductionDependencies()`.
+ * We use `commons-code` with version `1.16.0`, forcing it in `forceProductionDependencies()`.
+ *
+ * So, we should be safe with the current version `artifactregistry-auth-common` until
+ * we migrate to a later version.
+ */
+fun DependencyHandlerScope.dependOnAuthCommon() {
+    @Suppress("VulnerableLibrariesLocal", "RedundantSuppression")
     implementation(
         "com.google.cloud.artifactregistry:artifactregistry-auth-common:$googleAuthToolVersion"
     ) {
         exclude(group = "com.google.guava")
     }
-
-    implementation("com.google.guava:guava:$guavaVersion")
-    api("com.github.jk1:gradle-license-report:$licenseReportVersion")
-    implementation("org.ajoberstar.grgit:grgit-core:${grGitVersion}")
-    implementation("net.ltgt.gradle:gradle-errorprone-plugin:${errorPronePluginVersion}")
-
-    // Add explicit dependency to avoid warning on different Kotlin runtime versions.
-    implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion")
-    implementation("com.google.protobuf:protobuf-gradle-plugin:$protobufPluginVersion")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:${dokkaVersion}")
-    implementation("org.jetbrains.dokka:dokka-base:${dokkaVersion}")
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:${shadowVersion}")
-
-    // https://github.com/srikanth-lingala/zip4j
-    implementation("net.lingala.zip4j:zip4j:2.10.0")
-
-    implementation("io.kotest:kotest-gradle-plugin:$kotestJvmPluginVersion")
-    implementation("org.jetbrains.kotlinx:kover-gradle-plugin:$koverVersion")
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/IntelliJ.kt
@@ -24,37 +24,37 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+@file:Suppress("ConstPropertyName")
+
 package io.spine.internal.dependency
 
-// https://github.com/protocolbuffers/protobuf
-@Suppress(
-    "MemberVisibilityCanBePrivate" /* used directly from the outside */,
-    "ConstPropertyName" /* https://bit.ly/kotlin-prop-names */
-)
-object Protobuf {
-    private const val group = "com.google.protobuf"
-    const val version       = "3.25.0"
-    /**
-     * The Java library containing proto definitions of Google Protobuf.
-     */
-    const val protoSrcLib = "${group}:protobuf-java:${version}"
-    val libs = listOf(
-        protoSrcLib,
-        "${group}:protobuf-java-util:${version}",
-        "${group}:protobuf-kotlin:${version}"
-    )
-    const val compiler = "${group}:protoc:${version}"
+/**
+ * The components of the IntelliJ Platform.
+ *
+ * Make sure to add the `intellijReleases` and `jetBrainsCacheRedirector`
+ * repositories to your project. See `kotlin/Repositories.kt` for details.
+ */
+@Suppress("unused")
+object IntelliJ {
 
-    // https://github.com/google/protobuf-gradle-plugin/releases
-    object GradlePlugin {
-        /**
-         * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
-         * Thus, when applying the plugin to projects build files, only the [id] should be used.
-         *
-         * When changing the version, also change the version used in the `build.gradle.kts`.
-         */
-        const val version = "0.9.4"
-        const val id = "com.google.protobuf"
-        const val lib = "${group}:protobuf-gradle-plugin:${version}"
+    /**
+     * The version of the IntelliJ platform.
+     *
+     * This is the version used by Kotlin compiler `1.9.21`.
+     * Advance this version with caution because it may break the setup of
+     * IntelliJ platform standalone execution.
+     */
+    const val version = "213.7172.53"
+
+    object Platform {
+        private const val group = "com.jetbrains.intellij.platform"
+        const val core = "$group:core:$version"
+        const val util = "$group:util:$version"
+    }
+
+    object JavaPsi {
+        private const val group = "com.jetbrains.intellij.java"
+        const val api = "$group:java-psi:$version"
+        const val impl = "$group:java-psi-impl:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Kotlin.kt
@@ -34,8 +34,8 @@ object Kotlin {
     /**
      * When changing the version, also change the version used in the `buildSrc/build.gradle.kts`.
      */
-    @Suppress("MemberVisibilityCanBePrivate") // used directly from outside
-    const val version = "1.9.20"
+    @Suppress("MemberVisibilityCanBePrivate") // used directly from the outside.
+    const val version = "1.9.22"
 
     /**
      * The version of the JetBrains annotations library, which is a transitive

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/KotlinX.kt
@@ -26,35 +26,16 @@
 
 package io.spine.internal.dependency
 
-// https://github.com/protocolbuffers/protobuf
-@Suppress(
-    "MemberVisibilityCanBePrivate" /* used directly from the outside */,
-    "ConstPropertyName" /* https://bit.ly/kotlin-prop-names */
-)
-object Protobuf {
-    private const val group = "com.google.protobuf"
-    const val version       = "3.25.0"
-    /**
-     * The Java library containing proto definitions of Google Protobuf.
-     */
-    const val protoSrcLib = "${group}:protobuf-java:${version}"
-    val libs = listOf(
-        protoSrcLib,
-        "${group}:protobuf-java-util:${version}",
-        "${group}:protobuf-kotlin:${version}"
-    )
-    const val compiler = "${group}:protoc:${version}"
+@Suppress("unused", "ConstPropertyName")
+object KotlinX {
 
-    // https://github.com/google/protobuf-gradle-plugin/releases
-    object GradlePlugin {
-        /**
-         * The version of this plugin is already specified in `buildSrc/build.gradle.kts` file.
-         * Thus, when applying the plugin to projects build files, only the [id] should be used.
-         *
-         * When changing the version, also change the version used in the `build.gradle.kts`.
-         */
-        const val version = "0.9.4"
-        const val id = "com.google.protobuf"
-        const val lib = "${group}:protobuf-gradle-plugin:${version}"
+    const val group = "org.jetbrains.kotlinx"
+
+    object Coroutines {
+
+        // https://github.com/Kotlin/kotlinx.coroutines
+        const val version = "1.7.3"
+        const val core = "$group:kotlinx-coroutines-core:$version"
+        const val jdk8 = "$group:kotlinx-coroutines-jdk8:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -29,7 +29,7 @@ package io.spine.internal.dependency
 /**
  * Dependencies on ProtoData modules.
  *
- * In order to use locally published ProtoData version instead of the version from a public plugin
+ * To use a locally published ProtoData version instead of the version from a public plugin
  * registry, set the `PROTODATA_VERSION` and/or the `PROTODATA_DF_VERSION` environment variables
  * and stop the Gradle daemons so that Gradle observes the env change:
  * ```
@@ -40,7 +40,7 @@ package io.spine.internal.dependency
  * ./gradle build   # Conduct the intended checks.
  * ```
  *
- * Then, in order to reset the console to run the usual versions again, remove the values of
+ * Then, to reset the console to run the usual versions again, remove the values of
  * the environment variables and stop the daemon:
  * ```
  * export PROTODATA_VERSION=""
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.14.2"
+    private const val fallbackVersion = "0.16.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,19 +74,39 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.14.2"
+    private const val fallbackDfVersion = "0.16.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
      */
     val pluginLib: String
 
+    fun pluginLib(version: String): String =
+        "$group:gradle-plugin:$version"
+
+    fun api(version: String): String =
+        "$group:protodata-api:$version"
+
     val api
-        get() = "$group:protodata-api:$version"
+        get() = api(version)
+
     val compiler
         get() = "$group:protodata-compiler:$version"
+
+    val gradleApi
+        get() = "$group:protodata-gradle-api:$version"
+
+    val cliApi
+        get() = "$group:protodata-cli-api:$version"
+
+    fun codegenJava(version: String): String =
+        "$group:protodata-codegen-java:$version"
+
     val codegenJava
-        get() = "$group:protodata-codegen-java:$version"
+        get() = codegenJava(version)
+
+    val fatCli
+        get() = "$group:protodata-fat-cli:$version"
 
     /**
      * An env variable storing a custom [version].
@@ -113,7 +133,7 @@ object ProtoData {
             version = experimentVersion ?: fallbackVersion
             dogfoodingVersion = experimentDfVersion ?: fallbackDfVersion
 
-            pluginLib = "${group}:gradle-plugin:$version"
+            pluginLib = pluginLib(version)
             println("""
 
                 ❗ Running an experiment with ProtoData. ❗

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
 )
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.25.0"
+    const val version       = "3.25.1"
     /**
      * The Java library containing proto definitions of Google Protobuf.
      */

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -45,14 +45,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.192"
+        const val base = "2.0.0-SNAPSHOT.194"
 
         /**
          * The version of [Spine.reflect].
          *
          * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
          */
-        const val reflect = "2.0.0-SNAPSHOT.182"
+        const val reflect = "2.0.0-SNAPSHOT.183"
 
         /**
          * The version of [Spine.logging].
@@ -75,7 +75,7 @@ object Spine {
          * @see [Spine.CoreJava.server]
          * @see <a href="https://github.com/SpineEventEngine/core-java">core-java</a>
          */
-        const val core = "2.0.0-SNAPSHOT.173"
+        const val core = "2.0.0-SNAPSHOT.175"
 
         /**
          * The version of [Spine.modelCompiler].
@@ -89,14 +89,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/mc-java">spine-mc-java</a>
          */
-        const val mcJava = "2.0.0-SNAPSHOT.172"
+        const val mcJava = "2.0.0-SNAPSHOT.175"
 
         /**
          * The version of [Spine.baseTypes].
          *
          * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
          */
-        const val baseTypes = "2.0.0-SNAPSHOT.125"
+        const val baseTypes = "2.0.0-SNAPSHOT.126"
 
         /**
          * The version of [Spine.time].
@@ -117,14 +117,14 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
          */
-        const val text = "2.0.0-SNAPSHOT.5"
+        const val text = "2.0.0-SNAPSHOT.6"
 
         /**
          * The version of [Spine.toolBase].
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.186"
+        const val toolBase = "2.0.0-SNAPSHOT.191"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/Repositories.kt
@@ -38,6 +38,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository
 import org.gradle.kotlin.dsl.ScriptHandlerScope
+import org.gradle.kotlin.dsl.maven
 
 /**
  * Applies [standard][doApplyStandard] repositories to this [ScriptHandlerScope]
@@ -214,6 +215,12 @@ fun RepositoryHandler.spineArtifacts(): MavenArtifactRepository = maven {
     }
 }
 
+val RepositoryHandler.intellijReleases: MavenArtifactRepository
+    get() = maven("https://www.jetbrains.com/intellij-repository/releases")
+
+val RepositoryHandler.jetBrainsCacheRedirector: MavenArtifactRepository
+    get() = maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+
 /**
  * Applies repositories commonly used by Spine Event Engine projects.
  */
@@ -235,6 +242,9 @@ fun RepositoryHandler.standardToSpineSdk() {
                 includeSpineOnly()
             }
         }
+
+    intellijReleases
+    jetBrainsCacheRedirector
 
     maven {
         url = URI(Repos.sonatypeSnapshots)

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.194`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.195`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -14,14 +14,6 @@
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotations. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotations](https://errorprone.info/error_prone_annotations)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
-
-1.  **Group** : com.google.flogger. **Name** : flogger-system-backend. **Version** : 0.7.4.
-     * **Project URL:** [https://github.com/google/flogger](https://github.com/google/flogger)
-     * **License:** [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.guava. **Name** : failureaccess. **Version** : 1.0.1.
      * **Project URL:** [https://github.com/google/guava/](https://github.com/google/guava/)
@@ -38,21 +30,16 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
-
-1.  **Group** : org.checkerframework. **Name** : checker-compat-qual. **Version** : 2.5.3.
-     * **Project URL:** [https://checkerframework.org](https://checkerframework.org)
-     * **License:** [GNU General Public License, version 2 (GPL2), with the classpath exception](http://www.gnu.org/software/classpath/license.html)
-     * **License:** [The MIT License](http://opensource.org/licenses/MIT)
 
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
      * **Project URL:** [https://checkerframework.org/](https://checkerframework.org/)
@@ -62,20 +49,20 @@
      * **Project URL:** [https://github.com/JetBrains/java-annotations](https://github.com/JetBrains/java-annotations)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.**No license information found**
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -221,18 +208,18 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -620,7 +607,7 @@
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-reflect. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -648,16 +635,16 @@
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.20.**No license information found**
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-common. **Version** : 1.9.22.**No license information found**
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk7. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.20.
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-stdlib-jdk8. **Version** : 1.9.22.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
@@ -784,4 +771,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 12 23:35:01 WET 2023** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 02 17:24:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -30,15 +30,15 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
@@ -208,18 +208,18 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.0.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.1.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -771,4 +771,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 02 17:24:22 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jan 02 17:30:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -32,19 +32,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.25.0</version>
+    <version>3.25.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.25.0</version>
+    <version>3.25.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-kotlin</artifactId>
-    <version>3.25.0</version>
+    <version>3.25.1</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -174,7 +174,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.25.0</version>
+    <version>3.25.1</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.194</version>
+<version>2.0.0-SNAPSHOT.195</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,19 +32,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-kotlin</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.0</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -56,13 +56,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-reflect</artifactId>
-    <version>2.0.0-SNAPSHOT.182</version>
+    <version>2.0.0-SNAPSHOT.183</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>org.jetbrains.kotlin</groupId>
     <artifactId>kotlin-reflect</artifactId>
-    <version>1.9.20</version>
+    <version>1.9.22</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -174,7 +174,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.0</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>

--- a/src/main/resources/desc.ref
+++ b/src/main/resources/desc.ref
@@ -1,1 +1,0 @@
-known_types_main.desc

--- a/src/test/resources/desc.ref
+++ b/src/test/resources/desc.ref
@@ -1,1 +1,0 @@
-known_types_test.desc

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.194")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.195")


### PR DESCRIPTION
This changeset addresses the inconsistencies in descriptor set generation.

Now, this library is going to have a descriptor file named after `base`'s Maven coordinates. Also, the manually placed `desc.ref` files were removed from the sources, as they are now generated automatically. See [config#504](https://github.com/SpineEventEngine/config/pull/504) for more details.

Lastly, the latest dependencies from `config` were picked up.