### PR TITLE
Mark `(default_message)` as `internal`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.232`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.233`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sat Dec 14 19:22:12 WET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Dec 18 17:20:44 CET 2024** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.232</version>
+<version>2.0.0-SNAPSHOT.233</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -348,18 +348,27 @@ extend google.protobuf.MessageOptions {
     // Validation Constraints
     //------------------------
 
-    // The default format string for validation error message text.
+    // The default validation error message.
     //
-    // This option extends message types that extend `FieldOptions`
-    // The number of parameters and their types are determined by the type of field options.
+    // Please note, this option is intended for INTERNAL USE only. It applies to message types
+    // that extend `FieldOptions` and is not intended for external usage.
     //
-    // Usage of this value is deprecated. Along with the old `msg_format`s, it exists to support
-    // the old version of the Validation library.
-    // The new version of the Validation library, which does not lie in the `base` repository,
-    // constructs the default error messages separately when creating language-agnostic
-    // validation rules.
+    // If a validation option detects a constraint violation and no custom error message is defined
+    // for that specific option, it will fall back to the message specified by `(default_message)`.
     //
-    string default_message = 73901 [deprecated = true];
+    // For example, here is how to declare the default message for `(goes)` option:
+    //
+    // ```
+    // message GoesOption {
+    //   // The default error message.
+    //   option (default_message) = "The field `{goes.companion}` must also be set when `{field.name}` is set.";
+    // }
+    // ```
+    //
+    // Note: The placeholders available within `(default_message)` depend solely on the particular
+    // validation option that uses it. Each option may define its own set of placeholders, or none.
+    //
+    string default_message = 73901 [(internal) = true];
 
     // The constraint to require at least one of the fields or a combination of fields.
     //

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.232")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.233")


### PR DESCRIPTION
This PR marks `(default_message)` option as `internal` and updates its docs.