### PR TITLE
Update `(distinct)` docs

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.242`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.243`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -849,4 +849,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Feb 20 14:11:20 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 26 14:42:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.242</version>
+<version>2.0.0-SNAPSHOT.243</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1167,7 +1167,7 @@ message IfSetAgainOption {
     string error_msg = 1;
 }
 
-// Defines the error message used if a `(distinct)` field has duplicates.
+// Defines the error message used if a `distinct` field has duplicates.
 //
 // Applies only to the `repeated` and `map` fields marked with the `(distinct)` option.
 //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -215,24 +215,42 @@ extend google.protobuf.FieldOptions {
     //
     bool set_once = 73824;
 
-    // The option to mark a `repeated` field as a collection of unique elements.
+    // The option to enforce uniqueness for collection fields.
     //
-    // When this option is set to `true`, all elements in the `repeated` field must be unique.
+    // When the option is set to `true`, the behavior is as follows:
+    //
+    // 1. For `repeated` fields: all elements must be unique.
+    // 2. For `map` fields: while the map keys are inherently unique, all associated values
+    //    must also be unique.
+    //
+    // Other field types are not supported.
+    //
     // Uniqueness is determined by comparing the elements themselves, using their full equality.
-    // For example, in Java, it is defined by the `equals()` method.
+    // For example, in Java, it is defined by the `equals()` method. No special cases are applied,
+    // such as comparing only specific fields like IDs.
     //
-    // No special cases are applied, such as comparing only specific fields like IDs.
-    //
-    // Example: Using `(distinct)` constraint for a repeated field.
+    // Example: Using `(distinct)` constraint for a `repeated` field.
     //
     //    message Blizzard {
     //
     //        // All snowflakes must be unique in this blizzard.
     //        //
     //        // Attempting to add a snowflake that is equal to an existing one would result
-    //        // in constraint violation error.
+    //        // in a constraint violation error.
     //        //
-    //        repeated Snowflake = 1 [(distinct) = true];
+    //        repeated Snowflake snowflakes = 1 [(distinct) = true];
+    //    }
+    //
+    // Example: Using `(distinct)` constraint for a `map` field.
+    //
+    //    message UniqueEmails {
+    //
+    //        // The associated email values must be unique.
+    //        //
+    //        // Attempting to add a key/value pair where the `Email` value duplicates
+    //        // an existing one would result in a constraint violation error.
+    //        //
+    //        map<string, Email> emails = 1 [(distinct) = true];
     //    }
     //
     bool distinct = 73825;
@@ -1149,9 +1167,9 @@ message IfSetAgainOption {
     string error_msg = 1;
 }
 
-// Defines the error message used if a `distinct` field has duplicates.
+// Defines the error message used if a `(distinct)` field has duplicates.
 //
-// Applies only to the repeated fields marked as `distinct`.
+// Applies only to the `repeated` and `map` fields marked with the `(distinct)` option.
 //
 message IfHasDuplicatesOption {
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.242")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.243")


### PR DESCRIPTION
This PR actualizes specification of `(distinct)` option. 

We actually support `map` fields for this option in `validation`. And even [use](https://github.com/SpineEventEngine/ProtoData/blob/2600629bfc15434005c735775f878598a0a06989/api/src/main/proto/spine/protodata/source.proto#L63) it in ProtoData.

Discovered #855.