### PR TITLE
Restore `pom.xml` generation

### DIFF
--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/PomGenerator.kt
@@ -75,7 +75,7 @@ object PomGenerator {
             plugin(BasePlugin::class.java)
         }
 
-        project.tasks.register("generatePom") {
+        val task = project.tasks.register("generatePom") {
             doLast {
                 val pomFile = project.projectDir.resolve("pom.xml")
                 project.delete(pomFile)
@@ -85,11 +85,11 @@ object PomGenerator {
                 writer.writeTo(pomFile)
             }
 
-            val buildTask = project.tasks.findByName("build")!!
-            buildTask.finalizedBy(this)
-
             val assembleTask = project.tasks.findByName("assemble")!!
             dependsOn(assembleTask)
         }
+
+        val buildTask = project.tasks.findByName("build")!!
+        buildTask.finalizedBy(task)
     }
 }

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -103,7 +103,7 @@ val manifestAttributes = mapOf(
  * when running tests. We cannot depend on the `Jar` from `resources` because it would
  * form a circular dependency.
  */
-val exposeManifestForTests by tasks.creating {
+val exposeManifestForTests by tasks.registering {
 
     val outputFile = layout.buildDirectory.file("resources/main/META-INF/MANIFEST.MF")
     outputs.file(outputFile).withPropertyName("manifestFile")

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.243`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.244`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -849,4 +849,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 26 14:42:28 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Feb 26 14:56:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.243</version>
+<version>2.0.0-SNAPSHOT.244</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.243")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.244")


### PR DESCRIPTION
This changeset restores the automatic generation of `pom.xml` file generation, which was recently broken during the migration to Gradle 8.13.

In particular, now the `generatePom` task is explicitly wired to `build` task. Previously, we have relied onto the fact that the "lazily evaluated" task action would execute at some point. However, apparently, it is not so anymore.

Another minor change is the migration from `tasks.creating ...` API call to `tasks.registering ...` It's just a newly encountered Gradle warning. It has nothing to do with the `pom.xml` generation.

By this PR, #855 is addressed.