### PR TITLE
Introduce `Mistake`, a special kind of `RuntimeException` for human errors

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -16,4 +16,4 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v4

--- a/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
+++ b/.github/workflows/remove-obsolete-artifacts-from-packages.yaml
@@ -1,0 +1,73 @@
+#
+# Periodically removes obsolete artifacts from GitHub Packages.
+#
+# Only non-release artifacts—those containing "SNAPSHOT" in their version name—are eligible
+# for removal. The latest non-release artifacts will be retained, with the exact number determined
+# by the `VERSION_COUNT_TO_KEEP` environment variable.
+#
+# Please note the following details:
+#
+# 1. An artifact cannot be deleted if it is public and has been downloaded more than 5,000 times.
+#   In this scenario, contact GitHub support for further assistance.
+#
+# 2. This workflow only applies to artifacts published from this repository.
+#
+# 3. A maximum of 100 artifacts can be removed per run from each package;
+#   if there are more than 100 obsolete artifacts, either manually restart the workflow
+#   or wait for the next scheduled removal.
+#
+# 4. When artifacts with version `x.x.x-SNAPSHOT` are published, GitHub automatically appends
+#   the current timestamp, resulting in versions like `x.x.x-SNAPSHOT.20241024.173759`.
+#   All such artifacts are grouped into one package and treated as a single package
+#   in GitHub Packages with the version `x.x.x-SNAPSHOT`. Consequently, it is not possible
+#   to remove obsolete versions within a package; only the entire package can be deleted.
+#
+
+name: Remove obsolete Maven artifacts from GitHub Packages
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every day at midnight.
+
+env:
+  VERSION_COUNT_TO_KEEP: 5  # Number of most recent SNAPSHOT versions to retain.
+
+jobs:
+  retrieve-package-names:
+    name: Retrieve the package names published from this repository
+    runs-on: ubuntu-latest
+    outputs:
+      package-names: ${{ steps.request-package-names.outputs.package-names }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+
+      - name: Retrieve the names of packages
+        id: request-package-names
+        shell: bash
+        run: |
+          repoName=$(echo ${{ github.repository }} | cut -d '/' -f2)
+          chmod +x ./config/scripts/request-package-names.sh
+          ./config/scripts/request-package-names.sh ${{ github.token }} \
+                $repoName ${{ github.repository_owner }} ./package-names.json
+          echo "package-names=$(<./package-names.json)" >> $GITHUB_OUTPUT
+
+  delete-obsolete-artifacts:
+    name: Remove obsolete artifacts published from this repository to GitHub Packages
+    needs: retrieve-package-names
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package-name: ${{ fromJson(needs.retrieve-package-names.outputs.package-names) }}
+    steps:
+      - name: Remove obsolete artifacts from '${{ matrix.package-name }}' package
+        uses: actions/delete-package-versions@v5
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: ${{ matrix.package-name }}
+          package-type: 'maven'
+          token: ${{ github.token }}
+          min-versions-to-keep: ${{ env.VERSION_COUNT_TO_KEEP }}
+          # Ignores artifacts that do not contain the word "SNAPSHOT".
+          ignore-versions: '^(?!.+SNAPSHOT).*$'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,8 @@ import io.spine.dependency.lib.AutoServiceKsp
 import io.spine.dependency.lib.Kotlin
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Logging
-import io.spine.dependency.local.Spine
+import io.spine.dependency.local.Reflect
+import io.spine.dependency.local.TestLib
 import io.spine.gradle.publish.IncrementGuard
 import io.spine.gradle.publish.PublishingRepos
 import io.spine.gradle.publish.excludeGoogleProtoFromArtifacts
@@ -80,7 +81,7 @@ dependencies {
     ksp(AutoServiceKsp.processor)
 
     implementation(Logging.lib)
-    implementation(Spine.reflect)
+    implementation(Reflect.lib)
     implementation(Kotlin.reflect)
 
     /* Have `protobuf` dependency instead of `api` or `implementation` so that proto
@@ -92,13 +93,13 @@ dependencies {
     */
     protobuf(Protobuf.protoSrcLib)
 
-    testImplementation(Spine.testlib)
+    testImplementation(TestLib.lib)
     testImplementation(Logging.smokeTest)
 }
 
 configurations.all {
     resolutionStrategy {
-        force(Spine.reflect)
+        force(Reflect.lib)
         force(Logging.lib)
         force(Logging.libJvm)
     }

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -46,6 +46,7 @@ import io.spine.dependency.lib.Okio
 import io.spine.dependency.lib.Plexus
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.lib.Slf4J
+import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
 import io.spine.dependency.test.Hamcrest
 import io.spine.dependency.test.JUnit
@@ -186,7 +187,7 @@ fun ModuleDependency.excludeSpineBase() {
 fun Project.forceSpineBase() {
     configurations.all {
         resolutionStrategy {
-            force(Spine.base)
+            force(Base.lib)
         }
     }
 }
@@ -200,7 +201,7 @@ fun Project.forceBaseInProtoTasks() {
     configurations.configureEach {
         if (name.lowercased().contains("proto")) {
             resolutionStrategy {
-                force(Spine.baseForBuildScript)
+                force(Base.libForBuildScript)
             }
         }
     }

--- a/buildSrc/src/main/kotlin/Strings.kt
+++ b/buildSrc/src/main/kotlin/Strings.kt
@@ -24,6 +24,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.gradle.configurationcache.extensions.capitalized
+
 /**
  * This file provides extensions to `String` and `CharSequence` that wrap
  * analogues from standard Kotlin runtime.
@@ -42,18 +44,18 @@ private const val ABOUT = ""
  * Makes the first character come in the title case.
  */
 fun String.titleCaseFirstChar(): String {
-     return replaceFirstChar { it.titlecase() }
+    // return replaceFirstChar { it.titlecase() }
     // OR for earlier Kotlin versions:
     //   1. add import of `org.gradle.configurationcache.extensions.capitalized`
     //   2. call `capitalized()` instead of `replaceFirstChar` above.
-    // return capitalized()
+    return capitalized()
 }
 
 /**
  * Converts this string to lowercase.
  */
 fun String.lowercased(): String {
-    return lowercase()
+    //    return lowercase()
     // OR for earlier Kotlin versions call:
-    // return toLowerCase()
+    return toLowerCase()
 }

--- a/buildSrc/src/main/kotlin/Strings.kt
+++ b/buildSrc/src/main/kotlin/Strings.kt
@@ -24,8 +24,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import org.gradle.configurationcache.extensions.capitalized
-
 /**
  * This file provides extensions to `String` and `CharSequence` that wrap
  * analogues from standard Kotlin runtime.
@@ -44,18 +42,18 @@ private const val ABOUT = ""
  * Makes the first character come in the title case.
  */
 fun String.titleCaseFirstChar(): String {
-    // return replaceFirstChar { it.titlecase() }
+     return replaceFirstChar { it.titlecase() }
     // OR for earlier Kotlin versions:
     //   1. add import of `org.gradle.configurationcache.extensions.capitalized`
     //   2. call `capitalized()` instead of `replaceFirstChar` above.
-    return capitalized()
+    //    return capitalized()
 }
 
 /**
  * Converts this string to lowercase.
  */
 fun String.lowercased(): String {
-    //    return lowercase()
+        return lowercase()
     // OR for earlier Kotlin versions call:
-    return toLowerCase()
+    // return toLowerCase()
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
@@ -31,17 +31,20 @@ package io.spine.dependency.build
 object ErrorProne {
     // https://github.com/google/error-prone
     private const val version = "2.23.0"
+
+    const val group = "com.google.errorprone"
+
     // https://github.com/tbroyer/gradle-errorprone-plugin/blob/v0.8/build.gradle.kts
     private const val javacPluginVersion = "9+181-r4173-1"
 
     val annotations = listOf(
-        "com.google.errorprone:error_prone_annotations:$version",
-        "com.google.errorprone:error_prone_type_annotations:$version"
+        "$group:error_prone_annotations:$version",
+        "$group:error_prone_type_annotations:$version"
     )
-    const val core = "com.google.errorprone:error_prone_core:$version"
-    const val checkApi = "com.google.errorprone:error_prone_check_api:$version"
-    const val testHelpers = "com.google.errorprone:error_prone_test_helpers:$version"
-    const val javacPlugin  = "com.google.errorprone:javac:$javacPluginVersion"
+    const val core = "$group:error_prone_core:$version"
+    const val checkApi = "$group:error_prone_check_api:$version"
+    const val testHelpers = "$group:error_prone_test_helpers:$version"
+    const val javacPlugin  = "$group:javac:$javacPluginVersion"
 
     // https://github.com/tbroyer/gradle-errorprone-plugin/releases
     object GradlePlugin {

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Asm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Asm.kt
@@ -30,13 +30,14 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object Asm {
     private const val version = "9.6"
-    const val lib = "org.ow2.asm:asm:$version"
+    const val group = "org.ow2.asm"
+    const val lib = "$group:asm:$version"
 
     // We use the following artifacts only to force the versions
     // of the dependencies which are transitive for us.
     //
-    const val tree = "org.ow2.asm:asm-tree:$version"
-    const val analysis = "org.ow2.asm:asm-analysis:$version"
-    const val util = "org.ow2.asm:asm-util:$version"
-    const val commons = "org.ow2.asm:asm-commons:$version"
+    const val tree = "$group:asm-tree:$version"
+    const val analysis = "$group:asm-analysis:$version"
+    const val util = "$group:asm-util:$version"
+    const val commons = "$group:asm-commons:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Grpc.kt
@@ -31,20 +31,21 @@ package io.spine.dependency.lib
 object Grpc {
     @Suppress("MemberVisibilityCanBePrivate")
     const val version        = "1.59.0"
-    const val api            = "io.grpc:grpc-api:$version"
-    const val auth           = "io.grpc:grpc-auth:$version"
-    const val core           = "io.grpc:grpc-core:$version"
-    const val context        = "io.grpc:grpc-context:$version"
-    const val inProcess      = "io.grpc:grpc-inprocess:$version"
-    const val stub           = "io.grpc:grpc-stub:$version"
-    const val okHttp         = "io.grpc:grpc-okhttp:$version"
-    const val protobuf       = "io.grpc:grpc-protobuf:$version"
-    const val protobufLite   = "io.grpc:grpc-protobuf-lite:$version"
-    const val netty          = "io.grpc:grpc-netty:$version"
-    const val nettyShaded    = "io.grpc:grpc-netty-shaded:$version"
+    const val group          = "io.grpc"
+    const val api            = "$group:grpc-api:$version"
+    const val auth           = "$group:grpc-auth:$version"
+    const val core           = "$group:grpc-core:$version"
+    const val context        = "$group:grpc-context:$version"
+    const val inProcess      = "$group:grpc-inprocess:$version"
+    const val stub           = "$group:grpc-stub:$version"
+    const val okHttp         = "$group:grpc-okhttp:$version"
+    const val protobuf       = "$group:grpc-protobuf:$version"
+    const val protobufLite   = "$group:grpc-protobuf-lite:$version"
+    const val netty          = "$group:grpc-netty:$version"
+    const val nettyShaded    = "$group:grpc-netty-shaded:$version"
 
     object ProtocPlugin {
         const val id = "grpc"
-        const val artifact = "io.grpc:protoc-gen-grpc-java:$version"
+        const val artifact = "$group:protoc-gen-grpc-java:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaPoet.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaPoet.kt
@@ -30,5 +30,8 @@ package io.spine.dependency.lib
 @Suppress("unused", "ConstPropertyName")
 object JavaPoet {
     private const val version = "1.13.0"
-    const val lib = "com.squareup:javapoet:$version"
+    const val group = "com.squareup"
+    const val artifact = "javapoet"
+    const val module = "$group:$artifact"
+    const val lib = "$module:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/JavaX.kt
@@ -30,7 +30,8 @@ package io.spine.dependency.lib
 object JavaX {
     // This artifact, which used to be a part of J2EE, moved under the Eclipse EE4J project.
     // https://github.com/eclipse-ee4j/common-annotations-api
-    const val annotations = "javax.annotation:javax.annotation-api:1.3.2"
+    const val annotationGroup = "javax.annotation"
+    const val annotations = "$annotationGroup:javax.annotation-api:1.3.2"
 
     const val servletApi = "javax.servlet:javax.servlet-api:3.1.0"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
@@ -34,8 +34,9 @@ object KotlinX {
     object Coroutines {
 
         // https://github.com/Kotlin/kotlinx.coroutines
-        const val version = "1.7.3"
+        const val version = "1.9.0"
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val jdk8 = "$group:kotlinx-coroutines-jdk8:$version"
+        const val test = "$group:kotlinx-coroutines-test:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Protobuf.kt
@@ -32,7 +32,7 @@ package io.spine.dependency.lib
     "ConstPropertyName" /* https://bit.ly/kotlin-prop-names */
 )
 object Protobuf {
-    private const val group = "com.google.protobuf"
+    const val group = "com.google.protobuf"
     const val version       = "3.25.1"
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Roaster.kt
@@ -39,6 +39,7 @@ object Roaster {
      */
     private const val version = "2.28.0.Final"
 
-    const val api = "org.jboss.forge.roaster:roaster-api:$version"
-    const val jdt = "org.jboss.forge.roaster:roaster-jdt:$version"
+    const val group = "org.jboss.forge.roaster"
+    const val api = "$group:roaster-api:$version"
+    const val jdt = "$group:roaster-jdt:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ArtifactVersion.kt
@@ -37,15 +37,23 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
      */
-    const val base = "2.0.0-SNAPSHOT.215"
-    const val baseForBuildScript = "2.0.0-SNAPSHOT.215"
+    @Deprecated(message = "Please use `Base.version`.", ReplaceWith("Base.version"))
+    const val base = Base.version
+
+    @Suppress("unused")
+    @Deprecated(
+        message = "Please use `Base.versionForBuildScript`.",
+        ReplaceWith("Base.versionForBuildScript")
+    )
+    const val baseForBuildScript = Base.versionForBuildScript
 
     /**
      * The version of [Spine.reflect].
      *
      * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
      */
-    const val reflect = "2.0.0-SNAPSHOT.191"
+    @Deprecated(message = "Please use `Reflect.version`.", ReplaceWith("Reflect.version"))
+    const val reflect = Reflect.version
 
     /**
      * The version of [Logging].
@@ -58,7 +66,8 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
      */
-    const val testlib = "2.0.0-SNAPSHOT.184"
+    @Deprecated(message = "Please use `TestLib.version`.", ReplaceWith("TestLib.version"))
+    const val testlib = TestLib.version
 
     /**
      * The version of `core-java`.
@@ -71,41 +80,51 @@ object ArtifactVersion {
      *
      * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
      */
-    const val mc = "2.0.0-SNAPSHOT.133"
+    @Deprecated(
+        message = "Please use `ModelCompiler.version` instead.",
+        ReplaceWith("ModelCompiler.version")
+    )
+    const val mc = ModelCompiler.version
 
     /**
      * The version of [Spine.baseTypes].
      *
      * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
      */
-    const val baseTypes = "2.0.0-SNAPSHOT.126"
+    @Deprecated(message = "Please use `BaseTypes.version`.", ReplaceWith("BaseTypes.version"))
+    const val baseTypes = BaseTypes.version
 
     /**
      * The version of [Spine.time].
      *
      * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
      */
-    const val time = "2.0.0-SNAPSHOT.135"
+    @Deprecated(message = "Please use `Time.version`.", ReplaceWith("Time.version"))
+    const val time = Time.version
 
     /**
      * The version of [Spine.change].
      *
      * @see <a href="https://github.com/SpineEventEngine/change">spine-change</a>
      */
-    const val change = "2.0.0-SNAPSHOT.118"
+    @Deprecated(message = "Please use `Change.version`.", ReplaceWith("Change.version"))
+    const val change = Change.version
 
     /**
      * The version of [Spine.text].
      *
      * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
      */
-    const val text = "2.0.0-SNAPSHOT.6"
+    @Deprecated(message = "Please use `Text.version`.", ReplaceWith("Text.version"))
+    const val text = Text.version
 
     /**
      * The version of [Spine.toolBase].
      *
      * @see <a href="https://github.com/SpineEventEngine/tool-base">spine-tool-base</a>
      */
+    @Suppress("unused")
+    @Deprecated(message = "Please use `ToolBase.version`.", ReplaceWith("ToolBase.version"))
     const val toolBase = ToolBase.version
 
     /**

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -24,21 +24,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Base module.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/base">spine-base</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Base {
+    const val version = "2.0.0-SNAPSHOT.224"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.224"
+    const val group = Spine.group
+    const val artifact = "spine-base"
+    const val lib = "$group:$artifact:$version"
+    const val libForBuildScript = "$group:$artifact:$versionForBuildScript"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/BaseTypes.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/BaseTypes.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Base module.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/base-types">spine-base-types</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object BaseTypes {
+    const val version = "2.0.0-SNAPSHOT.126"
+    const val group = Spine.group
+    const val artifact = "spine-base-types"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Change.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/change">spine-change</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Change {
+    const val version = "2.0.0-SNAPSHOT.118"
+    const val group = Spine.group
+    const val artifact = "spine-change"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,9 +34,15 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.177"
-    const val core = "$group:spine-core:$version"
-    const val client = "$group:spine-client:$version"
-    const val server = "$group:spine-server:$version"
+    const val version = "2.0.0-SNAPSHOT.182"
+
+    const val coreArtifact = "spine-core"
+    const val clientArtifact = "spine-client"
+    const val serverArtifact = "spine-server"
+
+    const val core = "$group:$coreArtifact:$version"
+    const val client = "$group:$clientArtifact:$version"
+    const val server = "$group:$serverArtifact:$version"
+
     const val testUtilServer = "${Spine.toolsGroup}:spine-testutil-server:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Logging.kt
@@ -35,7 +35,10 @@ package io.spine.dependency.local
 object Logging {
     const val version = "2.0.0-SNAPSHOT.242"
     const val group = Spine.group
-    const val lib = "$group:spine-logging:$version"
+
+    const val loggingArtifact = "spine-logging"
+
+    const val lib = "$group:$loggingArtifact:$version"
     const val libJvm = "$group:spine-logging-jvm:$version"
 
     const val log4j2Backend = "$group:spine-logging-log4j2-backend:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ModelCompiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ModelCompiler.kt
@@ -27,53 +27,14 @@
 package io.spine.dependency.local
 
 /**
- * Dependencies on Spine Model Compiler for Java.
+ * Spine Model Compiler Gradle API.
  *
- * See [mc-java](https://github.com/SpineEventEngine/mc-java).
+ * @see <a href="https://github.com/SpineEventEngine/model-compiler">spine-model-compiler</a>
  */
-@Suppress(
-    "MemberVisibilityCanBePrivate" /* `pluginLib()` is used by subprojects. */,
-    "ConstPropertyName",
-    "unused"
-)
-object McJava {
+@Suppress("ConstPropertyName")
+object ModelCompiler {
+    const val version = "2.0.0-SNAPSHOT.133"
     const val group = Spine.toolsGroup
-
-    /**
-     * The version used to in the build classpath.
-     */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.259"
-
-    /**
-     * The version to be used for integration tests.
-     */
-    const val version = "2.0.0-SNAPSHOT.259"
-
-    /**
-     * The ID of the Gradle plugin.
-     */
-    const val pluginId = "io.spine.mc-java"
-
-    /**
-     * The library with the [dogfoodingVersion].
-     */
-    val pluginLib = pluginLib(dogfoodingVersion)
-
-    /**
-     * The library with the given [version].
-     */
-    fun pluginLib(version: String): String = "$group:spine-mc-java-plugins:$version:all"
-
-    /** The artifact reference for forcing in configurations. */
-    const val pluginsArtifact: String = "$group:spine-mc-java-plugins:$version"
-
-    /**
-     * The `mc-java-base` artifact with the [version].
-     */
-    val base = base(version)
-
-    /**
-     * The `mc-java-base` artifact with the given [version].
-     */
-    fun base(version: String): String = "$group:spine-mc-java-base:$version"
+    const val artifact = "spine-model-compiler"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.64.0"
+    private const val fallbackVersion = "0.70.1"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.61.8"
+    private const val fallbackDfVersion = "0.70.1"
 
     /**
      * The artifact for the ProtoData Gradle plugin.
@@ -115,8 +115,10 @@ object ProtoData {
     val cliApi
         get() = "$group:protodata-cli-api:$version"
 
+    val javaModule = "$group:protodata-java"
+
     fun java(version: String): String =
-        "$group:protodata-java:$version"
+        "$javaModule:$version"
 
     val java
         get() = java(version)

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Reflect.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Reflect.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/reflect">spine-reflect</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Reflect {
+    const val version = "2.0.0-SNAPSHOT.191"
+    const val group = Spine.group
+    const val artifact = "spine-reflect"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Spine.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Spine.kt
@@ -35,30 +35,59 @@ object Spine {
     const val group = "io.spine"
     const val toolsGroup = "io.spine.tools"
 
-    const val base = "$group:spine-base:${ArtifactVersion.base}"
-    const val baseForBuildScript = "$group:spine-base:${ArtifactVersion.baseForBuildScript}"
+    @Deprecated(message = "Please use `Base.lib`.", ReplaceWith("Base.lib"))
+    const val base = Base.lib
 
-    const val reflect = "$group:spine-reflect:${ArtifactVersion.reflect}"
-    const val baseTypes = "$group:spine-base-types:${ArtifactVersion.baseTypes}"
-    const val time = "$group:spine-time:${ArtifactVersion.time}"
-    const val change = "$group:spine-change:${ArtifactVersion.change}"
-    const val text = "$group:spine-text:${ArtifactVersion.text}"
+    @Deprecated(
+        message = "Please use `Base.libForBuildScript`.",
+        ReplaceWith("Base.libForBuildScript")
+    )
+    const val baseForBuildScript = Base.libForBuildScript
 
-    const val testlib = "$toolsGroup:spine-testlib:${ArtifactVersion.testlib}"
-    const val testUtilTime = "$toolsGroup:spine-testutil-time:${ArtifactVersion.time}"
+    @Deprecated(message = "Please use `Reflect.lib`.", ReplaceWith("Reflect.lib"))
+    const val reflect = Reflect.lib
+
+    @Deprecated(message = "Please use `BaseTypes.lib`.", ReplaceWith("BaseTypes.lib"))
+    const val baseTypes = BaseTypes.lib
+
+    @Deprecated(message = "Please use `Time.lib`.", ReplaceWith("Time.lib"))
+    const val time = Time.lib
+
+    @Deprecated(message = "Please use `Time.lib`.", ReplaceWith("Time.lib"))
+    const val change = Change.lib
+
+    @Deprecated(message = "Please use `Text.lib`.", ReplaceWith("Text.lib"))
+    const val text = Text.lib
+
+    @Deprecated(message = "Please use `TestLib.lib`.", ReplaceWith("TestLib.lib"))
+    const val testlib = TestLib.lib
+
+    @Deprecated(message = "Please use `Time.testLib`.", ReplaceWith("Time.testLib"))
+    const val testUtilTime = Time.testLib
 
     @Deprecated(message = "Please use `ToolBase.psiJava` instead`.")
-    const val psiJava = "$toolsGroup:spine-psi-java:${ArtifactVersion.toolBase}"
+    const val psiJava = "$toolsGroup:spine-psi-java:${ToolBase.version}"
+
     @Deprecated(message = "Please use `ToolBase.psiJava` instead`.")
-    const val psiJavaBundle = "$toolsGroup:spine-psi-java-bundle:${ArtifactVersion.toolBase}"
+    const val psiJavaBundle = "$toolsGroup:spine-psi-java-bundle:${ToolBase.version}"
+
     @Deprecated(message = "Please use `ToolBase.lib` instead`.")
-    const val toolBase = "$toolsGroup:spine-tool-base:${ArtifactVersion.toolBase}"
-    @Deprecated(message = "Please use `ToolBase.pluginBase` instead`.")
-    const val pluginBase = "$toolsGroup:spine-plugin-base:${ArtifactVersion.toolBase}"
-    @Deprecated(message = "Please use `ToolBase.pluginTestlib` instead`.")
-    const val pluginTestlib = "$toolsGroup:spine-plugin-testlib:${ArtifactVersion.toolBase}"
+    const val toolBase = "$toolsGroup:spine-tool-base:${ToolBase.version}"
 
-    const val modelCompiler = "$toolsGroup:spine-model-compiler:${ArtifactVersion.mc}"
+    @Deprecated(message = "Please use `ToolBase.pluginBase` instead`.")
+    const val pluginBase = "$toolsGroup:spine-plugin-base:${ToolBase.version}"
+
+    @Deprecated(
+        message = "Please use `ToolBase.pluginTestlib` instead`.",
+        ReplaceWith("ToolBase.pluginTestlib")
+    )
+    const val pluginTestlib = ToolBase.pluginTestlib
+
+    @Deprecated(
+        message = "Please use `ModelCompiler.lib` instead.",
+        ReplaceWith("ModelCompiler.lib")
+    )
+    const val modelCompiler = ModelCompiler.lib
 
     @Deprecated(
         message = "Please use top level `McJava` object instead.",

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/TestLib.kt
@@ -27,53 +27,14 @@
 package io.spine.dependency.local
 
 /**
- * Dependencies on Spine Model Compiler for Java.
+ * Spine TestLib library.
  *
- * See [mc-java](https://github.com/SpineEventEngine/mc-java).
+ * @see <a href="https://github.com/SpineEventEngine/testlib">spine-testlib</a>
  */
-@Suppress(
-    "MemberVisibilityCanBePrivate" /* `pluginLib()` is used by subprojects. */,
-    "ConstPropertyName",
-    "unused"
-)
-object McJava {
+@Suppress("ConstPropertyName")
+object TestLib {
+    const val version = "2.0.0-SNAPSHOT.184"
     const val group = Spine.toolsGroup
-
-    /**
-     * The version used to in the build classpath.
-     */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.259"
-
-    /**
-     * The version to be used for integration tests.
-     */
-    const val version = "2.0.0-SNAPSHOT.259"
-
-    /**
-     * The ID of the Gradle plugin.
-     */
-    const val pluginId = "io.spine.mc-java"
-
-    /**
-     * The library with the [dogfoodingVersion].
-     */
-    val pluginLib = pluginLib(dogfoodingVersion)
-
-    /**
-     * The library with the given [version].
-     */
-    fun pluginLib(version: String): String = "$group:spine-mc-java-plugins:$version:all"
-
-    /** The artifact reference for forcing in configurations. */
-    const val pluginsArtifact: String = "$group:spine-mc-java-plugins:$version"
-
-    /**
-     * The `mc-java-base` artifact with the [version].
-     */
-    val base = base(version)
-
-    /**
-     * The `mc-java-base` artifact with the given [version].
-     */
-    fun base(version: String): String = "$group:spine-mc-java-base:$version"
+    const val artifact = "spine-testlib"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Text.kt
@@ -24,21 +24,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Reflect library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/text">spine-text</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Text {
+    const val version = "2.0.0-SNAPSHOT.6"
+    const val group = Spine.group
+    const val artifact = "spine-text"
+    const val lib = "$group:$artifact:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Time.kt
@@ -24,21 +24,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.dependency.lib
+package io.spine.dependency.local
 
 /**
- * The dependencies for Guava.
+ * Spine Time library.
  *
- * When changing the version, also change the version used in the `build.gradle.kts`. We need
- * to synchronize the version used in `buildSrc` and in Spine modules. Otherwise, when testing
- * Gradle plugins, errors may occur due to version clashes.
- *
- * @see <a href="https://github.com/google/guava">Guava at GitHub</a>.
+ * @see <a href="https://github.com/SpineEventEngine/time">spine-time</a>
  */
-@Suppress("unused", "ConstPropertyName")
-object Guava {
-    private const val version = "32.1.3-jre"
-    const val group = "com.google.guava"
-    const val lib     = "$group:guava:$version"
-    const val testLib = "$group:guava-testlib:$version"
+@Suppress("ConstPropertyName")
+object Time {
+    const val version = "2.0.0-SNAPSHOT.135"
+    const val group = Spine.group
+    const val artifact = "spine-time"
+    const val lib = "$group:$artifact:$version"
+
+    //TODO:2024-11-29:alexander.yevsyukov: Change the artifact name to `spine-time-testlib`.
+    const val testLib = "${Spine.toolsGroup}:spine-testutil-time:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.233"
+    const val version = "2.0.0-SNAPSHOT.234"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -31,21 +31,24 @@ package io.spine.dependency.local
  *
  * See [`SpineEventEngine/validation`](https://github.com/SpineEventEngine/validation/).
  */
-@Suppress("unused", "ConstPropertyName")
+@Suppress("ConstPropertyName")
 object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.160"
+    const val version = "2.0.0-SNAPSHOT.178"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"
 
-    const val runtime = "$group:$prefix-java-runtime:$version"
+    const val runtimeModule = "$group:$prefix-java-runtime"
+    const val runtime = "$runtimeModule:$version"
     const val java = "$group:$prefix-java:$version"
 
+    const val javaBundleModule = "$group:$prefix-java-bundle"
+
     /** Obtains the artifact for the `java-bundle` artifact of the given version. */
-    fun javaBundle(version: String) = "$group:$prefix-java-bundle:$version"
+    fun javaBundle(version: String) = "$javaBundleModule:$version"
 
     val javaBundle = javaBundle(version)
 

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -29,14 +29,14 @@ package io.spine.dependency.test
 // https://junit.org/junit5/
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
-    const val version = "5.11.3"
+    const val version = "5.10.0"
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
     private const val apiGuardianVersion = "1.1.2"
 
     // https://github.com/junit-pioneer/junit-pioneer
-    private const val pioneerVersion = "2.3.0"
+    private const val pioneerVersion = "2.0.1"
 
     const val legacy = "junit:junit:$legacyVersion"
 
@@ -54,7 +54,7 @@ object JUnit {
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.11.3"
+        const val version = "1.10.0"
         internal const val group = "org.junit.platform"
         const val commons = "$group:junit-platform-commons:$version"
         const val launcher = "$group:junit-platform-launcher:$version"

--- a/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
@@ -55,9 +55,8 @@ fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
 fun KotlinCompile.setFreeCompilerArgs() {
     // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20.
     // See: https://youtrack.jetbrains.com/issue/KT-61573
-    val expectActualClasses = KotlinVersion.CURRENT.run {
-        if (isAtLeast(1, 9, 20) && major < 2) "-Xexpect-actual-classes" else ""
-    }
+    val expectActualClasses =
+        if (KotlinVersion.CURRENT.isAtLeast(1, 9, 20)) "-Xexpect-actual-classes" else ""
     kotlinOptions {
         freeCompilerArgs = listOf(
             "-Xskip-prerelease-check",

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -25,6 +25,7 @@
  */
 
 import BuildSettings.javaVersion
+import Jvm_module_gradle.Module
 import io.spine.dependency.build.CheckerFramework
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
@@ -32,7 +33,8 @@ import io.spine.dependency.lib.Guava
 import io.spine.dependency.lib.JavaX
 import io.spine.dependency.lib.Protobuf
 import io.spine.dependency.local.Logging
-import io.spine.dependency.local.Spine
+import io.spine.dependency.local.Reflect
+import io.spine.dependency.local.TestLib
 import io.spine.dependency.test.JUnit
 import io.spine.dependency.test.Jacoco
 import io.spine.dependency.test.Kotest
@@ -144,7 +146,7 @@ fun Module.addDependencies() = dependencies {
     testImplementation(JUnit.pioneer)
     JUnit.api.forEach { testImplementation(it) }
 
-    testImplementation(Spine.testlib)
+    testImplementation(TestLib.lib)
     testImplementation(Kotest.frameworkEngine)
     testImplementation(Kotest.datatest)
     testImplementation(Kotest.runnerJUnit5Jvm)
@@ -161,7 +163,7 @@ fun Module.forceConfigurations() {
                     JUnit.bom,
                     JUnit.runner,
                     Dokka.BasePlugin.lib,
-                    Spine.reflect
+                    Reflect.lib,
                 )
             }
         }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.231`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.232`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -770,39 +770,39 @@
      * **Project URL:** [https://jsoup.org/](https://jsoup.org/)
      * **License:** [The MIT License](https://jsoup.org/license)
 
-1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.11.3.
+1.  **Group** : org.junit. **Name** : junit-bom. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 2.3.0.
+1.  **Group** : org.junit-pioneer. **Name** : junit-pioneer. **Version** : 2.0.1.
      * **Project URL:** [https://junit-pioneer.org/](https://junit-pioneer.org/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.11.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-api. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.11.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-engine. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.11.3.
+1.  **Group** : org.junit.jupiter. **Name** : junit-jupiter-params. **Version** : 5.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.11.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-commons. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.11.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-engine. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.11.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-launcher. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
-1.  **Group** : org.junit.platform. **Name** : junit-platform-suite-api. **Version** : 1.11.3.
+1.  **Group** : org.junit.platform. **Name** : junit-platform-suite-api. **Version** : 1.10.0.
      * **Project URL:** [https://junit.org/junit5/](https://junit.org/junit5/)
      * **License:** [Eclipse Public License v2.0](https://www.eclipse.org/legal/epl-v20.html)
 
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Dec 13 17:22:03 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 14 19:12:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 14 19:12:06 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sat Dec 14 19:22:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.231</version>
+<version>2.0.0-SNAPSHOT.232</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -116,25 +116,25 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit-pioneer</groupId>
     <artifactId>junit-pioneer</artifactId>
-    <version>2.3.0</version>
+    <version>2.0.1</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
-    <version>5.11.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.11.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-params</artifactId>
-    <version>5.11.3</version>
+    <version>5.10.0</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/src/main/kotlin/io/spine/base/Mistake.kt
+++ b/src/main/kotlin/io/spine/base/Mistake.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2024, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.base
+
+/**
+ * A special kind of [Throwable] that requires more fine-tuned treatment
+ * when catching or propagating.
+ *
+ * @param message The human-readable text with the details on the problem.
+ * @param cause The cause of this mistake.
+ */
+public abstract class Mistake(message: String?, cause: Throwable?) : Throwable(message, cause) {
+
+    /**
+     * Creates an instance with an optional message.
+     */
+    public constructor(message: String?) : this(message, null)
+
+    /**
+     * Creates an instance with an optional cause.
+     *
+     * If the cause is provided its
+     */
+    public constructor(cause: Throwable?) : this(cause?.toString(), cause)
+
+    /**
+     * Creates an instance without a message or a cause.
+     */
+    public constructor() : this(null, null)
+
+    public companion object {
+        private const val serialVersionUID: Long = 0L
+    }
+}

--- a/src/test/java/io/spine/base/MistakeJavaSpec.java
+++ b/src/test/java/io/spine/base/MistakeJavaSpec.java
@@ -24,40 +24,29 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.base
+package io.spine.base;
 
-/**
- * A special kind of [RuntimeException] that represents an error, such as a programming or
- * a system configuration error made by a human or a software agent.
- *
- * Unlike [java.lang.Error], descendants of this class are meant to be caught.
- * Also, mistakes are going to be treated differently than other exceptions in
- * terms of catching, propagating, or logging.
- *
- * @param message The human-readable text with the details on the problem.
- * @param cause The cause of this mistake.
- */
-public abstract class Mistake(message: String?, cause: Throwable?) :
-    RuntimeException(message, cause) {
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-    /**
-     * Creates an instance with an optional message.
-     */
-    public constructor(message: String?) : this(message, null)
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-    /**
-     * Creates an instance with an optional cause.
-     *
-     * If the cause is provided its string form serves as a message.
-     */
-    public constructor(cause: Throwable?) : this(cause?.toString(), cause)
+@DisplayName("`Mistake` Java API should")
+class MistakeJavaSpec {
 
-    /**
-     * Creates an instance without a message or a cause.
-     */
-    public constructor() : this(null, null)
+    @Test
+    @DisplayName("not require `throws` clause in a method")
+    void noThrowsClause() {
+        assertThrows(JMistake.class, MistakeJavaSpec::throwsMistake);
+    }
 
-    public companion object {
-        private const val serialVersionUID: Long = 0L
+    private static void throwsMistake() {
+        throw new JMistake();
+    }
+
+    @SuppressWarnings("ExceptionClassNameDoesntEndWithException")
+    private static class JMistake extends Mistake {
+
+        private static final long serialVersionUID = 0L;
     }
 }

--- a/src/test/kotlin/io/spine/base/MistakeSpec.kt
+++ b/src/test/kotlin/io/spine/base/MistakeSpec.kt
@@ -26,38 +26,56 @@
 
 package io.spine.base
 
-/**
- * A special kind of [RuntimeException] that represents an error, such as a programming or
- * a system configuration error made by a human or a software agent.
- *
- * Unlike [java.lang.Error], descendants of this class are meant to be caught.
- * Also, mistakes are going to be treated differently than other exceptions in
- * terms of catching, propagating, or logging.
- *
- * @param message The human-readable text with the details on the problem.
- * @param cause The cause of this mistake.
- */
-public abstract class Mistake(message: String?, cause: Throwable?) :
-    RuntimeException(message, cause) {
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
 
-    /**
-     * Creates an instance with an optional message.
-     */
-    public constructor(message: String?) : this(message, null)
+@DisplayName("`Mistake` should")
+internal class MistakeSpec {
 
-    /**
-     * Creates an instance with an optional cause.
-     *
-     * If the cause is provided its string form serves as a message.
-     */
-    public constructor(cause: Throwable?) : this(cause?.toString(), cause)
+    @Test
+    fun `provide no arg constructor`() {
+        KMistake().let {
+            it.message shouldBe null
+            it.cause shouldBe null
+        }
+    }
 
-    /**
-     * Creates an instance without a message or a cause.
-     */
-    public constructor() : this(null, null)
+    @Test
+    fun `have a cause`() {
+        val cause = Exception("The cause")
+        KMistake(cause).let {
+            it.cause shouldBe cause
+            it.message shouldBe cause.toString()
+        }
+    }
 
-    public companion object {
+    @Test
+    fun `have a message`() {
+        val message = "The message"
+        KMistake(message).let {
+            it.message shouldBe message
+            it.cause shouldBe null
+        }
+    }
+
+    @Test
+    fun `have both cause and message`() {
+        val message = "Tango"
+        val cause = Exception("Triplet")
+        KMistake(message, cause).let {
+            it.message shouldBe message
+            it.cause shouldBe cause
+        }
+    }
+}
+
+private class KMistake(message: String?, cause: Throwable?) : Mistake(message, cause) {
+    constructor(message: String?) : this(message, null)
+    constructor(cause: Throwable?) : this(cause?.toString(), cause)
+    constructor() : this(null, null)
+
+    companion object {
         private const val serialVersionUID: Long = 0L
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.231")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.232")


### PR DESCRIPTION
This PR introduces an exception class called `Mistake` which is meant to be something like `java.lang.Error` but for programming or configuration errors that are meant to be caught in the code.

We need to have special treatment of programming errors in the tools based on Spine. In particular, in handling exceptions thrown by message handling code. Currently, everything `Throwable` is caught and logged. 

We need a special way for handling problems that are discovered in the code. We do not want to derive exceptions for those problems from `java.lang.Error` because we want to treat everything derived from `Error` similarly to the rest of `Throwable`s, that is, have such unexpected problems logged, etc. Hence, the need for an abstract grouping base for those problems.
