### PR TITLE
Implement `ComparatorRegistry`

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-spine-base

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -8,6 +8,9 @@
       <option name="PREFER_LONGER_NAMES" value="false" />
       <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
       <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="1000" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value />
+      </option>
       <option name="JD_P_AT_EMPTY_LINES" value="false" />
       <option name="JD_DO_NOT_WRAP_ONE_LINE_COMMENTS" value="true" />
       <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
@@ -26,6 +29,9 @@
       </REPEAT_ANNOTATIONS>
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
       <option name="PACKAGES_IMPORT_LAYOUT">
         <value>
           <package name="" alias="false" withSubpackages="true" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@
 @file:Suppress("RemoveRedundantQualifierName") // Cannot use imports in some places.
 
 import io.spine.internal.dependency.AutoService
+import io.spine.internal.dependency.AutoServiceKsp
 import io.spine.internal.dependency.Kotlin
 import io.spine.internal.dependency.Protobuf
 import io.spine.internal.dependency.Spine
@@ -50,8 +51,8 @@ plugins {
     `compile-protobuf`
     `jvm-module`
     idea
-    `gradle-doctor`
     `project-report`
+    ksp
 }
 apply<IncrementGuard>()
 
@@ -82,8 +83,8 @@ configurations.all {
 }
 
 dependencies {
-    annotationProcessor(AutoService.processor)
     compileOnly(AutoService.annotations)
+    ksp(AutoServiceKsp.processor)
 
     implementation(Spine.Logging.lib)
     implementation(Spine.reflect)

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.207`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.208`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -141,10 +141,6 @@
      * **Project URL:** [https://github.com/google/auto/tree/main/common](https://github.com/google/auto/tree/main/common)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : com.google.auto.service. **Name** : auto-service. **Version** : 1.1.1.
-     * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
-     * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
-
 1.  **Group** : com.google.auto.service. **Name** : auto-service-annotations. **Version** : 1.1.1.
      * **Project URL:** [https://github.com/google/auto/tree/main/service](https://github.com/google/auto/tree/main/service)
      * **License:** [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -160,6 +156,18 @@
 1.  **Group** : com.google.code.gson. **Name** : gson. **Version** : 2.10.1.
      * **Project URL:** [https://github.com/google/gson/gson](https://github.com/google/gson/gson)
      * **License:** [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing. **Version** : 1.8.22-1.0.11.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-api. **Version** : 1.8.22-1.0.11.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : com.google.devtools.ksp. **Name** : symbol-processing-cmdline. **Version** : 1.8.22-1.0.11.
+     * **Project URL:** [https://goo.gle/ksp](https://goo.gle/ksp)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : com.google.errorprone. **Name** : error_prone_annotation. **Version** : 2.23.0.
      * **Project URL:** [https://errorprone.info/error_prone_annotation](https://errorprone.info/error_prone_annotation)
@@ -251,6 +259,10 @@
      * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
      * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
+1.  **Group** : com.squareup. **Name** : kotlinpoet. **Version** : 1.14.2.
+     * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : commons-beanutils. **Name** : commons-beanutils. **Version** : 1.9.4.
      * **Project URL:** [https://commons.apache.org/proper/commons-beanutils/](https://commons.apache.org/proper/commons-beanutils/)
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -262,6 +274,10 @@
 1.  **Group** : commons-collections. **Name** : commons-collections. **Version** : 3.2.2.
      * **Project URL:** [http://commons.apache.org/collections/](http://commons.apache.org/collections/)
      * **License:** [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : dev.zacsweers.autoservice. **Name** : auto-service-ksp. **Version** : 1.1.0.
+     * **Project URL:** [https://github.com/ZacSweers/auto-service-ksp](https://github.com/ZacSweers/auto-service-ksp)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
 1.  **Group** : info.picocli. **Name** : picocli. **Version** : 4.7.4.
      * **Project URL:** [https://picocli.info](https://picocli.info)
@@ -634,6 +650,10 @@
      * **Project URL:** [https://github.com/JetBrains/intellij-deps-trove4j](https://github.com/JetBrains/intellij-deps-trove4j)
      * **License:** [GNU LESSER GENERAL PUBLIC LICENSE 2.1](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
 
+1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler. **Version** : 1.8.22.
+     * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
+     * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.kotlin. **Name** : kotlin-compiler-embeddable. **Version** : 1.8.21.
      * **Project URL:** [https://kotlinlang.org/](https://kotlinlang.org/)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -845,4 +865,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Sep 09 18:36:52 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Sep 10 17:37:13 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.207</version>
+<version>2.0.0-SNAPSHOT.208</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -139,15 +139,24 @@ all modules and does not describe the project structure per-subproject.
   </dependency>
   <dependency>
     <groupId>com.google.auto.service</groupId>
-    <artifactId>auto-service</artifactId>
+    <artifactId>auto-service-annotations</artifactId>
     <version>1.1.1</version>
     <scope>provided</scope>
   </dependency>
   <dependency>
-    <groupId>com.google.auto.service</groupId>
-    <artifactId>auto-service-annotations</artifactId>
-    <version>1.1.1</version>
-    <scope>provided</scope>
+    <groupId>com.google.devtools.ksp</groupId>
+    <artifactId>symbol-processing</artifactId>
+    <version>1.8.22-1.0.11</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.devtools.ksp</groupId>
+    <artifactId>symbol-processing-api</artifactId>
+    <version>1.8.22-1.0.11</version>
+  </dependency>
+  <dependency>
+    <groupId>com.google.devtools.ksp</groupId>
+    <artifactId>symbol-processing-cmdline</artifactId>
+    <version>1.8.22-1.0.11</version>
   </dependency>
   <dependency>
     <groupId>com.google.errorprone</groupId>
@@ -180,6 +189,11 @@ all modules and does not describe the project structure per-subproject.
     <groupId>com.puppycrawl.tools</groupId>
     <artifactId>checkstyle</artifactId>
     <version>10.12.1</version>
+  </dependency>
+  <dependency>
+    <groupId>dev.zacsweers.autoservice</groupId>
+    <artifactId>auto-service-ksp</artifactId>
+    <version>1.1.0</version>
   </dependency>
   <dependency>
     <groupId>io.gitlab.arturbosch.detekt</groupId>

--- a/src/main/kotlin/io/spine/compare/ComparatorProvider.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.compare
+
+/**
+ * A service provider interface for custom comparators.
+ */
+public interface ComparatorProvider {
+
+    public fun provideIn(registry: ComparatorRegistry)
+}

--- a/src/main/kotlin/io/spine/compare/ComparatorProvider.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorProvider.kt
@@ -27,9 +27,22 @@
 package io.spine.compare
 
 /**
- * A service provider interface for custom comparators.
+ * A service provider interface for dynamic registering comparators
+ * in [ComparatorRegistry].
  */
 public interface ComparatorProvider {
 
-    public fun provideIn(registry: ComparatorRegistry)
+    /**
+     * Registers comparators for specific [Class]s in the given [registry].
+     *
+     * An example usage:
+     *
+     * ```
+     * override fun registerIn(registry: ComparatorRegistry) = registry.run {
+     *     register<Timestamp>(Timestamps.comparator())
+     *     register<Duration>(Durations.comparator())
+     * }
+     * ```
+     */
+    public fun registerIn(registry: ComparatorRegistry)
 }

--- a/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
@@ -26,7 +26,7 @@
 
 package io.spine.compare
 
-import java.util.*
+import java.util.ServiceLoader
 
 /**
  * The comparator registry, which maintains a mapping between a [Class]

--- a/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.compare
+
+import java.util.*
+import org.jetbrains.annotations.VisibleForTesting
+
+/**
+ * The registry of comparators to their types.
+ */
+public object ComparatorRegistry {
+
+    private val map = mutableMapOf<Class<*>, Comparator<*>>()
+
+    init {
+        applyProviders()
+    }
+
+    // `public` for Java users, Kotlin user should use reified counterparts.
+    public fun <T> register(clazz: Class<T>, comparator: Comparator<T>) {
+        map[clazz] = comparator
+    }
+
+    @Suppress("UNCHECKED_CAST") // Type safety is enforced by `register()` method.
+    public fun <T> get(clazz: Class<T>): Comparator<T> {
+        check(contains(clazz))
+        return map[clazz]!! as Comparator<T>
+    }
+
+    @Suppress("UNCHECKED_CAST") // Type safety is enforced by `register()` method.
+    public fun <T> find(clazz: Class<T>): Comparator<T>? = map[clazz] as Comparator<T>?
+
+    public fun contains(clazz: Class<*>): Boolean = map.containsKey(clazz)
+
+    private fun applyProviders() {
+        ServiceLoader.load(ComparatorProvider::class.java)
+            .forEach { it.provideIn(this) }
+    }
+
+    @VisibleForTesting
+    internal fun clear(): Unit = map.clear()
+}
+
+public inline fun <reified T : Any> ComparatorRegistry.contains(): Boolean = contains(T::class.java)
+
+public inline fun <reified T : Any> ComparatorRegistry.find(): Comparator<T>? = find(T::class.java)
+
+public inline fun <reified T : Any> ComparatorRegistry.get(): Comparator<T> = get(T::class.java)
+
+public inline fun <reified T> ComparatorRegistry.register(comparator: Comparator<T>): Unit =
+    register(T::class.java, comparator)

--- a/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
@@ -76,7 +76,7 @@ public object ComparatorRegistry {
 
     private fun loadServiceProviders() {
         ServiceLoader.load(ComparatorProvider::class.java)
-            .forEach { it.provideIn(this) }
+            .forEach { it.registerIn(this) }
     }
 }
 

--- a/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
@@ -60,9 +60,6 @@ public object ComparatorRegistry {
         ServiceLoader.load(ComparatorProvider::class.java)
             .forEach { it.provideIn(this) }
     }
-
-    @VisibleForTesting
-    internal fun clear(): Unit = map.clear()
 }
 
 public inline fun <reified T : Any> ComparatorRegistry.contains(): Boolean = contains(T::class.java)

--- a/src/main/kotlin/io/spine/compare/ProtoComparators.kt
+++ b/src/main/kotlin/io/spine/compare/ProtoComparators.kt
@@ -33,10 +33,17 @@ import com.google.protobuf.util.Durations
 import com.google.protobuf.util.Timestamps
 
 /**
- * Registers comparators for some of the Protobuf Well-Known messages
- * in the [ComparatorRegistry].
+ * Registers comparators for Protobuf Well-Known messages in the [ComparatorRegistry].
  *
- * The used comparators are provided by Protobuf itself.
+ * The following messages are assigned a comparator:
+ *
+ * 1. [Timestamp].
+ * 2. [Duration].
+ *
+ * The used comparators are provided by Protobuf itself in a scope
+ * of `protobuf-java-util` library.
+ *
+ * See also: [Protobuf Docs | Well-Known Types](https://protobuf.dev/reference/protobuf/google.protobuf/).
  */
 @AutoService(ComparatorProvider::class)
 internal class ProtoComparators : ComparatorProvider {

--- a/src/main/kotlin/io/spine/compare/ProtoComparators.kt
+++ b/src/main/kotlin/io/spine/compare/ProtoComparators.kt
@@ -32,10 +32,16 @@ import com.google.protobuf.Timestamp
 import com.google.protobuf.util.Durations
 import com.google.protobuf.util.Timestamps
 
+/**
+ * Registers comparators for some of the Protobuf Well-Known messages
+ * in the [ComparatorRegistry].
+ *
+ * The used comparators are provided by Protobuf itself.
+ */
 @AutoService(ComparatorProvider::class)
-internal class ProtoWellKnownComparators : ComparatorProvider {
+internal class ProtoComparators : ComparatorProvider {
 
-    override fun provideIn(registry: ComparatorRegistry) = registry.run {
+    override fun registerIn(registry: ComparatorRegistry) = registry.run {
         register<Timestamp>(Timestamps.comparator())
         register<Duration>(Durations.comparator())
     }

--- a/src/main/kotlin/io/spine/compare/ProtoComparators.kt
+++ b/src/main/kotlin/io/spine/compare/ProtoComparators.kt
@@ -33,17 +33,8 @@ import com.google.protobuf.util.Durations
 import com.google.protobuf.util.Timestamps
 
 /**
- * Registers comparators for Protobuf Well-Known messages in the [ComparatorRegistry].
- *
- * The following messages are assigned a comparator:
- *
- * 1. [Timestamp].
- * 2. [Duration].
- *
- * The used comparators are provided by Protobuf itself in a scope
- * of `protobuf-java-util` library.
- *
- * See also: [Protobuf Docs | Well-Known Types](https://protobuf.dev/reference/protobuf/google.protobuf/).
+ * Registers comparators provided by `protobuf-java-util` library
+ * for `Timestamp` and `Duration` types.
  */
 @AutoService(ComparatorProvider::class)
 internal class ProtoComparators : ComparatorProvider {

--- a/src/main/kotlin/io/spine/compare/ProtoWellKnownComparators.kt
+++ b/src/main/kotlin/io/spine/compare/ProtoWellKnownComparators.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.compare
+
+import com.google.auto.service.AutoService
+import com.google.protobuf.Duration
+import com.google.protobuf.Timestamp
+import com.google.protobuf.util.Durations
+import com.google.protobuf.util.Timestamps
+
+@AutoService(ComparatorProvider::class)
+internal class ProtoWellKnownComparators : ComparatorProvider {
+
+    override fun provideIn(registry: ComparatorRegistry) = registry.run {
+        register<Timestamp>(Timestamps.comparator())
+        register<Duration>(Durations.comparator())
+    }
+}

--- a/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
+++ b/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
@@ -33,33 +33,23 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.MethodOrderer
-import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestMethodOrder
 
-// The test covers both API.
 @DisplayName("`ComparatorRegistry` should`")
-@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
 internal class ComparatorRegistrySpec {
 
     private val registry = ComparatorRegistry
-    private val comparator = compareBy<String> { it.length }
-
-    @AfterEach
-    fun clearRegistry() = registry.clear()
 
     @Test
-    @Order(1)
-    fun `load the comparators from the present providers`() {
+    fun `load the comparators from the providers`() {
         registry.contains(Timestamp::class.java).shouldBeTrue()
         registry.contains(Duration::class.java).shouldBeTrue()
     }
 
     @Test
     fun `register and check presence of comparators`() {
+        val comparator = compareBy<String> { it.length }
         registry.contains<String>().shouldBeFalse()
         registry.register<String>(comparator)
         registry.contains<String>().shouldBeTrue()
@@ -67,23 +57,26 @@ internal class ComparatorRegistrySpec {
 
     @Test
     fun `override the already registered comparator`() {
-        val comparator2 = compareBy<String> { it.first() }
-        registry.register<String>(comparator)
-        registry.register<String>(comparator2)
-        registry.get<String>() shouldBe comparator2
+        val comparator1 = compareBy<Double> { it }
+        val comparator2 = compareBy<Double> { it }
+        registry.register<Double>(comparator1)
+        registry.register<Double>(comparator2)
+        registry.get<Double>() shouldBe comparator2
     }
 
     @Test
     fun `return a comparator`() {
-        shouldThrow<IllegalStateException> { registry.get<String>() }
-        registry.register<String>(comparator)
-        registry.get<String>() shouldBe comparator
+        val comparator = compareBy<Float> { it }
+        shouldThrow<IllegalStateException> { registry.get<Float>() }
+        registry.register<Float>(comparator)
+        registry.get<Float>() shouldBe comparator
     }
 
     @Test
     fun `search for a comparator`() {
-        registry.find<String>().shouldBeNull()
-        registry.register<String>(comparator)
-        registry.find<String>() shouldBe comparator
+        val comparator = compareBy<StringBuilder> { it.length }
+        registry.find<StringBuilder>().shouldBeNull()
+        registry.register<StringBuilder>(comparator)
+        registry.find<StringBuilder>() shouldBe comparator
     }
 }

--- a/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
+++ b/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
@@ -29,9 +29,6 @@ package io.spine.compare
 import com.google.protobuf.Duration
 import com.google.protobuf.Timestamp
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.matchers.booleans.shouldBeFalse
-import io.kotest.matchers.booleans.shouldBeTrue
-import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -43,16 +40,16 @@ internal class ComparatorRegistrySpec {
 
     @Test
     fun `load the comparators from the providers`() {
-        registry.contains(Timestamp::class.java).shouldBeTrue()
-        registry.contains(Duration::class.java).shouldBeTrue()
+        registry.contains(Timestamp::class.java) shouldBe true
+        registry.contains(Duration::class.java) shouldBe true
     }
 
     @Test
     fun `register and check presence of comparators`() {
         val comparator = compareBy<String> { it.length }
-        registry.contains<String>().shouldBeFalse()
+        registry.contains<String>() shouldBe false
         registry.register<String>(comparator)
-        registry.contains<String>().shouldBeTrue()
+        registry.contains<String>() shouldBe true
     }
 
     @Test
@@ -75,7 +72,7 @@ internal class ComparatorRegistrySpec {
     @Test
     fun `search for a comparator`() {
         val comparator = compareBy<StringBuilder> { it.length }
-        registry.find<StringBuilder>().shouldBeNull()
+        registry.find<StringBuilder>() shouldBe null
         registry.register<StringBuilder>(comparator)
         registry.find<StringBuilder>() shouldBe comparator
     }

--- a/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
+++ b/src/test/kotlin/io/spine/compare/ComparatorRegistrySpec.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.compare
+
+import com.google.protobuf.Duration
+import com.google.protobuf.Timestamp
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.booleans.shouldBeFalse
+import io.kotest.matchers.booleans.shouldBeTrue
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+
+// The test covers both API.
+@DisplayName("`ComparatorRegistry` should`")
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+internal class ComparatorRegistrySpec {
+
+    private val registry = ComparatorRegistry
+    private val comparator = compareBy<String> { it.length }
+
+    @AfterEach
+    fun clearRegistry() = registry.clear()
+
+    @Test
+    @Order(1)
+    fun `load the comparators from the present providers`() {
+        registry.contains(Timestamp::class.java).shouldBeTrue()
+        registry.contains(Duration::class.java).shouldBeTrue()
+    }
+
+    @Test
+    fun `register and check presence of comparators`() {
+        registry.contains<String>().shouldBeFalse()
+        registry.register<String>(comparator)
+        registry.contains<String>().shouldBeTrue()
+    }
+
+    @Test
+    fun `override the already registered comparator`() {
+        val comparator2 = compareBy<String> { it.first() }
+        registry.register<String>(comparator)
+        registry.register<String>(comparator2)
+        registry.get<String>() shouldBe comparator2
+    }
+
+    @Test
+    fun `return a comparator`() {
+        shouldThrow<IllegalStateException> { registry.get<String>() }
+        registry.register<String>(comparator)
+        registry.get<String>() shouldBe comparator
+    }
+
+    @Test
+    fun `search for a comparator`() {
+        registry.find<String>().shouldBeNull()
+        registry.register<String>(comparator)
+        registry.find<String>() shouldBe comparator
+    }
+}

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.207")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.208")


### PR DESCRIPTION
This PR introduces the `ComparatorRegistry` for maintaining `T::class -> Comparator<T>` mapping of available comparators. New comparators can be registered using the `ComparatorProvider` service provider.

We are going to use this registry when generating Java code for handling `compare_by` option in Proto messages. 

Please note, the registry along **with its custom providers** should be present in both generation and generated message's runtimes. The registry usage is incorporated into the generated code only if we are sure that it has the appropriate comparator, which is checked during the code generation.