### PR TITLE
Add extensions `String.ensurePrefix(String)` and `Path.replaceExtension(String)`

### DIFF
--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -25,7 +25,6 @@
  */
 
 import BuildSettings.javaVersion
-import Jvm_module_gradle.Module
 import io.spine.internal.dependency.CheckerFramework
 import io.spine.internal.dependency.Dokka
 import io.spine.internal.dependency.ErrorProne
@@ -46,6 +45,19 @@ import io.spine.internal.gradle.kotlin.setFreeCompilerArgs
 import io.spine.internal.gradle.report.license.LicenseReporter
 import io.spine.internal.gradle.testing.configureLogging
 import io.spine.internal.gradle.testing.registerTestTasks
+import org.gradle.api.Project
+import org.gradle.api.tasks.Delete
+import org.gradle.api.tasks.compile.JavaCompile
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getValue
+import org.gradle.kotlin.dsl.idea
+import org.gradle.kotlin.dsl.invoke
+import org.gradle.kotlin.dsl.`java-library`
+import org.gradle.kotlin.dsl.kotlin
+import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.kotlin.dsl.registering
+import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {

--- a/dependencies.md
+++ b/dependencies.md
@@ -841,4 +841,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri May 31 15:15:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 31 15:26:16 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.201`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.202`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -841,4 +841,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu May 30 14:02:13 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri May 31 15:15:38 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.201</version>
+<version>2.0.0-SNAPSHOT.202</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/kotlin/io/spine/io/Paths.kt
+++ b/src/main/kotlin/io/spine/io/Paths.kt
@@ -28,8 +28,10 @@
 
 package io.spine.io
 
+import io.spine.string.ensurePrefix
 import io.spine.string.toBase64Encoded
 import java.nio.file.Path
+import kotlin.io.path.nameWithoutExtension
 
 /**
  * Converts this path to a Base64-encoded string.
@@ -37,3 +39,18 @@ import java.nio.file.Path
  * @see [String.toBase64Encoded]
  */
 public fun Path.toBase64Encoded(): String = toString().toBase64Encoded()
+
+/**
+ * Replaces the extension for this file.
+ *
+ * @param newExtension
+ *         a new file extension with or without leading `"."`.
+ */
+public fun Path.replaceExtension(newExtension: String): Path {
+    val newExt = if (newExtension.isEmpty()) {
+        newExtension
+    } else {
+        newExtension.ensurePrefix(".")
+    }
+    return resolveSibling(nameWithoutExtension + newExt)
+}

--- a/src/main/kotlin/io/spine/io/Paths.kt
+++ b/src/main/kotlin/io/spine/io/Paths.kt
@@ -41,7 +41,10 @@ import kotlin.io.path.nameWithoutExtension
 public fun Path.toBase64Encoded(): String = toString().toBase64Encoded()
 
 /**
- * Replaces the extension for this file.
+ * Replaces the extension for the file denoted by this path.
+ *
+ * The function does not check the presence of the file.
+ * It does not check if this path represents a directory, either.
  *
  * @param newExtension
  *         a new file extension with or without leading `"."`.

--- a/src/main/kotlin/io/spine/string/Strings.kt
+++ b/src/main/kotlin/io/spine/string/Strings.kt
@@ -29,7 +29,7 @@
 
 package io.spine.string
 
-import java.util.*
+import java.util.Base64
 import kotlin.text.Charsets.UTF_8
 
 /**

--- a/src/main/kotlin/io/spine/string/Strings.kt
+++ b/src/main/kotlin/io/spine/string/Strings.kt
@@ -206,3 +206,17 @@ public fun String.count(substring: String): Int {
     }
     return count
 }
+
+/**
+ * Ensures that this string starts with the given prefix.
+ */
+public fun String.ensurePrefix(prefix: String): String {
+    require(prefix.isNotEmpty()) {
+        "The prefix must not be empty."
+    }
+    return if (startsWith(prefix)) {
+        this
+    } else {
+        prefix + this
+    }
+}

--- a/src/test/kotlin/io/spine/io/PathsSpec.kt
+++ b/src/test/kotlin/io/spine/io/PathsSpec.kt
@@ -49,7 +49,7 @@ internal class PathsSpec {
 
     @Test
     fun `replace file extension`() {
-        Path("file.bin").replaceExtension(".txt") shouldBe Path("file.txt")
+        Path("my/path/file.bin").replaceExtension(".txt") shouldBe Path("my/path/file.txt")
         Path("file").replaceExtension(".txt") shouldBe Path("file.txt")
         Path("file").replaceExtension("txt") shouldBe Path("file.txt")
         Path("file.txt").replaceExtension("") shouldBe Path("file")

--- a/src/test/kotlin/io/spine/io/PathsSpec.kt
+++ b/src/test/kotlin/io/spine/io/PathsSpec.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.shouldBe
 import io.spine.string.decodeBase64
 import io.spine.testing.TestValues.randomString
 import java.nio.file.Paths
+import kotlin.io.path.Path
 import kotlin.io.path.div
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -44,5 +45,14 @@ internal class PathsSpec {
         val decoded = Paths.get(encoded.decodeBase64())
         
         decoded shouldBe original
+    }
+
+    @Test
+    fun `replace file extension`() {
+        Path("file.bin").replaceExtension(".txt") shouldBe Path("file.txt")
+        Path("file").replaceExtension(".txt") shouldBe Path("file.txt")
+        Path("file").replaceExtension("txt") shouldBe Path("file.txt")
+        Path("file.txt").replaceExtension("") shouldBe Path("file")
+        Path("file.").replaceExtension("") shouldBe Path("file")
     }
 }

--- a/src/test/kotlin/io/spine/string/StringsSpec.kt
+++ b/src/test/kotlin/io/spine/string/StringsSpec.kt
@@ -32,6 +32,7 @@ import io.kotest.matchers.string.shouldStartWith
 import io.spine.testing.TestValues.randomString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
@@ -135,5 +136,15 @@ class StringsSpec {
         "baobab".count("mao") shouldBe 0
         "ababababa".count("aba") shouldBe 2
         "the three truths".count("th") shouldBe 3
+    }
+
+    @Test
+    fun `ensure prefix`() {
+        "abc".ensurePrefix("x") shouldBe "xabc"
+        "".ensurePrefix("x") shouldBe "x"
+        "abc".ensurePrefix("ab") shouldBe "abc"
+        assertThrows<IllegalArgumentException> {
+            "abc".ensurePrefix("")
+        }
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.201")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.202")


### PR DESCRIPTION
This PR adds the aforementioned extensions for later usage, in particular, in ProtoData and McJava for "gymnastics" files with different formats.

