### PR TITLE
Utility method for checking UUID value

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,7 +58,6 @@ apply<IncrementGuard>()
 spinePublishing {
     destinations = with(PublishingRepos) {
         setOf(
-            cloudRepo,
             cloudArtifactRegistry,
             gitHub("base")
         )

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -30,6 +30,7 @@ import io.spine.internal.dependency.ErrorProne
 import io.spine.internal.dependency.GradleDoctor
 import io.spine.internal.dependency.Kotest
 import io.spine.internal.dependency.Kover
+import io.spine.internal.dependency.Ksp
 import io.spine.internal.dependency.ProtoData
 import io.spine.internal.dependency.ProtoTap
 import io.spine.internal.dependency.Protobuf
@@ -64,9 +65,9 @@ fun ScriptHandlerScope.standardSpineSdkRepositories() {
  *
  * But for some plugins, it's impossible to apply them directly to a project.
  * For example, when a plugin is not published to Gradle Portal, it can only be
- * applied with buildscript's classpath. Thus, it's needed to leave some freedom
+ * applied with the buildscript's classpath. Thus, it's needed to leave some freedom
  * upon how to apply them. In such cases, just a shortcut to a dependency object
- * can be declared, without applying of the plugin in-place.
+ * can be declared without applying the plugin in-place.
  */
 private const val ABOUT_DEPENDENCY_EXTENSIONS = ""
 
@@ -132,6 +133,9 @@ val PluginDependenciesSpec.kotest: PluginDependencySpec
 
 val PluginDependenciesSpec.kover: PluginDependencySpec
     get() = id(Kover.id).version(Kover.version)
+
+val PluginDependenciesSpec.ksp: PluginDependencySpec
+    get() = id(Ksp.id).version(Ksp.version)
 
 /**
  * Configures the dependencies between third-party Gradle tasks

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Aedile.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Aedile.kt
@@ -24,19 +24,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle.publish
-
-import io.spine.internal.gradle.Repository
+package io.spine.internal.dependency
 
 /**
- * Repositories to which we may publish.
+ * A Kotlin wrapper over [Caffeine].
+ *
+ * @see <a href="https://github.com/sksamuel/aedile">Aedile at GitHub</a>
  */
-object PublishingRepos {
-
-    val cloudArtifactRegistry = CloudArtifactRegistry.repository
-
-    /**
-     * Obtains a GitHub repository by the given name.
-     */
-    fun gitHub(repoName: String): Repository = GitHubPackages.repository(repoName)
+@Suppress("unused")
+object Aedile {
+    private const val version = "1.3.1"
+    const val lib = "com.sksamuel.aedile:aedile-core:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Auto.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Auto.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2023, TeamDev. All rights reserved.
+ * Copyright 2024, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -31,13 +31,13 @@ package io.spine.internal.dependency
 // https://github.com/google/auto
 object AutoCommon {
     private const val version = "1.2.2"
-    const val lib = "com.google.auto:auto-common:${version}"
+    const val lib = "com.google.auto:auto-common:$version"
 }
 
 // https://github.com/google/auto
 object AutoService {
     private const val version = "1.1.1"
-    const val annotations = "com.google.auto.service:auto-service-annotations:${version}"
+    const val annotations = "com.google.auto.service:auto-service-annotations:$version"
     @Suppress("unused")
     const val processor   = "com.google.auto.service:auto-service:${version}"
 }
@@ -45,5 +45,16 @@ object AutoService {
 // https://github.com/google/auto
 object AutoValue {
     private const val version = "1.10.2"
-    const val annotations = "com.google.auto.value:auto-value-annotations:${version}"
+    const val annotations = "com.google.auto.value:auto-value-annotations:$version"
+}
+
+// https://github.com/ZacSweers/auto-service-ksp
+object AutoServiceKsp {
+    /**
+     * The latest version compatible with Kotlin 1.8.22.
+     *
+     * @see Ksp.version
+     */
+    private const val version = "1.1.0"
+    const val processor = "dev.zacsweers.autoservice:auto-service-ksp:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Clikt.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Clikt.kt
@@ -24,19 +24,10 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle.publish
+package io.spine.internal.dependency
 
-import io.spine.internal.gradle.Repository
-
-/**
- * Repositories to which we may publish.
- */
-object PublishingRepos {
-
-    val cloudArtifactRegistry = CloudArtifactRegistry.repository
-
-    /**
-     * Obtains a GitHub repository by the given name.
-     */
-    fun gitHub(repoName: String): Repository = GitHubPackages.repository(repoName)
+// https://ajalt.github.io/clikt/
+object Clikt {
+    private const val version = "3.5.2"
+    const val lib = "com.github.ajalt.clikt:clikt:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Ksp.kt
@@ -24,19 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle.publish
-
-import io.spine.internal.gradle.Repository
+package io.spine.internal.dependency
 
 /**
- * Repositories to which we may publish.
+ * Kotlin Symbol Processing API.
+ *
+ * @see <a href="https://github.com/google/ksp">KSP GitHub repository</a>
  */
-object PublishingRepos {
-
-    val cloudArtifactRegistry = CloudArtifactRegistry.repository
-
+object Ksp {
     /**
-     * Obtains a GitHub repository by the given name.
+     * The latest version compatible with Kotlin v1.8.22, which is bundled with Gradle 7.6.4.
      */
-    fun gitHub(repoName: String): Repository = GitHubPackages.repository(repoName)
+    const val version = "1.8.22-1.0.11"
+    const val id = "com.google.devtools.ksp"
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/LicenseReport.kt
@@ -24,19 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.internal.gradle.publish
+package io.spine.internal.dependency
 
-import io.spine.internal.gradle.Repository
+// https://github.com/jk1/Gradle-License-Report
+@Suppress("unused")
+object LicenseReport {
+    private const val version = "1.16"
+    const val lib = "com.github.jk1:gradle-license-report:${version}"
 
-/**
- * Repositories to which we may publish.
- */
-object PublishingRepos {
-
-    val cloudArtifactRegistry = CloudArtifactRegistry.repository
-
-    /**
-     * Obtains a GitHub repository by the given name.
-     */
-    fun gitHub(repoName: String): Repository = GitHubPackages.repository(repoName)
+    object GradlePlugin {
+        const val version = LicenseReport.version
+        const val id = "com.github.jk1.dependency-license-report"
+        const val lib = LicenseReport.lib
+    }
 }

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoData.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -65,7 +65,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.21.3"
+    private const val fallbackVersion = "0.30.0"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -74,7 +74,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.21.3"
+    private const val fallbackDfVersion = "0.27.0"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -122,6 +122,9 @@ object ProtoData {
 
     val fatCli
         get() = "$group:protodata-fat-cli:$version"
+
+    val testlib
+        get() = "$group:protodata-testlib:$version"
 
     /**
      * An env variable storing a custom [version].

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/ProtoTap.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -38,7 +38,7 @@ package io.spine.internal.dependency
 )
 object ProtoTap {
     const val group = "io.spine.tools"
-    const val version = "0.8.3"
+    const val version = "0.8.7"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/dependency/Spine.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -45,7 +45,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
          */
-        const val base = "2.0.0-SNAPSHOT.199"
+        const val base = "2.0.0-SNAPSHOT.203"
 
         /**
          * The version of [Spine.reflect].
@@ -124,7 +124,7 @@ object Spine {
          *
          * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
          */
-        const val toolBase = "2.0.0-SNAPSHOT.212"
+        const val toolBase = "2.0.0-SNAPSHOT.215"
 
         /**
          * The version of [Spine.javadocTools].

--- a/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
+++ b/buildSrc/src/main/kotlin/io/spine/internal/gradle/publish/IncrementGuard.kt
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -56,7 +56,7 @@ class IncrementGuard : Plugin<Project> {
     override fun apply(target: Project) {
         val tasks = target.tasks
         tasks.register(taskName, CheckVersionIncrement::class.java) {
-            repository = CloudRepo.published
+            repository = CloudArtifactRegistry.repository
             tasks.getByName("check").dependsOn(this)
 
             if (!shouldCheckVersion()) {

--- a/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
+++ b/buildSrc/src/main/kotlin/jacoco-kotlin-jvm.gradle.kts
@@ -54,6 +54,7 @@ private val about = ""
 /**
  * Configure Jacoco task with custom input from this Kotlin Multiplatform project.
  */
+@Suppress("unused")
 val jacocoTestReport: JacocoReport by tasks.getting(JacocoReport::class) {
 
     val classFiles = File("$buildDirectory/classes/kotlin/jvm/")

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.203`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.204`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -841,4 +841,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Jun 01 14:17:25 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Jul 23 02:41:08 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.203</version>
+<version>2.0.0-SNAPSHOT.204</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/java/io/spine/base/UuidValue.java
+++ b/src/main/java/io/spine/base/UuidValue.java
@@ -29,6 +29,11 @@ package io.spine.base;
 import com.google.errorprone.annotations.Immutable;
 import io.spine.type.KnownMessage;
 
+import java.util.UUID;
+
+import static io.spine.util.Exceptions.newIllegalArgumentException;
+import static io.spine.util.Preconditions2.checkNotEmptyOrBlank;
+
 /**
  * A common interface for the {@code string}-based unique identifiers.
  *
@@ -49,4 +54,22 @@ import io.spine.type.KnownMessage;
 @SuppressWarnings("InterfaceNeverImplemented") // Used by the Protobuf Compiler plugin.
 @Immutable
 public interface UuidValue extends KnownMessage {
+
+    /**
+     * Verifies if the given UUID value is valid.
+     *
+     * @param uuid
+     *         the value to check
+     * @throws IllegalArgumentException
+     *          if the given string is not a valid representation of UUID
+     */
+    @SuppressWarnings("ResultOfMethodCallIgnored") // We use `UUID.fromString()` only for checking.
+    static void checkValid(String uuid) {
+        checkNotEmptyOrBlank(uuid);
+        try {
+            UUID.fromString(uuid);
+        } catch (NumberFormatException e) {
+            throw newIllegalArgumentException(e, "Invalid UUID string: `%s`.", uuid);
+        }
+    }
 }

--- a/src/main/kotlin/io/spine/string/Strings.kt
+++ b/src/main/kotlin/io/spine/string/Strings.kt
@@ -33,14 +33,6 @@ import java.util.Base64
 import kotlin.text.Charsets.UTF_8
 
 /**
- * This file contains extension functions for obtaining <em>standard</em> string
- * representation of various objects. For string representations using [Stringifier],
- * please see [io.spine.string.Stringifiers].
- */
-@Suppress("unused")
-private const val ABOUT = ""
-
-/**
  * Joins these strings into a `CamelCase` string.
  *
  * The string will start with the first capital letter if possible.

--- a/src/test/kotlin/io/spine/base/UuidValueSpec.kt
+++ b/src/test/kotlin/io/spine/base/UuidValueSpec.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base
+
+import java.util.UUID
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+@DisplayName("`UuidValue` should")
+internal class UuidValueSpec {
+
+    @Test
+    fun `provide validation method for a string value`() {
+        assertThrows<IllegalArgumentException> {
+            UuidValue.checkValid("")
+        }
+        assertThrows<IllegalArgumentException> {
+            UuidValue.checkValid("1-2-3")
+        }
+        assertDoesNotThrow {
+            UuidValue.checkValid(UUID.randomUUID().toString())
+        }
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.203")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.204")


### PR DESCRIPTION
This PR extends `UuidValue` interface with a utility static method for checking a string representation of UUID value. The method will be used in new code generation for message types implementing the interface. 

Currently, the code of checking UUID value is repeated for all `UuidValue` types. This PR is the first set of "refactoring" this approach, so that the generated code would simply call `UuidValue.checkValid()`.
