### PR TITLE
Create `TypeUrl` via `GenericDescriptor`

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -146,13 +146,11 @@
     <inspection_tool class="ComparableImplementedButEqualsNotOverridden" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ComparatorNotSerializable" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="CompareToUsesNonFinalVariable" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ComparisonOfShortAndChar" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConditionSignal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingElse" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="reportWhenNoStatementFollow" value="false" />
     </inspection_tool>
     <inspection_tool class="ConfusingFloatingPointLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="ConfusingMainMethod" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConfusingOctalEscape" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantAssertCondition" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ConstantConditions" enabled="true" level="TYPO" enabled_by_default="true">
@@ -194,7 +192,6 @@
       <option name="ignoreLocalVariables" value="false" />
       <option name="ignorePrivateMethodsAndFields" value="false" />
     </inspection_tool>
-    <inspection_tool class="DefaultNotLastCaseInSwitch" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DisjointPackage" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DollarSignInName" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="DoubleLiteralMayBeFloatLiteral" enabled="true" level="WARNING" enabled_by_default="true" />
@@ -578,7 +575,6 @@
     </inspection_tool>
     <inspection_tool class="NonSerializableObjectBoundToHttpSession" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableObjectPassedToObjectStream" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="NonSerializableWithSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonSerializableWithSerializationMethods" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonShortCircuitBoolean" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="NonStaticFinalLogger" enabled="true" level="WARNING" enabled_by_default="true">
@@ -623,6 +619,9 @@
     </inspection_tool>
     <inspection_tool class="OctalAndDecimalIntegersMixed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="OnDemandImport" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="OptionalOfNullableMisuse" enabled="true" level="WARNING" enabled_by_default="true">
+      <scope name="Production" level="WARNING" enabled="true" />
+    </inspection_tool>
     <inspection_tool class="OverloadedMethodsWithSameNumberOfParameters" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreInconvertibleTypes" value="true" />
     </inspection_tool>
@@ -690,7 +689,6 @@
       <option name="ignoreSerializable" value="false" />
       <option name="ignoreCloneable" value="false" />
     </inspection_tool>
-    <inspection_tool class="RedundantMethodOverride" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ResultOfObjectAllocationIgnored" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
@@ -711,7 +709,6 @@
     <inspection_tool class="SamePackageImport" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SameParameterValue" enabled="true" level="TYPO" enabled_by_default="true" />
     <inspection_tool class="SerialPersistentFieldsWithWrongSignature" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SerialVersionUIDNotStaticFinal" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SerializableInnerClassHasSerialVersionUIDField" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ignoreAnonymousInnerClasses" value="false" />
@@ -750,13 +747,10 @@
     <inspection_tool class="StringBufferToStringInConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringConcatenationInMessageFormatCall" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="StringEqualsEmptyString" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="StringReplaceableByStringBuffer" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="onlyWarnOnLoop" value="true" />
     </inspection_tool>
     <inspection_tool class="SubtractionInCompareTo" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SuspiciousIndentAfterControlStatement" enabled="true" level="WARNING" enabled_by_default="true" />
-    <inspection_tool class="SwitchStatementWithConfusingDeclaration" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="SwitchStatementsWithoutDefault" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_ignoreFullyCoveredEnums" value="true" />
     </inspection_tool>
@@ -790,7 +784,6 @@
     <inspection_tool class="ThrowableNotThrown" enabled="true" level="WARNING" enabled_by_default="true">
       <scope name="Tests" level="WARNING" enabled="false" />
     </inspection_tool>
-    <inspection_tool class="ThrowablePrintStackTrace" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="ThrownExceptionsPerMethod" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="m_limit" value="3" />
     </inspection_tool>
@@ -811,7 +804,6 @@
     <inspection_tool class="TransientFieldInNonSerializableClass" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TransientFieldNotInitialized" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TrivialIf" enabled="true" level="TYPO" enabled_by_default="true" />
