### PR TITLE
Provide static methods for `ComparatorRegistry`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.211`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.212`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -865,4 +865,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Sep 13 19:28:02 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Oct 07 14:01:46 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.211</version>
+<version>2.0.0-SNAPSHOT.212</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
+++ b/src/main/kotlin/io/spine/compare/ComparatorRegistry.kt
@@ -48,6 +48,7 @@ public object ComparatorRegistry {
      *
      * The method overrides the previously set comparator, if any.
      */
+    @JvmStatic
     public fun <T> register(clazz: Class<T>, comparator: Comparator<T>) {
         map[clazz] = comparator
     }
@@ -57,6 +58,7 @@ public object ComparatorRegistry {
      *
      * @throws IllegalStateException if there is no a comparator for the given [clazz].
      */
+    @JvmStatic
     @Suppress("UNCHECKED_CAST") // Type safety is enforced by `register()` method signature.
     public fun <T> get(clazz: Class<T>): Comparator<T> {
         check(contains(clazz))
@@ -66,12 +68,14 @@ public object ComparatorRegistry {
     /**
      * Returns a comparator for the given [clazz], if any.
      */
+    @JvmStatic
     @Suppress("UNCHECKED_CAST") // Type safety is enforced by `register()` method signature.
     public fun <T> find(clazz: Class<T>): Comparator<T>? = map[clazz] as Comparator<T>?
 
     /**
      * Tells whether the registry has a comparator for the given [clazz].
      */
+    @JvmStatic
     public fun contains(clazz: Class<*>): Boolean = map.containsKey(clazz)
 
     private fun loadServiceProviders() {

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.211")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.212")


### PR DESCRIPTION
This PR makes `ComparatorRegistry` provide static methods for Java callers.

So that, `ComparatorRegistry.INSTANCE.get()` becomes `ComparatorRegistry.get()`.