### PR TITLE
Update docs to `(set_once)` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.221`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.222`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 02 15:12:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 18:10:33 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.220`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.221`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 24 19:01:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 15:41:33 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.221</version>
+<version>2.0.0-SNAPSHOT.222</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.220</version>
+<version>2.0.0-SNAPSHOT.221</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -147,6 +147,17 @@ extend google.protobuf.FieldOptions {
 
     // Indicates that a field can only be set once.
     //
+    // The field is considered unset as long as it has the default value. Setting a value over
+    // the default one is always allowed because it is not considered as "overriding".
+    // An overriding of a non-default value with the same value is also allowed. Please note,
+    // as for now, there is no support for explicit `optional` fields.
+    //
+    // The option can be applied to any singular field type:
+    //
+    // - any message or enum type;
+    // - any number type;
+    // - `bool`, `string` and `bytes`.
+    //
     // A typical use-case would include a value of an ID, which doesn't change over the course of
     // the life of an entity.
     //
@@ -159,7 +170,20 @@ extend google.protobuf.FieldOptions {
     // Once set, the `id` field cannot be changed.
     //
     // Use `(if_set_again).error_msg` option to specify a custom error message that will be shown
-    // on attempt to re-assign the field value.
+    // on attempt to re-assign the field value. An example usage can be found in docs to the
+    // corresponding option.
+    //
+    // Also, please note, depending on the target language, a Protobuf message can be built
+    // in different ways. For example, in Java, we have the following ways to create a message:
+    //
+    // 1. Create a new message instance, then set values field-by-field using the provided setters.
+    // 2. Merge data from another instance of the message or from the binary representation.
+    // 3. Build a message using `DynamicMessage` class.
+    // 4. Merge it from a message provided by a third-party Protobuf implementation.
+    // 5. And other...
+    //
+    // Primarily, the option aims to cover only regular usages like (1) and (2). For Java,
+    // for example, service usages like (4) and (5) are not supported.
     //
     bool set_once = 73824;
 
@@ -984,7 +1008,7 @@ message CompareByOption {
     //
     // The allowed field types are:
     //  - any number type;
-    //  - `bool` (false is less than true);
+    //  - `bool` (`false` is less than `true`);
     //  - `string` (in the order of respective Unicode values);
     //  - enumerations (following the order of numbers associated with each constant);
     //  - local messages (generated within the current build) marked with `(compare_by)`;

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -147,18 +147,47 @@ extend google.protobuf.FieldOptions {
 
     // Indicates that a field can only be set once.
     //
-    // A field is considered unset as long as it retains its default value. Setting a value
-    // different from the default is always allowed, as it is not treated as "overriding."
-    // Overwriting a non-default value with the same value is also permitted. Please note
-    // that explicit `optional` fields are not supported at this time.
+    // This option allows the target field to accept assignments only if one of the following
+    // conditions is met:
     //
-    // This option can be applied to the following singular field types:
+    // 1. The current filed value is the default for its type.
+    //    Refer to the official docs on default values: https://protobuf.dev/programming-guides/proto3/#default.
+    // 2. The current field value equals to the proposed new value.
+    //
+    // The option can be applied to the following singular field types:
     //
     // - any message or enum type;
-    // - any number type;
+    // - any numeric type;
     // - `bool`, `string` and `bytes`.
     //
-    // Repeated and map fields are not supported. Such declarations can lead to build-time errors.
+    // Repeated fields, maps, and fields with explicit `optional` cardinality are not supported.
+    // Such declarations can lead to build-time errors. For more information on field cardinality,
+    // refer to the official docs: https://protobuf.dev/programming-guides/proto3/#field-labels.
+    //
+    // Assigning a value to a message field can be done in various ways in the generated code.
+    // It depends on the target language and specific implementation of `protoc`. This option
+    // doesn't enforce field immutability at the binary representation level. Also, it does not
+    // prevent the use of Protobuf utilities that can construct new messages without using field
+    // setters or properties. The primary purpose of this option is to support standard use cases,
+    // such as assigning values through setters or retrieving them during data merging.
+    //
+    // For example, let's take a look on how it works for the generated Java code. The following
+    // use cases are supported and validated by the option:
+    //
+    // 1. Assigning a field value using the field setter.
+    // 2. Assigning a field value using the field descriptor.
+    // 3. Merging data from another instance of the message class.
+    // 4. Merging data from a message's binary representation.
+    // 5. Merging specific fields (available for Message fields).
+    //
+    // Unsupported Java use cases include:
+    //
+    // 1. Constructing a message using the `DynamicMessage` class.
+    // 2. Merging data from messages provided by third-party Protobuf implementations.
+    // 3. Clearing a specific field or an entire message.
+    //
+    // For unsupported scenarios, the option performs no validation. It does not throw errors
+    // or prints warnings.
     //
     // A typical use case involves a field, such as an ID, which remains constant throughout
     // the lifecycle of an entity.
@@ -174,18 +203,6 @@ extend google.protobuf.FieldOptions {
     // Use `(if_set_again).error_msg` option to specify a custom error message that will be shown
     // on attempt to re-assign the field value. Refer to the documentation for the corresponding
     // option for an example of its usage.
-    //
-    // Note: depending on the target language, a Protobuf message can be built in various ways.
-    // For example, in Java, messages can be created as follows:
-    //
-    // 1. Create a new message instance and set values field-by-field using the provided setters.
-    // 2. Merge data from another instance of the message or from its binary representation.
-    // 3. Build a message using `DynamicMessage` class.
-    // 4. Merge data from a message provided by a third-party Protobuf implementation.
-    // 5. And other...
-    //
-    // This option is primarily intended to support standard use cases such as (1) and (2).
-    // In Java, for instance, scenarios like (4) and (5) are not supported.
     //
     bool set_once = 73824;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -158,6 +158,8 @@ extend google.protobuf.FieldOptions {
     // - any number type;
     // - `bool`, `string` and `bytes`.
     //
+    // Repeated and map fields are not supported. Such declarations can lead to build-time errors.
+    //
     // A typical use case involves a field, such as an ID, which remains constant throughout
     // the lifecycle of an entity.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -150,7 +150,7 @@ extend google.protobuf.FieldOptions {
     // This option allows the target field to accept assignments only if one of the following
     // conditions is met:
     //
-    // 1. The current filed value is the default for its type.
+    // 1. The current field value is the default for its type.
     //    Refer to the official docs on default values: https://protobuf.dev/programming-guides/proto3/#default.
     // 2. The current field value equals to the proposed new value.
     //
@@ -161,7 +161,7 @@ extend google.protobuf.FieldOptions {
     // - `bool`, `string` and `bytes`.
     //
     // Repeated fields, maps, and fields with explicit `optional` cardinality are not supported.
-    // Such declarations can lead to build-time errors. For more information on field cardinality,
+    // Such declarations will lead to build-time errors. For more information on field cardinality,
     // refer to the official docs: https://protobuf.dev/programming-guides/proto3/#field-labels.
     //
     // Assigning a value to a message field can be done in various ways in the generated code.
@@ -187,7 +187,7 @@ extend google.protobuf.FieldOptions {
     // 3. Clearing a specific field or an entire message.
     //
     // For unsupported scenarios, the option performs no validation. It does not throw errors
-    // or prints warnings.
+    // or print warnings.
     //
     // A typical use case involves a field, such as an ID, which remains constant throughout
     // the lifecycle of an entity.
@@ -200,9 +200,9 @@ extend google.protobuf.FieldOptions {
     //
     // Once set, the `id` field cannot be changed.
     //
-    // Use `(if_set_again).error_msg` option to specify a custom error message that will be shown
-    // on attempt to re-assign the field value. Refer to the documentation for the corresponding
-    // option for an example of its usage.
+    // Use `(if_set_again).error_msg` option to specify a custom error message that will be used for
+    // composing the error upon attempting to re-assign the field value. Refer to the documentation
+    // for the corresponding option for an example of its usage.
     //
     bool set_once = 73824;
 
@@ -1035,7 +1035,7 @@ message CompareByOption {
     //    OR have a comparator provided in `io.spine.compare.ComparatorRegistry`.
     //
     // Other types are not permitted. Repeated or map fields are not permitted either.
-    // Such declarations can lead to build-time errors.
+    // Such declarations will lead to build-time errors.
     //
     // To refer to nested fields, separate the field names with a dot (`.`).
     // No fields in the path can be repeated or maps.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -147,19 +147,19 @@ extend google.protobuf.FieldOptions {
 
     // Indicates that a field can only be set once.
     //
-    // The field is considered unset as long as it has the default value. Setting a value over
-    // the default one is always allowed because it is not considered as "overriding".
-    // An overriding of a non-default value with the same value is also allowed. Please note,
-    // as for now, there is no support for explicit `optional` fields.
+    // A field is considered unset as long as it retains its default value. Setting a value
+    // different from the default is always allowed, as it is not treated as "overriding."
+    // Overwriting a non-default value with the same value is also permitted. Please note
+    // that explicit `optional` fields are not supported at this time.
     //
-    // The option can be applied to any singular field type:
+    // This option can be applied to the following singular field types:
     //
     // - any message or enum type;
     // - any number type;
     // - `bool`, `string` and `bytes`.
     //
-    // A typical use-case would include a value of an ID, which doesn't change over the course of
-    // the life of an entity.
+    // A typical use case involves a field, such as an ID, which remains constant throughout
+    // the lifecycle of an entity.
     //
     // Example: Using `(set_once)` field validation constraint.
     //
@@ -170,20 +170,20 @@ extend google.protobuf.FieldOptions {
     // Once set, the `id` field cannot be changed.
     //
     // Use `(if_set_again).error_msg` option to specify a custom error message that will be shown
-    // on attempt to re-assign the field value. An example usage can be found in docs to the
-    // corresponding option.
+    // on attempt to re-assign the field value. Refer to the documentation for the corresponding
+    // option for an example of its usage.
     //
-    // Also, please note, depending on the target language, a Protobuf message can be built
-    // in different ways. For example, in Java, we have the following ways to create a message:
+    // Note: depending on the target language, a Protobuf message can be built in various ways.
+    // For example, in Java, messages can be created as follows:
     //
-    // 1. Create a new message instance, then set values field-by-field using the provided setters.
-    // 2. Merge data from another instance of the message or from the binary representation.
+    // 1. Create a new message instance and set values field-by-field using the provided setters.
+    // 2. Merge data from another instance of the message or from its binary representation.
     // 3. Build a message using `DynamicMessage` class.
-    // 4. Merge it from a message provided by a third-party Protobuf implementation.
+    // 4. Merge data from a message provided by a third-party Protobuf implementation.
     // 5. And other...
     //
-    // Primarily, the option aims to cover only regular usages like (1) and (2). For Java,
-    // for example, service usages like (4) and (5) are not supported.
+    // This option is primarily intended to support standard use cases such as (1) and (2).
+    // In Java, for instance, scenarios like (4) and (5) are not supported.
     //
     bool set_once = 73824;
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.220")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.221")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.221")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.222")


### PR DESCRIPTION
This PR adds more details to `(set_once)` option specification.