### PR TITLE
Add `if_set_again` field option

### DIFF
--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -267,7 +267,10 @@ extend google.protobuf.FieldOptions {
     //
     bool column = 73854;
 
-    // Reserved 73855 to 73890 for future options.
+    // See `IfSetAgainOption`.
+    IfSetAgainOption if_set_again = 73855;
+
+    // Reserved 73856 to 73890 for future options.
 
     // Reserved 73900 for removed `by` option.
 }
@@ -1002,4 +1005,24 @@ message CompareByOption {
     // If true, the default order is reversed. For example, numbers are ordered from the greater to
     // the lower, enums — from the last number value to the 0th value, etc.
     bool descending = 2;
+}
+
+// Defines the error message used if a `set_once` field is set again.
+//
+// Applies only to the fields marked as `set_once`.
+//
+// Example: Using the `(set_once)` option.
+//
+//     message User {
+//         UserId id = 1 [(set_once) = true,
+//                        (if_set_again).error_msg = "The student ID can't be re-assigned."];
+//     }
+//
+message IfSetAgainOption {
+
+    // The default error message for the field.
+    option (default_message) = "The field value can't be re-assigned.";
+
+    // A user-defined error message.
+    string error_msg = 1;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.215")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.216")


### PR DESCRIPTION
This PR creates `IfSetAgainOption` to use in conjunction with `set_once_option`. The added option allows specifying the custom error message in case the field's value is re-assigned.