### PR TITLE
Update specs to `(goes)` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.223`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.224`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Dec 03 12:20:21 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Mon Dec 09 15:30:34 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.223</version>
+<version>2.0.0-SNAPSHOT.224</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -89,14 +89,17 @@ extend google.protobuf.FieldOptions {
 
     // The option to mark a field as required.
     //
-    // If the field type is a `message`, it must be set to a non-default instance.
-    // If it is `string` or `bytes`, the value must not be an empty string or an array.
-    // Other field types are not applicable.
-    // If the field is repeated, it must have at least one element.
+    // When this option is set:
     //
-    // Unlike the `required` keyword used in Protobuf 2, the option does not affect the transfer
-    // layer. Even if a message content violates the requirement set by the option, it would still
-    // be a valid message for the Protobuf library.
+    // 1. For message or enum fields, the field must be set to a non-default instance.
+    // 2. For `string` and `bytes` fields, the value must be set to a non-empty string or an array.
+    // 3. For repeated fields and maps, at least one element must be present.
+    //
+    // Other field types are not supported by the option.
+    //
+    // Unlike the `required` keyword in Protobuf 2, this option does not affect message
+    // serialization or deserialization. Even if a message content violates the requirement
+    // set by the option, it would still be a valid message for the Protobuf library.
     //
     // Example: Using `(required)` field validation constraint.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -885,7 +885,7 @@ message GoesOption {
 
     // The default error message used when the companion field specified in `with` is not present
     // alongside the target field.
-    option (default_message) = "The field `%s` can only be set when the field `%s` is defined.";
+    option (default_message) = "The field `{fieldName}` can only be set when `{companionName}` field is defined.";
 
     // The name of the companion field whose presence is required for this field to be valid.
     string with = 1;
@@ -895,7 +895,7 @@ message GoesOption {
 
     // A user-defined error message.
     //
-    // The specified message may include the following tokens:
+    // The specified message may include the following placeholders:
     // 1. `{fieldName}` – the name of the field to which this option is applied.
     // 2. `{companionName}` – the name of the companion field specified in `with`.
     //
@@ -1077,12 +1077,12 @@ message IfSetAgainOption {
 
     // A user-defined error message.
     //
-    // The specified message may include the following tokens:
+    // The specified message may include the following placeholders:
     // 1. `{fieldName}` — the field name.
     // 2. `{currentValue}` — the current field value.
     // 3. `{proposedValue}` — the value that was attempted to be set.
     //
-    // The tokens will be replaced at runtime when the error is constructed.
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     // Example: Using the `(set_once)` option.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -857,11 +857,18 @@ message IfInvalidOption {
     string error_msg = 2;
 }
 
-// Specifies that a message field can be present only if another field is present.
+// Specifies that another field must be present if the option's target field is present.
 //
 // Unlike the `required_field` that handles combination of required fields, this option is useful
-// when it is needed to say that an optional field makes sense only when another optional field is
-// present.
+// when it is needed to say that an optional field makes sense only when another optional field
+// is present.
+//
+// This option can be applied to the same field types as `(required)`, including both the
+// target field and its companion. Supported field types are:
+//
+// - Messages and enums.
+// - Repeated fields and maps.
+// - `string` and `bytes`.
 //
 // Example: Requiring mutual presence of optional fields.
 //
@@ -873,23 +880,23 @@ message IfInvalidOption {
 //
 message GoesOption {
 
-    // The default error message format string.
-    //
-    // The first parameter is the name of the field for which we specify the option.
-    // The second parameter is the name of the field set in the "with" value.
-    //
+    // The default error message used when the companion field specified in `with` is not present
+    // alongside the target field.
     option (default_message) = "The field `%s` can only be set when the field `%s` is defined.";
 
-    // A name of the field required for presence of the field for which we set the option.
+    // The name of the companion field whose presence is required for this field to be valid.
     string with = 1;
 
     // A user-defined validation error format message.
     string msg_format = 2 [deprecated = true];
 
-    // A user-defined validation error format message.
+    // A user-defined error message.
     //
-    // May include the token `{value}` for the actual value of the field. The token will be replaced
-    // at runtime when the error is constructed.
+    // The specified message may include the following tokens:
+    // 1. `{fieldName}` – the name of the field to which this option is applied.
+    // 2. `{companionName}` – the name of the companion field specified in `with`.
+    //
+    // The tokens will be replaced at runtime when the error is constructed.
     //
     string error_msg = 3;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.223")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.224")


### PR DESCRIPTION
This PR updates specs to `(goes)` option. 

In particular, it specifies the supported field types and replaces `%s`-based error message pattern for named placeholders, just as in `IfSetAgain` option.