-    <inspection_tool class="TrivialStringConcatenation" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TsLint" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="TypeMayBeWeakened" enabled="true" level="INFO" enabled_by_default="true">
       <scope name="Problems" level="INFO" enabled="true">

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.220`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.221`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Nov 24 19:01:34 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 02 15:12:33 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.220</version>
+<version>2.0.0-SNAPSHOT.221</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/java/io/spine/base/Field.java
+++ b/src/main/java/io/spine/base/Field.java
@@ -398,13 +398,13 @@ public final class Field extends ValueHolder<FieldPath> {
     }
 
     /** Obtains the type of the values stored in the field. */
-    static Class<?> classOf(FieldDescriptor field) {
+    private static Class<?> classOf(FieldDescriptor field) {
         var type = field.getType();
         if (type == MESSAGE) {
-            var cls = TypeUrl.from(field.getMessageType()).toJavaClass();
+            var cls = TypeUrl.of(field.getMessageType()).toJavaClass();
             return cls;
         } else if (type == ENUM) {
-            var cls = TypeUrl.from(field.getEnumType()).toJavaClass();
+            var cls = TypeUrl.of(field.getEnumType()).toJavaClass();
             return cls;
         } else {
             var result = ScalarType.javaType(field.toProto().getType());

--- a/src/main/java/io/spine/base/Identifier.java
+++ b/src/main/java/io/spine/base/Identifier.java
@@ -361,7 +361,7 @@ public final class Identifier<I> {
     private static <I> boolean sameType(Class<I> idClass, FieldDescriptor f) {
         @SuppressWarnings("unchecked") // safe since it's Message type.
         var messageType = TypeUrl.of((Class<? extends Message>) idClass);
-        var fieldType = TypeUrl.from(f.getMessageType());
+        var fieldType = TypeUrl.of(f.getMessageType());
         return fieldType.equals(messageType);
     }
 

--- a/src/main/java/io/spine/protobuf/AnyPacker.java
+++ b/src/main/java/io/spine/protobuf/AnyPacker.java
@@ -72,7 +72,7 @@ public final class AnyPacker {
         if (message instanceof Any) {
             return (Any) message;
         }
-        var typeUrl = TypeUrl.from(message.getDescriptorForType());
+        var typeUrl = TypeUrl.of(message.getDescriptorForType());
         var typeUrlPrefix = typeUrl.prefix();
         var result = Any.pack(message, typeUrlPrefix);
         return result;

--- a/src/main/java/io/spine/type/EnumType.java
+++ b/src/main/java/io/spine/type/EnumType.java
@@ -56,7 +56,7 @@ public final class EnumType extends Type<EnumDescriptor, EnumDescriptorProto> {
 
     @Override
     public TypeUrl url() {
-        return TypeUrl.from(descriptor());
+        return TypeUrl.of(descriptor());
     }
 
     @Override

--- a/src/main/java/io/spine/type/MessageType.java
+++ b/src/main/java/io/spine/type/MessageType.java
@@ -125,7 +125,7 @@ public class MessageType extends Type<Descriptor, DescriptorProto> implements Wi
 
     @Override
     public final TypeUrl url() {
-        return TypeUrl.from(descriptor());
+        return TypeUrl.of(descriptor());
     }
 
     @Override

--- a/src/main/java/io/spine/type/ServiceType.java
+++ b/src/main/java/io/spine/type/ServiceType.java
@@ -80,7 +80,7 @@ public final class ServiceType extends Type<ServiceDescriptor, ServiceDescriptor
 
     @Override
     public TypeUrl url() {
-        return TypeUrl.from(descriptor());
+        return TypeUrl.of(descriptor());
     }
 
     @Override

--- a/src/main/java/io/spine/type/TypeUrl.java
+++ b/src/main/java/io/spine/type/TypeUrl.java
@@ -29,6 +29,7 @@ package io.spine.type;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import com.google.errorprone.annotations.Immutable;
+import com.google.errorprone.annotations.InlineMe;
 import com.google.protobuf.Any;
 import com.google.protobuf.AnyOrBuilder;
 import com.google.protobuf.Descriptors.Descriptor;
@@ -67,6 +68,10 @@ public final class TypeUrl implements Serializable {
     private static final String SEPARATOR = "/";
     private static final Splitter splitter = Splitter.on(SEPARATOR);
 
+    /** Suggested replacement for the deprecated API. */
+    private static final String TYPE_URL_OF = "TypeUrl.of(descriptor)";
+    private static final String TYPE_URL =  "io.spine.type.TypeUrl";
+
     /** The prefix of the type URL. */
     private final String prefix;
 
@@ -98,42 +103,55 @@ public final class TypeUrl implements Serializable {
      */
     public static TypeUrl of(Message msg) {
         checkNotNull(msg);
-        return from(msg.getDescriptorForType());
+        return of(msg.getDescriptorForType());
+    }
+
+    /**
+     * Creates a new instance by the passed message descriptor taking its type URL.
+     *
+     * @param descriptor the descriptor of the Protobuf declaration
+     */
+    public static TypeUrl of(GenericDescriptor descriptor) {
+        checkNotNull(descriptor);
+        var prefix = prefixFor(descriptor);
+        return create(prefix, descriptor.getFullName());
     }
 
     /**
      * Creates a new instance by the passed message descriptor taking its type URL.
      *
      * @param descriptor the descriptor of the type
+     * @deprecated Please use {@link TypeUrl#of}.
      */
+    @Deprecated
+    @InlineMe(replacement = TYPE_URL_OF, imports = TYPE_URL)
     public static TypeUrl from(Descriptor descriptor) {
-        checkNotNull(descriptor);
-        var prefix = prefixFor(descriptor);
-        return create(prefix, descriptor.getFullName());
+        return of(descriptor);
     }
 
     /**
      * Creates a new instance by the passed enum descriptor taking its type URL.
      *
      * @param descriptor the descriptor of the type
+     * @deprecated Please use {@link TypeUrl#of}.
      */
+    @Deprecated
+    @InlineMe(replacement = TYPE_URL_OF, imports = TYPE_URL)
     public static TypeUrl from(EnumDescriptor descriptor) {
-        checkNotNull(descriptor);
-        var prefix = prefixFor(descriptor);
-        return create(prefix, descriptor.getFullName());
+        return of(descriptor);
     }
 
     /**
      * Creates a new instance by the passed service descriptor taking its type URL.
      *
      * @param descriptor the descriptor of the type
+     * @deprecated Please use {@link TypeUrl#of}.
      */
+    @Deprecated
+    @InlineMe(replacement = TYPE_URL_OF, imports = TYPE_URL)
     public static TypeUrl from(ServiceDescriptor descriptor) {
-        checkNotNull(descriptor);
-        var prefix = prefixFor(descriptor);
-        return create(prefix, descriptor.getFullName());
+        return of(descriptor);
     }
-
 
     /**
      * Creates a new instance from the passed type URL.
@@ -226,7 +244,7 @@ public final class TypeUrl implements Serializable {
      * by this type URL.
      *
      * <p>This is a convenience method. Use it only when you are sure the {@code TypeUrl} represents
-     * a message (i.e. not an enum).
+     * a message (i.e., not an enum).
      *
      * @throws IllegalStateException if the type URL represents an enum
      */
@@ -291,6 +309,9 @@ public final class TypeUrl implements Serializable {
         /**
          * Type prefix for standard Protobuf types.
          */
+        @SuppressWarnings(
+                "DuplicateStringLiteralInspection" /* Duplicates are in the generated code. */
+        )
         GOOGLE_APIS("type.googleapis.com"),
 
         /**

--- a/src/test/java/io/spine/type/TypeUrlTest.java
+++ b/src/test/java/io/spine/type/TypeUrlTest.java
@@ -68,7 +68,7 @@ class TypeUrlTest {
     private static final String TYPE_URL_VALUE =
             composeTypeUrl(TypeUrl.Prefix.GOOGLE_APIS.value(), TYPE_NAME);
 
-    private final TypeUrl stringValueTypeUrl = TypeUrl.from(TYPE_DESCRIPTOR);
+    private final TypeUrl stringValueTypeUrl = TypeUrl.of(TYPE_DESCRIPTOR);
 
     private static void assertValue(String expected, TypeUrl typeUrl) {
         assertThat(typeUrl.value())
@@ -112,7 +112,7 @@ class TypeUrlTest {
         @Test
         @DisplayName("a descriptor of standard Protobuf type")
         void standardDescriptor() {
-            var typeUrl = TypeUrl.from(TYPE_DESCRIPTOR);
+            var typeUrl = TypeUrl.of(TYPE_DESCRIPTOR);
 
             assertTypeUrl(typeUrl);
         }
@@ -124,7 +124,7 @@ class TypeUrlTest {
             var expectedUrl = composeTypeUrl(TypeUrl.Prefix.SPINE.value(),
                                              descriptor.getFullName());
 
-            var typeUrl = TypeUrl.from(descriptor);
+            var typeUrl = TypeUrl.of(descriptor);
 
             assertValue(expectedUrl, typeUrl);
         }
@@ -154,7 +154,7 @@ class TypeUrlTest {
         private void assertCreatedTypeUrl(String expectedPrefix, EnumDescriptor descriptor) {
             var expected = composeTypeUrl(expectedPrefix, descriptor.getFullName());
 
-            var typeUrl = TypeUrl.from(descriptor);
+            var typeUrl = TypeUrl.of(descriptor);
             assertValue(expected, typeUrl);
         }
 
@@ -209,7 +209,7 @@ class TypeUrlTest {
         @Test
         @DisplayName("created for a type declared in a file with empty `(type_url_prefix)`")
         void inFile() {
-            noPrefixType = TypeUrl.from(TypeWithoutPrefix.getDescriptor());
+            noPrefixType = TypeUrl.of(TypeWithoutPrefix.getDescriptor());
             assertEmptyPrefix();
         }
 

--- a/src/test/kotlin/io/spine/type/KnownTypesSpec.kt
+++ b/src/test/kotlin/io/spine/type/KnownTypesSpec.kt
@@ -134,7 +134,7 @@ internal class KnownTypesSpec {
 
         @Test
         fun `nested into other proto types`() {
-            val typeUrl = TypeUrl.from(EntityOption.Kind.getDescriptor())
+            val typeUrl = TypeUrl.of(EntityOption.Kind.getDescriptor())
             val className = knownTypes.classNameOf(typeUrl)
 
             className shouldBe ClassName.of(EntityOption.Kind::class.java)
@@ -143,7 +143,7 @@ internal class KnownTypesSpec {
 
     @Test
     fun `find type URL by type name`() {
-        val typeUrlExpected = TypeUrl.from(StringValue.getDescriptor())
+        val typeUrlExpected = TypeUrl.of(StringValue.getDescriptor())
         val typeUrlActual = knownTypes.find(typeUrlExpected.toTypeName())
             .map { obj: Type<*, *> -> obj.url() }
 
@@ -154,9 +154,9 @@ internal class KnownTypesSpec {
 
     @Test
     fun `obtain all types under a given package`() {
-        val taskId = TypeUrl.from(KnownTaskId.getDescriptor())
-        val taskName = TypeUrl.from(KnownTaskName.getDescriptor())
-        val task = TypeUrl.from(KnownTask.getDescriptor())
+        val taskId = TypeUrl.of(KnownTaskId.getDescriptor())
+        val taskName = TypeUrl.of(KnownTaskName.getDescriptor())
+        val task = TypeUrl.of(KnownTask.getDescriptor())
         val packageName = "spine.test.types"
         val packageTypes = knownTypes.allFromPackage(packageName)
 
@@ -191,9 +191,9 @@ internal class KnownTypesSpec {
     fun `print known type URLs in alphabetical order`() {
         val output = knownTypes.printAllTypes()
 
-        val anyUrl = TypeUrl.from(Any.getDescriptor()).value()
-        val timestampUrl = TypeUrl.from(Timestamp.getDescriptor()).value()
-        val durationUrl = TypeUrl.from(Duration.getDescriptor()).value()
+        val anyUrl = TypeUrl.of(Any.getDescriptor()).value()
+        val timestampUrl = TypeUrl.of(Timestamp.getDescriptor()).value()
+        val durationUrl = TypeUrl.of(Duration.getDescriptor()).value()
 
         output shouldContain anyUrl
         output shouldContain timestampUrl

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.220")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.221")


### PR DESCRIPTION
This PR introduces static factory method for `TypeUrl` via `GenericDescriptor`. Previously, we had factories accepting `Descriptor`, `EnumDescriptor`, and `ServiceDescriptor`. But in fact `GenericDescriptor` has everything we need for creating `TypeUrl`.

Corresponding static factories named `from()` were deprecated.
