### PR TITLE
Actualize docs to `(compare_by)` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.214`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.215`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -865,4 +865,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Oct 15 17:04:12 WEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Oct 16 14:55:14 CEST 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.214</version>
+<version>2.0.0-SNAPSHOT.215</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -978,7 +978,9 @@ message CompareByOption {
     //  - `bool` (false is less than true);
     //  - `string` (in the order of respective Unicode values);
     //  - enumerations (following the order of numbers associated with each constant);
-    //  - messages marked with `(compare_by)`.
+    //  - local messages (generated within the current build) marked with `(compare_by)`;
+    //  - external messages (from dependencies), which either marked with `(compare_by)`
+    //    OR have a comparator provided in `io.spine.compare.ComparatorRegistry`.
     //
     // Other types are not permitted. Repeated or map fields are not permitted either.
     // Such declarations can lead to build-time errors.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.214")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.215")


### PR DESCRIPTION
This PR mentions the ability to pass external messages to `(compare_by)` option using a custom comparator.