### PR TITLE
Restore and deprecate `if_invalid` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.235`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.236`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jan 07 13:42:22 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Jan 08 16:19:17 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.235</version>
+<version>2.0.0-SNAPSHOT.236</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -148,7 +148,8 @@ extend google.protobuf.FieldOptions {
     //
     bool validate = 73821;
 
-    // Reserved 73822 for deleted `(if_invalid)` option.
+    // See `IfInvalidOption`.
+    IfInvalidOption if_invalid = 73822 [deprecated = true];
 
     // See `GoesOption`.
     GoesOption goes = 73823;
@@ -866,6 +867,46 @@ message PatternOption {
         //
         bool partial_match = 5;
     }
+}
+
+// Specifies the message to show if a validated field happens to be invalid.
+//
+// It is applicable only to fields marked with `(validate)`.
+//
+message IfInvalidOption {
+
+    // Do not specify error message for `(validate)`, it is no longer used by
+    // the validation library.
+    option deprecated = true;
+
+    // The default error message.
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` is invalid. The field value: `${field.value}`.";
+
+    // A user-defined validation error format message.
+    //
+    // Use `error_msg` instead.
+    //
+    string msg_format = 1 [deprecated = true];
+
+    // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `${field.path}` – the field path.
+    // 2. `${field.value}` - the field value.
+    // 3. `${field.type}` – the fully qualified name of the field type.
+    // 4. `${parent.type}` – the fully qualified name of the field declaring type.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    // Example: Using the `(if_invalid)` option.
+    //
+    //     message Transaction {
+    //         TransactionDetails details = 1 [(validate) = true,
+    //                                         (if_invalid).error_msg = "The `${field.path}` field is invalid."];
+    //    }
+    //
+    string error_msg = 2;
 }
 
 // Specifies that another field must be present if the option's target field is present.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.235")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.236")


### PR DESCRIPTION
This PR restores binary compatibility with older versions. 

I can't migrate `spine-core` to the latest versions of `mc-java` and `validation`. And I can't remove usages of `if_invalid` without bumping the mentioned libs because the old versions were deleted from Maven.