### PR TITLE
Use named placeholder for error messages in `options.proto`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.224`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.230`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Dec 09 15:30:34 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Dec 12 14:27:09 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.224</version>
+<version>2.0.0-SNAPSHOT.230</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -933,7 +933,7 @@ message GoesOption {
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{goes.companion}` – the name of the companion specified in `with`.
     //
-    // The tokens will be replaced at runtime when the error is constructed.
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     string error_msg = 3;
 }
@@ -1119,7 +1119,7 @@ message IfSetAgainOption {
     // 4. `{field.proposed_value}` – the value, which was attempted to be set for the field.
     // 5. `{parent.type}` – the fully qualified name of the field declaring type.
     //
-    // The tokens will be replaced at runtime when the error is constructed.
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     // Example: Using the `(set_once)` option.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -135,9 +135,7 @@ extend google.protobuf.FieldOptions {
     //
     //   1. A message field value satisfies the validation constraints defined in the corresponding
     //      message type of the field.
-    //
     //   2. Each value of a map entry satisfies validation constraints.
-    //
     //   3. Each item of a repeated field satisfies validation constraints.
     //
     bool validate = 73821;
@@ -1130,7 +1128,7 @@ message IfSetAgainOption {
 message IfHasDuplicatesOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` must not contain duplicates. The found duplicates: `{field.duplicates}`.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` must not contain duplicates. The duplicates found: `{field.duplicates}`.";
 
     // A user-defined error message.
     //
@@ -1139,7 +1137,7 @@ message IfHasDuplicatesOption {
     // 1. `{field.name}` – the field name.
     // 2. `{field.type}` – the fully qualified name of the field type.
     // 3. `{field.value}` – the field value (the whole collection).
-    // 4. `{field.duplicates}` – the found duplicates (elements that occur more than once).
+    // 4. `{field.duplicates}` – the duplicates found (elements that occur more than once).
     // 5. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
@@ -1148,7 +1146,7 @@ message IfHasDuplicatesOption {
     //
     //    message Blizzard {
     //        repeated Snowflake = 1 [(distinct) = true,
-    //                                (if_has_duplicates).error_msg = "Every snowflake must be unique! The found duplicates: `{field.duplicates}`."];
+    //                                (if_has_duplicates).error_msg = "Every snowflake must be unique! The duplicates found: `{field.duplicates}`."];
     //    }
     //
     string error_msg = 1;
@@ -1179,7 +1177,7 @@ message RangeOption {
     //         double angle = 4 [(range).value = "(0.0..180.0)"];
     //     }
     //
-    // NOTE: That definition of ranges must be consistent with the type they constrain.
+    // NOTE: That definition of ranges must be consistent with the type they describe.
     //       An range for an integer field must be defined with integer endpoints.
     //       A range for a floating point field must be defined with decimal separator (`.`),
     //       even if the endpoint value does not have a fractional part.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1156,12 +1156,17 @@ message IfHasDuplicatesOption {
 }
 
 // The option to indicate that a numeric field is required to have a value which belongs
-// to the specified bounded range. For unbounded ranges, please use `(min)` and `(max) options.
+// to the specified bounded range.
+//
+// For unbounded ranges, please use `(min)` and `(max) options.
+//
 message RangeOption {
 
     // The default error message.
     option (default_message) = "The field `{parent.type}.{field.name}` must be within the following range: `{range.value}`.";
 
+    // The string representation of the range.
+    //
     // The range can be open (not including the endpoint) or closed (including the endpoint) on
     // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints are
     // indicated using a square bracket (`[`, `]`).

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -630,7 +630,7 @@ extend google.protobuf.ServiceOptions {
 // Validation Option Types
 //---------------------------
 
-// Defines the error message used if a `required` not set.
+// Defines the error message used if a `required` field is not set.
 //
 // Applies only to the fields marked as `required`.
 //
@@ -723,7 +723,7 @@ message MinOption {
 //
 //     message TowerCrane {
 //         double load = 1 [(max).value = "4.2",
-//                          (max).error_msg = "The `{field.name}` in `{parent.type}` can not exceed `{max.threshold}` tons, but provided `{field.value}`."];
+//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{max.threshold}` tons, but provided `{field.value}`."];
 //     }
 //
 message MaxOption {
@@ -775,7 +775,7 @@ message MaxOption {
 message PatternOption {
 
     // The default error message.
-    option (default_message) = "The `{parent.type}.{field.name}` field must match the regular expression `{regex.pattern}` (`{regex.modifiers}`). The passed value: `{field.value}`.";
+    option (default_message) = "The `{parent.type}.{field.name}` field must match the regular expression `{regex.pattern}` (modifiers: `{regex.modifiers}`). The passed value: `{field.value}`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -888,7 +888,7 @@ message IfInvalidOption {
     //
     //     message Transaction {
     //         TransactionDetails details = 1 [(validate) = true,
-    //                                         (if_invalid).error_msg = "The `detail` field is invalid."];
+    //                                         (if_invalid).error_msg = "The `{field.name}` field is invalid."];
     //    }
     //
     string error_msg = 2;

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1078,12 +1078,13 @@ message CompareByOption {
 //
 message IfSetAgainOption {
 
-    // The default error message used when the field value is re-assigned.
+    // The default error message.
     option (default_message) = "The field `{fieldName}` already has the value `{currentValue}` and cannot be reassigned to `{proposedValue}`.";
 
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
+    //
     // 1. `{fieldName}` — the field name.
     // 2. `{currentValue}` — the current field value.
     // 3. `{proposedValue}` — the value that was attempted to be set.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -655,9 +655,9 @@ message IfMissingOption {
     //
     // Example: Using the `(if_missing)` option.
     //
-    //    message Holder {
-    //        MyMessage field = 1 [(required) = true,
-    //                             (if_missing).error_msg = "This field is required."];
+    //    message Student {
+    //        Name name = 1 [(required) = true,
+    //                       (if_missing).error_msg = "The `{field.name}` field is mandatory for `{field.declaringType}`."];
     //    }
     //
     string error_msg = 2;
@@ -710,24 +710,19 @@ message MinOption {
 
 // The field value must be less than or equal to the given maximum number.
 //
-// Is applicable only to numbers.
+// Is applicable only to number fields.
 // Repeated fields are supported.
 //
 // Example: Defining upper boundary for a numeric field.
 //
-//     message Elevation {
-//         double value = 1 [(max).value = "8848.86"];
+//     message TowerCrane {
+//         double load = 1 [(max).value = "4.2"];
 //     }
 //
 message MaxOption {
 
-    // The default error message format string.
-    //
-    // The format parameters are:
-    //   1) "or equal to " string (if the `exclusive` parameter is false) or an empty string;
-    //   2) the maximum number.
-    //
-    option (default_message) = "The number must be less than %s%s.";
+    // The default error message.
+    option (default_message) = "The field '{field.name}' in '{field.declaringType}' must be {predicate} {threshold}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -741,10 +736,23 @@ message MaxOption {
     // A user-defined validation error format message.
     string msg_format = 3 [deprecated = true];
 
-    // A user-defined validation error format message.
+    // A user-defined error message.
     //
-    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
-    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.type}` – the field type.
+    // 3. `{field.declaringType}` – the name of the field's declaring type.
+    // 4. `{threshold}` – the maximum threshold value for the field.
+    // 5. `{predicate}` – string representation of the used predicate. It equals to
+    //    "less than or equal to" when `exclusive` is not set. Otherwise, "less than".
+    //
+    // Example: Using the `(max)` option with a custom error message.
+    //
+    //     message TowerCrane {
+    //         double load = 1 [(max).value = "4.2"
+    //                          (max).error_msg = "The crane `load` in `{field.declaringType}` can not exceed `{threshold}` tons!"];
+    //     }
     //
     string error_msg = 4;
 }

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -676,14 +676,14 @@ message IfMissingOption {
 //         double value = 1 [(min) = {
 //             value: "0.0",
 //             exclusive: true,
-//             error_msg: "The temperature cannot reach `{min.threshold}K`, but provided `{field.value}`."
+//             error_msg: "The temperature cannot reach `{min.value}K`, but provided `{field.value}`."
 //         }];
 //     }
 //
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {min.threshold}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {min.value}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -705,7 +705,7 @@ message MinOption {
     // 2. `{field.name}` – the field name.
     // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
-    // 5. `{min.threshold}` – the specified minimum threshold `value`.
+    // 5. `{min.value}` – the specified minimum `value`.
     // 6. `{min.comparison}` – if `exclusive` is set to `true`, this placeholder equals
     //    to "greater than". Otherwise, "greater than or equal to".
     //
@@ -723,13 +723,13 @@ message MinOption {
 //
 //     message TowerCrane {
 //         double load = 1 [(max).value = "4.2",
-//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{max.threshold}` tons, but provided `{field.value}`."];
+//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{max.value}` tons, but provided `{field.value}`."];
 //     }
 //
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {max.threshold}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {max.value}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -751,7 +751,7 @@ message MaxOption {
     // 2. `{field.value}` - the field value.
     // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
-    // 5. `{max.threshold}` – the specified maximum threshold `value`.
+    // 5. `{max.value}` – the specified maximum `value`.
     // 6. `{max.comparison}` – if `exclusive` is set to `true`, this placeholder equals
     //    to "less than". Otherwise, "less than or equal to".
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1133,3 +1133,34 @@ message IfSetAgainOption {
     //
     string error_msg = 1;
 }
+
+// Defines the error message used if a `distinct` field has duplicates.
+//
+// Applies only to the repeated fields marked as `distinct`.
+//
+message IfHasDuplicatesOption {
+
+    // The default error message.
+    option (default_message) = "The field `{parent.type}.{field.name}` of `{field.type}` must not contain duplicates. The found duplicates: `{field.duplicates}`.";
+
+    // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.type}` – the fully qualified name of the field type.
+    // 3. `{field.value}` – the field value (the whole collection).
+    // 4. `{field.duplicates}` – the found duplicates (elements that occur more than once).
+    // 5. `{parent.type}` – the fully qualified name of the field declaring type.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    // Example: Using the `(distinct)` option.
+    //
+    //    message Blizzard {
+    //        repeated Snowflake = 1 [(distinct) = true,
+    //                                (if_has_duplicates).error_msg = "Every snowflake must be unique! The found duplicates: `{field.duplicates}`."];
+    //    }
+    //
+    string error_msg = 1;
+}

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -238,7 +238,13 @@ extend google.protobuf.FieldOptions {
     //
     IfSetAgainOption if_set_again = 73827;
 
-    // Reserved 73827 to 73849 for future validation options.
+    // Defines the error message used if a `distinct` field has duplicates.
+    //
+    // Applies only to the repeated fields marked as `distinct`.
+    //
+    IfHasDuplicatesOption if_has_duplicates = 73828;
+
+    // Reserved 73829 to 73849 for future validation options.
 
     // API Annotations
     //-----------------
@@ -306,7 +312,7 @@ extend google.protobuf.FieldOptions {
     //
     bool column = 73854;
 
-    // Reserved 73856 to 73890 for future options.
+    // Reserved 73855 to 73890 for future options.
 
     // Reserved 73900 for removed `by` option.
 }

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -248,6 +248,12 @@ extend google.protobuf.FieldOptions {
     //
     string range = 73826;
 
+    // Defines the error message used if a `set_once` field is set again.
+    //
+    // Applies only to the fields marked as `set_once`.
+    //
+    IfSetAgainOption if_set_again = 73827;
+
     // Reserved 73827 to 73849 for future validation options.
 
     // API Annotations
@@ -315,12 +321,6 @@ extend google.protobuf.FieldOptions {
     // The `repeated` and `map` fields cannot be columns.
     //
     bool column = 73854;
-
-    // Defines the error message used if a `set_once` field is set again.
-    //
-    // Applies only to the fields marked as `set_once`.
-    //
-    IfSetAgainOption if_set_again = 73855;
 
     // Reserved 73856 to 73890 for future options.
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -127,16 +127,24 @@ extend google.protobuf.FieldOptions {
     // See `PatternOption`.
     PatternOption pattern = 73820;
 
-    // Turns on validation constraint checking for a value of a message, a map, or a repeated field.
+    // Enables validation constraint checking for fields that refer to a message.
     //
-    // Default value is `false`.
+    // Default value: `false`.
     //
-    // If set to `true`, the outer message declaring the annotated field would be valid if:
+    // This option can only be applied to fields that refer to a message. Such fields include:
     //
-    //   1. A message field value satisfies the validation constraints defined in the corresponding
-    //      message type of the field.
-    //   2. Each value of a map entry satisfies validation constraints.
-    //   3. Each item of a repeated field satisfies validation constraints.
+    //   1. Message fields.
+    //   2. Map fields with message types as values.
+    //   3. Repeated fields of message types.
+    //
+    // When set to `true`, the marked field is considered valid only if the field's value satisfies
+    // the validation constraints defined in the corresponding message type. This means:
+    //
+    //   1. For message fields: the message value itself must meet its constraints.
+    //   2. For map fields: each value within the map entries must meet the constraints defined
+    //      for its type. Note: Protobuf does not allow messages to be used as map keys.
+    //   3. For repeated fields: every item in the repeated field must satisfy the constraints
+    //      defined for the message type it refers to.
     //
     bool validate = 73821;
 
@@ -846,8 +854,7 @@ message PatternOption {
 
 // Specifies the message to show if a validated field happens to be invalid.
 //
-// It is applicable only to message fields marked with `(validate)`.
-// Repeated fields are supported.
+// It is applicable only to fields marked with `(validate)`.
 //
 message IfInvalidOption {
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -651,7 +651,7 @@ message IfMissingOption {
     //
     // 1. `{field.name}` – the field name.
     // 2. `{field.type}` – the field type.
-    // 3. `{parent.type}` – the field declaring type.
+    // 3. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -704,7 +704,7 @@ message MinOption {
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
     // 3. `{field.type}` – the field type.
-    // 4. `{parent.type}` – the field declaring type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{min.threshold}` – the specified minimum threshold `value`.
     // 6. `{min.comparison}` – if `exclusive` is set to `true`, this placeholder equals
     //    to "greater than". Otherwise, "greater than or equal to".
@@ -750,7 +750,7 @@ message MaxOption {
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
     // 3. `{field.type}` – the field type.
-    // 4. `{parent.type}` – the field declaring type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{max.threshold}` – the specified maximum threshold `value`.
     // 6. `{max.comparison}` – if `exclusive` is set to `true`, this placeholder equals
     //    to "less than". Otherwise, "less than or equal to".
@@ -795,7 +795,7 @@ message PatternOption {
     //
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
-    // 3. `{parent.type}` – the field declaring type.
+    // 3. `{parent.type}` – the fully qualified name of the field declaring type.
     // 4. `{regex.pattern}` – the specified regex pattern.
     // 5. `{regex.modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
     //
@@ -883,7 +883,7 @@ message IfInvalidOption {
     // 2. `{field.type}` – the field type.
     // 3. `{field.path}` – if the invalid field is nested, this placeholder will contain the full
     //    path from the root message to the invalid field. Otherwise, just a field name.
-    // 4. `{parent.type}` – the field declaring type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -915,7 +915,7 @@ message GoesOption {
 
     // The default error message used when the companion field specified in `with` is not present
     // alongside the target field.
-    option (default_message) = "The field `{fieldName}` can only be set when `{companionName}` field is defined.";
+    option (default_message) = "The field `{goes.companion}` must also be set when `{field.name}` is set in `{parent.type}`.";
 
     // The name of the companion field whose presence is required for this field to be valid.
     string with = 1;
@@ -926,8 +926,12 @@ message GoesOption {
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
-    // 1. `{fieldName}` – the name of the field to which this option is applied.
-    // 2. `{companionName}` – the name of the companion field specified in `with`.
+
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.value}` – the field value.
+    // 3. `{field.type}` – the field type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
+    // 5. `{goes.companion}` – the name of the companion specified in `with`.
     //
     // The tokens will be replaced at runtime when the error is constructed.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -926,7 +926,7 @@ message GoesOption {
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
-
+    //
     // 1. `{field.name}` – the field name.
     // 2. `{field.value}` – the field value.
     // 3. `{field.type}` – the field type.
@@ -1107,17 +1107,19 @@ message CompareByOption {
 message IfSetAgainOption {
 
     // The default error message.
-    option (default_message) = "The field `{fieldName}` already has the value `{currentValue}` and cannot be reassigned to `{proposedValue}`.";
+    option (default_message) = "The field `{field.name}` in `{parent.type}` already has the value `{field.value}` and cannot be reassigned to `{field.proposed_value}`.";
 
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{fieldName}` — the field name.
-    // 2. `{currentValue}` — the current field value.
-    // 3. `{proposedValue}` — the value that was attempted to be set.
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.value}` – the field value.
+    // 3. `{field.type}` – the field type.
+    // 4. `{field.proposed_value}` – the value, which was attempted to be set for the field.
+    // 5. `{parent.type}` – the fully qualified name of the field declaring type.
     //
-    // The placeholders will be replaced at runtime when the error is constructed.
+    // The tokens will be replaced at runtime when the error is constructed.
     //
     // Example: Using the `(set_once)` option.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -630,14 +630,14 @@ extend google.protobuf.ServiceOptions {
 // Validation Option Types
 //---------------------------
 
-// Defines the error message for `required` field with no value set.
+// Defines the error message used if a `required` not set.
 //
 // Applies only to the fields marked as `required`.
 //
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field `{field.name}` in `{parent.type}` must have a value.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of type `{field.type}` must have a value.";
 
     // A user-defined validation error format message.
     //
@@ -650,7 +650,7 @@ message IfMissingOption {
     // The specified message may include the following placeholders:
     //
     // 1. `{field.name}` – the field name.
-    // 2. `{field.type}` – the field type.
+    // 2. `{field.type}` – the fully qualified name of the field type.
     // 3. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
@@ -857,35 +857,38 @@ message PatternOption {
 
 // Specifies the message to show if a validated field happens to be invalid.
 //
-// It is applicable only to message fields.
+// It is applicable only to message fields marked with `(validate)`.
 // Repeated fields are supported.
-//
-// Example: Using the `(if_invalid)` option.
-//
-//     message Holder {
-//         MyMessage field = 1 [(validate) = true,
-//                              (if_invalid).error_msg = "The field is invalid."];
-//    }
 //
 message IfInvalidOption {
 
-    // The default error message for the field.
-    option (default_message) = "The field `{field.path}` in `{parent.type}` is invalid.";
+    // The default error message.
+    option (default_message) = "The field `{parent.type}.{field.path}` of type `{field.type}` is invalid. The field value: `{field.value}`.";
 
     // A user-defined validation error format message.
+    //
+    // Use `error_msg` instead.
+    //
     string msg_format = 1 [deprecated = true];
 
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.value}` - the field value.
-    // 2. `{field.type}` – the field type.
-    // 3. `{field.path}` – if the invalid field is nested, this placeholder will contain the full
+    // 1. `{field.path}` – if the invalid field is nested, this placeholder will contain the full
     //    path from the root message to the invalid field. Otherwise, just a field name.
+    // 2. `{field.value}` - the field value.
+    // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    // Example: Using the `(if_invalid)` option.
+    //
+    //     message Transaction {
+    //         TransactionDetails details = 1 [(validate) = true,
+    //                                         (if_invalid).error_msg = "The `detail` field is invalid."];
+    //    }
     //
     string error_msg = 2;
 }
@@ -1107,16 +1110,16 @@ message CompareByOption {
 message IfSetAgainOption {
 
     // The default error message.
-    option (default_message) = "The field `{field.name}` in `{parent.type}` already has the value `{field.value}` and cannot be reassigned to `{field.proposed_value}`.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of `{field.type}` already has the value `{field.value}` and cannot be reassigned to `{field.proposed_value}`.";
 
     // A user-defined error message.
     //
     // The specified message may include the following placeholders:
     //
     // 1. `{field.name}` – the field name.
-    // 2. `{field.value}` – the field value.
-    // 3. `{field.type}` – the field type.
-    // 4. `{field.proposed_value}` – the value, which was attempted to be set for the field.
+    // 2. `{field.type}` – the fully qualified name of the field type.
+    // 3. `{field.value}` – the current field value.
+    // 4. `{field.proposed_value}` – the value, which was attempted to be set.
     // 5. `{parent.type}` – the fully qualified name of the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -630,22 +630,14 @@ extend google.protobuf.ServiceOptions {
 // Validation Option Types
 //---------------------------
 
-// Defines the error handling for `required` field with no value set.
+// Defines the error message for `required` field with no value set.
 //
 // Applies only to the fields marked as `required`.
-// Validation error message is composed according to the rules defined by this option.
-//
-// Example: Using the `(if_missing)` option.
-//
-//    message Holder {
-//        MyMessage field = 1 [(required) = true,
-//                             (if_missing).error_msg = "This field is required."];
-//    }
 //
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "A value must be set.";
+    option (default_message) = "The field '{field.name}' of type '{field.type}' in '{field.declaringType}' must have a value.";
 
     // A user-defined validation error format message.
     //
@@ -654,6 +646,20 @@ message IfMissingOption {
     string msg_format = 1 [deprecated = true];
 
     // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.type}` – the field type.
+    // 3. `{field.declaringType}` – the name of the field's declaring type.
+    //
+    // Example: Using the `(if_missing)` option.
+    //
+    //    message Holder {
+    //        MyMessage field = 1 [(required) = true,
+    //                             (if_missing).error_msg = "This field is required."];
+    //    }
+    //
     string error_msg = 2;
 }
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -860,7 +860,8 @@ message PatternOption {
 }
 
 // Specifies the message to show if a validated field happens to be invalid.
-// Is applicable only to messages.
+//
+// It is applicable only to message fields.
 // Repeated fields are supported.
 //
 // Example: Using the `(if_invalid)` option.
@@ -873,15 +874,22 @@ message PatternOption {
 message IfInvalidOption {
 
     // The default error message for the field.
-    option (default_message) = "The message must have valid properties.";
+    option (default_message) = "The field '{field.path}' in '{parent.type}' is invalid.";
 
     // A user-defined validation error format message.
     string msg_format = 1 [deprecated = true];
 
-    // A user-defined validation error format message.
+    // A user-defined error message.
     //
-    // May include the token `{value}` for the actual value of the field.
-    // The token will be replaced at runtime when the error is constructed.
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.value}` - the field value.
+    // 2. `{field.type}` – the field type.
+    // 3. `{field.path}` – if the invalid field is nested, this placeholder will contain the full
+    //    path from the root message to the invalid field. Otherwise, just a field name.
+    // 4. `{parent.type}` – the field declaring type.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     string error_msg = 2;
 }

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -637,7 +637,7 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field '{field.name}' of type '{field.type}' in '{field.declaringType}' must have a value.";
+    option (default_message) = "The field '{field.path}' of type '{field.type}' must have a value.";
 
     // A user-defined validation error format message.
     //
@@ -651,13 +651,14 @@ message IfMissingOption {
     //
     // 1. `{field.name}` – the field name.
     // 2. `{field.type}` – the field type.
-    // 3. `{field.declaringType}` – the name of the field's declaring type.
+    // 3. `{field.path}` – the field name along with the name of its declaring type.
+    // 4. `{parent.type}` – the field declaring type.
     //
     // Example: Using the `(if_missing)` option.
     //
     //    message Student {
     //        Name name = 1 [(required) = true,
-    //                       (if_missing).error_msg = "The `{field.name}` field is mandatory for `{field.declaringType}`."];
+    //                       (if_missing).error_msg = "The `{field.name}` field is mandatory for `{parent.type}`."];
     //    }
     //
     string error_msg = 2;
@@ -722,7 +723,7 @@ message MinOption {
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field '{field.name}' in '{field.declaringType}' must be {predicate} {threshold}.";
+    option (default_message) = "The field '{field.path}' must be {predicate} {threshold}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -742,8 +743,9 @@ message MaxOption {
     //
     // 1. `{field.name}` – the field name.
     // 2. `{field.type}` – the field type.
-    // 3. `{field.declaringType}` – the name of the field's declaring type.
-    // 4. `{threshold}` – the maximum threshold value for the field.
+    // 3. `{field.path}` – the field name along with the name of its declaring type.
+    // 3. `{parent.type}` – the field declaring type.
+    // 4. `{threshold}` – the specified maximum threshold `value`.
     // 5. `{predicate}` – string representation of the used predicate. It equals to
     //    "less than or equal to" when `exclusive` is not set. Otherwise, "less than".
     //
@@ -751,7 +753,7 @@ message MaxOption {
     //
     //     message TowerCrane {
     //         double load = 1 [(max).value = "4.2"
-    //                          (max).error_msg = "The crane `load` in `{field.declaringType}` can not exceed `{threshold}` tons!"];
+    //                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{threshold}` tons!"];
     //     }
     //
     string error_msg = 4;

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -683,7 +683,7 @@ message IfMissingOption {
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {min.value}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.operator} {min.value}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -706,8 +706,8 @@ message MinOption {
     // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{min.value}` – the specified minimum `value`.
-    // 6. `{min.comparison}` – if `exclusive` is set to `true`, this placeholder equals
-    //    to "greater than". Otherwise, "greater than or equal to".
+    // 6. `{min.operator}` – if `exclusive` is set to `true`, this placeholder equals to ">".
+    //    Otherwise, ">=".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -729,7 +729,7 @@ message MinOption {
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {max.value}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.operator} {max.value}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -752,8 +752,8 @@ message MaxOption {
     // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{max.value}` – the specified maximum `value`.
-    // 6. `{max.comparison}` – if `exclusive` is set to `true`, this placeholder equals
-    //    to "less than". Otherwise, "less than or equal to".
+    // 6. `{max.operator}` – if `exclusive` is set to `true`, this placeholder equals to "<".
+    //    Otherwise, "<=".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -683,7 +683,7 @@ message IfMissingOption {
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field `{field.name}` in `{parent.type}` must be {max.comparison} {min.threshold}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {min.threshold}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -703,7 +703,7 @@ message MinOption {
     //
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
-    // 3. `{field.type}` – the field type.
+    // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{min.threshold}` – the specified minimum threshold `value`.
     // 6. `{min.comparison}` – if `exclusive` is set to `true`, this placeholder equals
@@ -723,13 +723,13 @@ message MinOption {
 //
 //     message TowerCrane {
 //         double load = 1 [(max).value = "4.2",
-//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{max.threshold}` tons!"];
+//                          (max).error_msg = "The `{field.name}` in `{parent.type}` can not exceed `{max.threshold}` tons, but provided `{field.value}`."];
 //     }
 //
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field `{field.name}` in `{parent.type}` must be {max.comparison} {max.threshold}.";
+    option (default_message) = "The field `{parent.type}.{field.name}` must be {max.comparison} {max.threshold}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -747,9 +747,9 @@ message MaxOption {
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.value}` - the field value.
-    // 2. `{field.name}` – the field name.
-    // 3. `{field.type}` – the field type.
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.value}` - the field value.
+    // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{max.threshold}` – the specified maximum threshold `value`.
     // 6. `{max.comparison}` – if `exclusive` is set to `true`, this placeholder equals
@@ -769,13 +769,13 @@ message MaxOption {
 //
 //     message CreateAccount {
 //         string id = 1 [(pattern).regex = "^[A-Za-z0-9+]+$",
-//                        (pattern).error_msg = "ID must be alphanumerical. Provided: `{value}`."];
+//                        (pattern).error_msg = "ID must be alphanumerical in `{parent.type}`. Provided: `{field.value}`."];
 //     }
 //
 message PatternOption {
 
-    // The default error message format string.
-    option (default_message) = "The `{field.name}` in `{parent.type}` must match the regular expression `{regex}`. The passed value: `{field.value}`.";
+    // The default error message.
+    option (default_message) = "The `{parent.type}.{field.name}` field must match the regular expression `{regex.pattern}` (`{regex.modifiers}`). The passed value: `{field.value}`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -793,11 +793,12 @@ message PatternOption {
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.value}` - the field value.
-    // 2. `{field.name}` – the field name.
-    // 3. `{parent.type}` – the fully qualified name of the field declaring type.
-    // 4. `{regex.pattern}` – the specified regex pattern.
-    // 5. `{regex.modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.value}` - the field value.
+    // 3. `{field.type}` – the fully qualified name of the field type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
+    // 5. `{regex.pattern}` – the specified regex pattern.
+    // 6. `{regex.modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -916,8 +917,7 @@ message IfInvalidOption {
 //
 message GoesOption {
 
-    // The default error message used when the companion field specified in `with` is not present
-    // alongside the target field.
+    // The default error message.
     option (default_message) = "The field `{goes.companion}` must also be set when `{field.name}` is set in `{parent.type}`.";
 
     // The name of the companion field whose presence is required for this field to be valid.
@@ -932,7 +932,7 @@ message GoesOption {
     //
     // 1. `{field.name}` – the field name.
     // 2. `{field.value}` – the field value.
-    // 3. `{field.type}` – the field type.
+    // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.
     // 5. `{goes.companion}` – the name of the companion specified in `with`.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -217,6 +217,12 @@ extend google.protobuf.FieldOptions {
 
     // The option to mark a `repeated` field as a collection of unique elements.
     //
+    // When this option is set to `true`, all elements in the `repeated` field must be unique.
+    // Uniqueness is determined by comparing the elements themselves, using their full equality.
+    // For example, in Java, it is defined by the `equals()` method.
+    //
+    // No special cases are applied, such as comparing only specific fields like IDs.
+    //
     // Example: Using `(distinct)` constraint for a repeated field.
     //
     //    message Blizzard {

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -702,12 +702,13 @@ message MinOption {
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.name}` – the field name.
-    // 2. `{field.type}` – the field type.
-    // 3. `{field.path}` – the field name along with the name of its declaring type.
-    // 3. `{parent.type}` – the field declaring type.
-    // 4. `{threshold}` – the specified minimum threshold `value`.
-    // 5. `{predicate}` – string representation of the used predicate. It equals to
+    // 1. `{field.value}` - the field value.
+    // 2. `{field.name}` – the field name.
+    // 3. `{field.type}` – the field type.
+    // 4. `{field.path}` – the field name along with the name of its declaring type.
+    // 5. `{parent.type}` – the field declaring type.
+    // 6. `{threshold}` – the specified minimum threshold `value`.
+    // 7. `{predicate}` – string representation of the used predicate. It equals to
     //    "greater than or equal to" when `exclusive` is not set. Otherwise, "greater than".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
@@ -748,12 +749,13 @@ message MaxOption {
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.name}` – the field name.
-    // 2. `{field.type}` – the field type.
-    // 3. `{field.path}` – the field name along with the name of its declaring type.
-    // 3. `{parent.type}` – the field declaring type.
-    // 4. `{threshold}` – the specified maximum threshold `value`.
-    // 5. `{predicate}` – string representation of the used predicate. It equals to
+    // 1. `{field.value}` - the field value.
+    // 2. `{field.name}` – the field name.
+    // 3. `{field.type}` – the field type.
+    // 4. `{field.path}` – the field name along with the name of its declaring type.
+    // 5. `{parent.type}` – the field declaring type.
+    // 6. `{threshold}` – the specified maximum threshold `value`.
+    // 7. `{predicate}` – string representation of the used predicate. It equals to
     //    "less than or equal to" when `exclusive` is not set. Otherwise, "less than".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
@@ -762,7 +764,8 @@ message MaxOption {
 }
 
 // A string field value must match the given regular expression.
-// Is applicable only to strings.
+//
+// Is applicable only to string fields.
 // Repeated fields are supported.
 //
 // Example: Using the `(pattern)` option.
@@ -775,10 +778,7 @@ message MaxOption {
 message PatternOption {
 
     // The default error message format string.
-    //
-    // The format parameter is the regular expression to which the value must match.
-    //
-    option (default_message) = "The string must match the regular expression `%s`.";
+    option (default_message) = "The `field.path` must match the regular expression `{regex}`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -794,8 +794,16 @@ message PatternOption {
 
     // A user-defined validation error format message.
     //
-    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
-    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.value}` - the field value.
+    // 2. `{field.name}` – the field name.
+    // 3. `{field.path}` – the field name along with the name of its declaring type.
+    // 4. `{parent.type}` – the field declaring type.
+    // 5. `{regex}` – the specified regex pattern.
+    // 6. `{modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     string error_msg = 5;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -637,7 +637,7 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field '{field.path}' of type '{field.type}' must have a value.";
+    option (default_message) = "The field `{field.name}` in `{parent.type}` must have a value.";
 
     // A user-defined validation error format message.
     //
@@ -651,8 +651,7 @@ message IfMissingOption {
     //
     // 1. `{field.name}` – the field name.
     // 2. `{field.type}` – the field type.
-    // 3. `{field.path}` – the field name along with the name of its declaring type.
-    // 4. `{parent.type}` – the field declaring type.
+    // 3. `{parent.type}` – the field declaring type.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -677,14 +676,14 @@ message IfMissingOption {
 //         double value = 1 [(min) = {
 //             value: "0.0",
 //             exclusive: true,
-//             error_msg: "Temperature cannot reach {other}K, but provided {value}."
+//             error_msg: "The temperature cannot reach `{min.threshold}K`, but provided `{field.value}`."
 //         }];
 //     }
 //
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field '{field.path}' must be {predicate} {threshold}.";
+    option (default_message) = "The field `{field.name}` in `{parent.type}` must be {max.comparison} {min.threshold}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -705,11 +704,10 @@ message MinOption {
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
     // 3. `{field.type}` – the field type.
-    // 4. `{field.path}` – the field name along with the name of its declaring type.
-    // 5. `{parent.type}` – the field declaring type.
-    // 6. `{threshold}` – the specified minimum threshold `value`.
-    // 7. `{predicate}` – string representation of the used predicate. It equals to
-    //    "greater than or equal to" when `exclusive` is not set. Otherwise, "greater than".
+    // 4. `{parent.type}` – the field declaring type.
+    // 5. `{min.threshold}` – the specified minimum threshold `value`.
+    // 6. `{min.comparison}` – if `exclusive` is set to `true`, this placeholder equals
+    //    to "greater than". Otherwise, "greater than or equal to".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -725,13 +723,13 @@ message MinOption {
 //
 //     message TowerCrane {
 //         double load = 1 [(max).value = "4.2",
-//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{threshold}` tons!"];
+//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{max.threshold}` tons!"];
 //     }
 //
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field '{field.path}' must be {predicate} {threshold}.";
+    option (default_message) = "The field `{field.name}` in `{parent.type}` must be {max.comparison} {max.threshold}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -752,11 +750,10 @@ message MaxOption {
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
     // 3. `{field.type}` – the field type.
-    // 4. `{field.path}` – the field name along with the name of its declaring type.
-    // 5. `{parent.type}` – the field declaring type.
-    // 6. `{threshold}` – the specified maximum threshold `value`.
-    // 7. `{predicate}` – string representation of the used predicate. It equals to
-    //    "less than or equal to" when `exclusive` is not set. Otherwise, "less than".
+    // 4. `{parent.type}` – the field declaring type.
+    // 5. `{max.threshold}` – the specified maximum threshold `value`.
+    // 6. `{max.comparison}` – if `exclusive` is set to `true`, this placeholder equals
+    //    to "less than". Otherwise, "less than or equal to".
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -778,7 +775,7 @@ message MaxOption {
 message PatternOption {
 
     // The default error message format string.
-    option (default_message) = "The `field.path` must match the regular expression `{regex}`.";
+    option (default_message) = "The `{field.name}` in `{parent.type}` must match the regular expression `{regex}`. The passed value: `{field.value}`.";
 
     // The regular expression to match.
     string regex = 1;
@@ -798,10 +795,9 @@ message PatternOption {
     //
     // 1. `{field.value}` - the field value.
     // 2. `{field.name}` – the field name.
-    // 3. `{field.path}` – the field name along with the name of its declaring type.
-    // 4. `{parent.type}` – the field declaring type.
-    // 5. `{regex}` – the specified regex pattern.
-    // 6. `{modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
+    // 3. `{parent.type}` – the field declaring type.
+    // 4. `{regex.pattern}` – the specified regex pattern.
+    // 5. `{regex.modifiers}` – the specified modifiers, if any. For example, `[dot_all, unicode]`.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
@@ -874,7 +870,7 @@ message PatternOption {
 message IfInvalidOption {
 
     // The default error message for the field.
-    option (default_message) = "The field '{field.path}' in '{parent.type}' is invalid.";
+    option (default_message) = "The field `{field.path}` in `{parent.type}` is invalid.";
 
     // A user-defined validation error format message.
     string msg_format = 1 [deprecated = true];

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -226,27 +226,11 @@ extend google.protobuf.FieldOptions {
     bool distinct = 73825;
 
     // The option to indicate that a numeric field is required to have a value which belongs
-    // to the specified bounded range. For unbounded ranges, please use `(min)` and `(max) options.
+    // to the specified bounded range.
     //
-    // The range can be open (not including the endpoint) or closed (including the endpoint) on
-    // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints are
-    // indicated using a square bracket (`[`, `]`).
+    // For unbounded ranges, please use `(min)` and `(max) options.
     //
-    // Example: Defining ranges of numeric values.
-    //
-    //     message NumRanges {
-    //         int32 hour = 1 [(range) = "[0..24)"];
-    //         uint32 minute = 2 [(range) = "[0..59]"];
-    //         float degree = 3 [(range) = "[0.0..360.0)"];
-    //         double angle = 4 [(range) = "(0.0..180.0)"];
-    //     }
-    //
-    // NOTE: That definition of ranges must be consistent with the type they constrain.
-    //       An range for an integer field must be defined with integer endpoints.
-    //       A range for a floating point field must be defined with decimal separator (`.`),
-    //       even if the endpoint value does not have a fractional part.
-    //
-    string range = 73826;
+    RangeOption range = 73826;
 
     // Defines the error message used if a `set_once` field is set again.
     //
@@ -1163,4 +1147,46 @@ message IfHasDuplicatesOption {
     //    }
     //
     string error_msg = 1;
+}
+
+// The option to indicate that a numeric field is required to have a value which belongs
+// to the specified bounded range. For unbounded ranges, please use `(min)` and `(max) options.
+message RangeOption {
+
+    // The default error message.
+    option (default_message) = "The field `{parent.type}.{field.name}` must be within the following range: `{range.value}`.";
+
+    // The range can be open (not including the endpoint) or closed (including the endpoint) on
+    // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints are
+    // indicated using a square bracket (`[`, `]`).
+    //
+    // Example: Defining ranges of numeric values.
+    //
+    //     message NumRanges {
+    //         int32 hour = 1 [(range).value = "[0..24)"];
+    //         uint32 minute = 2 [(range).value = "[0..59]"];
+    //         float degree = 3 [(range).value = "[0.0..360.0)"];
+    //         double angle = 4 [(range).value = "(0.0..180.0)"];
+    //     }
+    //
+    // NOTE: That definition of ranges must be consistent with the type they constrain.
+    //       An range for an integer field must be defined with integer endpoints.
+    //       A range for a floating point field must be defined with decimal separator (`.`),
+    //       even if the endpoint value does not have a fractional part.
+    //
+    string value = 1;
+
+    // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.value}` - the field value.
+    // 3. `{field.type}` – the fully qualified name of the field type.
+    // 4. `{parent.type}` – the fully qualified name of the field declaring type.
+    // 5. `{range.value}` – the specified range.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 2;
 }

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -854,7 +854,7 @@ message PatternOption {
 message IfInvalidOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.path}` of the type `{field.type}` is invalid. The field value: `{field.value}`.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` is invalid. The field value: `{field.value}`.";
 
     // A user-defined validation error format message.
     //
@@ -866,8 +866,7 @@ message IfInvalidOption {
     //
     // The specified message may include the following placeholders:
     //
-    // 1. `{field.path}` – if the invalid field is nested, this placeholder will contain the full
-    //    path from the root message to the invalid field. Otherwise, just a field name.
+    // 1. `{field.name}` – the field name.
     // 2. `{field.value}` - the field value.
     // 3. `{field.type}` – the fully qualified name of the field type.
     // 4. `{parent.type}` – the fully qualified name of the field declaring type.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -627,7 +627,7 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` of type `{field.type}` must have a value.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` must have a value.";
 
     // A user-defined validation error format message.
     //
@@ -854,7 +854,7 @@ message PatternOption {
 message IfInvalidOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.path}` of type `{field.type}` is invalid. The field value: `{field.value}`.";
+    option (default_message) = "The field `{parent.type}.{field.path}` of the type `{field.type}` is invalid. The field value: `{field.value}`.";
 
     // A user-defined validation error format message.
     //
@@ -1100,7 +1100,7 @@ message CompareByOption {
 message IfSetAgainOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` of `{field.type}` already has the value `{field.value}` and cannot be reassigned to `{field.proposed_value}`.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` already has the value `{field.value}` and cannot be reassigned to `{field.proposed_value}`.";
 
     // A user-defined error message.
     //
@@ -1131,7 +1131,7 @@ message IfSetAgainOption {
 message IfHasDuplicatesOption {
 
     // The default error message.
-    option (default_message) = "The field `{parent.type}.{field.name}` of `{field.type}` must not contain duplicates. The found duplicates: `{field.duplicates}`.";
+    option (default_message) = "The field `{parent.type}.{field.name}` of the type `{field.type}` must not contain duplicates. The found duplicates: `{field.duplicates}`.";
 
     // A user-defined error message.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -654,6 +654,8 @@ message IfMissingOption {
     // 3. `{field.path}` – the field name along with the name of its declaring type.
     // 4. `{parent.type}` – the field declaring type.
     //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
     // Example: Using the `(if_missing)` option.
     //
     //    message Student {
@@ -666,7 +668,7 @@ message IfMissingOption {
 
 // The field value must be greater than or equal to the given minimum number.
 //
-// Is applicable only to numbers.
+// Is applicable only to number fields.
 // Repeated fields are supported.
 //
 // Example: Defining lower boundary for a numeric field.
@@ -681,13 +683,8 @@ message IfMissingOption {
 //
 message MinOption {
 
-    // The default error message format string.
-    //
-    // The format parameters are:
-    //   1) "or equal to " string (if the `exclusive` parameter is false) or an empty string;
-    //   2) the minimum number.
-    //
-    option (default_message) = "The number must be greater than %s%s.";
+    // The default error message.
+    option (default_message) = "The field '{field.path}' must be {predicate} {threshold}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -701,10 +698,19 @@ message MinOption {
     // A user-defined validation error format message.
     string msg_format = 3 [deprecated = true];
 
-    // A user-defined validation error format message.
+    // A user-defined error message.
     //
-    // May include tokens `{value}`—for the actual value of the field, and `{other}`—for
-    // the threshold value. The tokens will be replaced at runtime when the error is constructed.
+    // The specified message may include the following placeholders:
+    //
+    // 1. `{field.name}` – the field name.
+    // 2. `{field.type}` – the field type.
+    // 3. `{field.path}` – the field name along with the name of its declaring type.
+    // 3. `{parent.type}` – the field declaring type.
+    // 4. `{threshold}` – the specified minimum threshold `value`.
+    // 5. `{predicate}` – string representation of the used predicate. It equals to
+    //    "greater than or equal to" when `exclusive` is not set. Otherwise, "greater than".
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     string error_msg = 4;
 }
@@ -717,7 +723,8 @@ message MinOption {
 // Example: Defining upper boundary for a numeric field.
 //
 //     message TowerCrane {
-//         double load = 1 [(max).value = "4.2"];
+//         double load = 1 [(max).value = "4.2",
+//                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{threshold}` tons!"];
 //     }
 //
 message MaxOption {
@@ -749,12 +756,7 @@ message MaxOption {
     // 5. `{predicate}` – string representation of the used predicate. It equals to
     //    "less than or equal to" when `exclusive` is not set. Otherwise, "less than".
     //
-    // Example: Using the `(max)` option with a custom error message.
-    //
-    //     message TowerCrane {
-    //         double load = 1 [(max).value = "4.2"
-    //                          (max).error_msg = "The crane load in `{parent.type}` can not exceed `{threshold}` tons!"];
-    //     }
+    // The placeholders will be replaced at runtime when the error is constructed.
     //
     string error_msg = 4;
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.224")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.230")


### PR DESCRIPTION
This PR unifies error messages format for all Spine options. Previously, the default error messages used `printf`-style format, but the custom ones expected placeholders instead. Now, both the custom and the default messages expect a string, which may contain placeholders in an arbitrary order.

A number of placeholders have been increased to allow specifying more detailed errors.