### PR TITLE
Update the default error message for `(if_missing)`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.236`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.237`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -845,4 +845,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Jan 08 16:19:17 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 05 12:27:40 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.236</version>
+<version>2.0.0-SNAPSHOT.237</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -650,7 +650,7 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` must have a value.";
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` must have a non-default value.";
 
     // A user-defined validation error format message.
     //

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.236")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.237")


### PR DESCRIPTION
This updates the default error message for `(if_missing)`, so that it reads better for all field types.