### PR TITLE
Properly migrate the field type in `options.proto`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.230`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.231`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Dec 12 14:27:09 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Dec 13 17:22:03 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.230</version>
+<version>2.0.0-SNAPSHOT.231</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -237,12 +237,7 @@ extend google.protobuf.FieldOptions {
     //
     bool distinct = 73825;
 
-    // The option to indicate that a numeric field is required to have a value which belongs
-    // to the specified bounded range.
-    //
-    // For unbounded ranges, please use `(min)` and `(max) options.
-    //
-    RangeOption range = 73826;
+    // Reserved 73826 for deleted `range` option, which had `string` type.
 
     // Defines the error message used if a `set_once` field is set again.
     //
@@ -256,7 +251,14 @@ extend google.protobuf.FieldOptions {
     //
     IfHasDuplicatesOption if_has_duplicates = 73828;
 
-    // Reserved 73829 to 73849 for future validation options.
+    // The option to indicate that a numeric field is required to have a value which belongs
+    // to the specified bounded range.
+    //
+    // For unbounded ranges, please use `(min)` and `(max) options.
+    //
+    RangeOption range = 73829;
+
+    // Reserved 73830 to 73849 for future validation options.
 
     // API Annotations
     //-----------------

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.230")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.231")


### PR DESCRIPTION
This PR assigns a new field number to the field, which has changed the type in #842. 

Not following this convention, breaks compilation of ProtoData with `InvalidWireTypeException`. 

I've tested the local publication. ProtoData builds successfully with this change.