### PR TITLE
Promote `Closeable` inteface from `io.spine.server`

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Protobuf.kt
@@ -33,7 +33,7 @@ package io.spine.internal.dependency
 )
 object Protobuf {
     private const val group = "com.google.protobuf"
-    const val version       = "3.25.1"
+    const val version       = "3.25.2"
     /**
      * The Java library containing proto definitions of Google Protobuf.
      */

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.196`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.197`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -771,4 +771,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jan 08 14:50:35 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 03 21:40:29 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -30,15 +30,15 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.2.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
 1.  **Group** : org.checkerframework. **Name** : checker-qual. **Version** : 3.40.0.
@@ -208,18 +208,18 @@
      * **Project URL:** [https://github.com/google/j2objc/](https://github.com/google/j2objc/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java. **Version** : 3.25.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-java-util. **Version** : 3.25.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protobuf-kotlin. **Version** : 3.25.2.
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
 
-1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.1.
+1.  **Group** : com.google.protobuf. **Name** : protoc. **Version** : 3.25.2.
      * **Project URL:** [https://developers.google.com/protocol-buffers/](https://developers.google.com/protocol-buffers/)
      * **License:** [BSD-3-Clause](https://opensource.org/licenses/BSD-3-Clause)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -771,4 +771,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Feb 03 21:40:29 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Feb 03 21:50:00 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -32,19 +32,19 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-java-util</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protobuf-kotlin</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.2</version>
     <scope>compile</scope>
   </dependency>
   <dependency>
@@ -174,7 +174,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.protobuf</groupId>
     <artifactId>protoc</artifactId>
-    <version>3.25.1</version>
+    <version>3.25.2</version>
   </dependency>
   <dependency>
     <groupId>com.puppycrawl.tools</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.196</version>
+<version>2.0.0-SNAPSHOT.197</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/kotlin/io/spine/io/Closeable.kt
+++ b/src/main/kotlin/io/spine/io/Closeable.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package io.spine.io
+
+/**
+ * Base interface for objects that may hold resources that need to be released
+ * at the end of the object lifecycle.
+ *
+ * A class will benefit from implementing *this* interface instead of
+ * [AutoCloseable] if it needs to see if the instance is [open][isOpen]
+ * prior to making other calls.
+ *
+ * @see isOpen
+ * @see checkOpen
+ */
+public interface Closeable : AutoCloseable {
+
+    /**
+     * Tells if the object is still open.
+     *
+     * Implementations must return `false` after [close] is invoked.
+     */
+    public val isOpen: Boolean
+
+    /**
+     * Closes the object.
+     *
+     * Overrides to remove the checked exception from the signature.
+     */
+    public override fun close()
+
+    /**
+     * Ensures that the object [isOpen].
+     *
+     * @throws IllegalStateException otherwise
+     */
+    @Throws(IllegalStateException::class)
+    public fun checkOpen() {
+        check(isOpen) { "`$this` is already closed." }
+    }
+
+    /**
+     * Performs the release of the resources held by this object only if it is still open.
+     *
+     * Otherwise, does nothing.
+     */
+    public fun closeIfOpen() {
+        if (isOpen) {
+            close()
+        }
+    }
+}

--- a/src/main/kotlin/io/spine/io/Closeable.kt
+++ b/src/main/kotlin/io/spine/io/Closeable.kt
@@ -46,9 +46,16 @@ public interface Closeable : AutoCloseable {
     public val isOpen: Boolean
 
     /**
-     * Closes the object.
+     * Performs the release of the resources held by this object.
      *
      * Overrides to remove the checked exception from the signature.
+     *
+     * Implementations <em>may</em> require that the object implementing this interface
+     * invokes this method only once, and throw [IllegalStateException] for repeated invocation.
+     * If this is the case, and you would like to avoid [pre-checking][isOpen] consider
+     * using [closeIfOpen], which does the check itself.
+     *
+     * @see closeIfOpen
      */
     public override fun close()
 
@@ -66,6 +73,8 @@ public interface Closeable : AutoCloseable {
      * Performs the release of the resources held by this object only if it is still open.
      *
      * Otherwise, does nothing.
+     *
+     * @see close
      */
     public fun closeIfOpen() {
         if (isOpen) {

--- a/src/test/kotlin/io/spine/io/CloseableSpec.kt
+++ b/src/test/kotlin/io/spine/io/CloseableSpec.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.io
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`Closeable` interface should")
+internal class CloseableSpec {
+
+    @Test
+    fun `tell if the object is open`() {
+        Window(true).isOpen shouldBe true
+        Window(false).isOpen shouldBe false
+    }
+
+    @Test
+    fun `close the object`() {
+        with (Window(true)) {
+            close()
+            isOpen shouldBe false
+        }
+    }
+
+    @Test
+    fun `ensure that the object is open`() {
+        assertThrows<IllegalStateException> {
+            Window(false).checkOpen()
+        }
+    }
+
+    @Test
+    fun `close the object, if open`() {
+        with(Window(true)) {
+            isOpen shouldBe true
+            closeIfOpen()
+            isOpen shouldBe false
+        }
+        with(Window(false)) {
+            isOpen shouldBe false
+            assertDoesNotThrow { closeIfOpen() }
+            isOpen shouldBe false
+        } 
+    }
+}
+
+private class Window(private var state: Boolean) : Closeable {
+
+    override val isOpen: Boolean
+        get() = state
+
+    override fun close() {
+        state = false
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.196")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.197")


### PR DESCRIPTION
This PR brings the `Closeable` interface which was for years a part of `core-java` on the server side to Spine Base. 

Recent works on code generation in `tool-base` show that we need a custom `Closeable` in modules that do not have `io.spine.server` package in their classpath (and we don't want to bring the dependency on `spine-server` artifact just because of the interface).

It is also expected that the interface would be useful for other usage scenarios that do not assume dependency on `spine-server`.

After copying the interface was converted to Kotlin and supplied with unit tests.

### Dependencies
 * Protobuf -> `3.25.2`
