### PR TITLE
Add receiver-based overloadings for `builderFor(...)`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.244`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.245`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -849,4 +849,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Feb 26 14:56:27 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Feb 28 16:56:35 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.244</version>
+<version>2.0.0-SNAPSHOT.245</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/kotlin/io/spine/protobuf/MessageExts.kt
+++ b/src/main/kotlin/io/spine/protobuf/MessageExts.kt
@@ -35,6 +35,7 @@ import com.google.protobuf.Any
 import com.google.protobuf.Message
 import io.spine.annotation.Internal
 import java.lang.reflect.Type
+import kotlin.reflect.KClass
 
 /**
  * Obtains the default instance of the passed message class.
@@ -71,7 +72,7 @@ private class MessageCacheLoader : CacheLoader<Class<out Message>, Message>() {
 }
 
 /**
- * Returns the builder for the passed message class.
+ * Creates a new builder for the passed message class.
  */
 @Internal
 public fun <M : Message> builderFor(cls: Class<M>): Message.Builder {
@@ -83,6 +84,16 @@ public fun <M : Message> builderFor(cls: Class<M>): Message.Builder {
         )
     }
 }
+
+/**
+ * Creates a new builder for this message [Class].
+ */
+public fun Class<out Message>.newBuilder(): Message.Builder = builderFor(this)
+
+/**
+ * Creates a new builder for this message [KClass].
+ */
+public fun KClass<out Message>.newBuilder(): Message.Builder = builderFor(java)
 
 /**
  * Ensures that the passed instance of `Message` is not an instance

--- a/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
@@ -41,11 +41,12 @@ import org.junit.jupiter.api.Test
 internal class MessageExtsSpec {
 
     @Test
-    fun `return builder for the message`() {
+    fun `create a new builder for the message`() {
         val messageBuilder = builderFor(MessageWithStringValue::class.java)
 
         messageBuilder shouldNotBe null
         messageBuilder.build().javaClass shouldBe MessageWithStringValue::class.java
+        messageBuilder shouldNotBe builderFor(MessageWithStringValue::class.java)
     }
 
     @Test
@@ -63,9 +64,8 @@ internal class MessageExtsSpec {
         value.ensureUnpacked() shouldBe value
     }
 
-    @Nested
-    @DisplayName("verify that")
-    internal inner class VerifyThat {
+    @Nested inner class
+    `verify that` {
 
         @Test
         fun `a message is not in the default state`() {

--- a/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
@@ -40,13 +40,23 @@ import org.junit.jupiter.api.Test
 @DisplayName("Extensions for `Message`-related types should")
 internal class MessageExtsSpec {
 
-    @Test
-    fun `create a new builder for the message`() {
-        val messageBuilder = builderFor(MessageWithStringValue::class.java)
+    @Nested inner class
+    `create a new builder` {
 
-        messageBuilder shouldNotBe null
-        messageBuilder shouldNotBe builderFor(MessageWithStringValue::class.java)
-        messageBuilder.build().javaClass shouldBe MessageWithStringValue::class.java
+        @Test
+        fun `for the passed Java message class`() = assertMessageBuilder {
+            builderFor(MessageWithStringValue::class.java)
+        }
+
+        @Test
+        fun `for this Java message class`() = assertMessageBuilder {
+            MessageWithStringValue::class.java.newBuilder()
+        }
+
+        @Test
+        fun `for this Kotlin message class`() = assertMessageBuilder {
+            MessageWithStringValue::class.newBuilder()
+        }
     }
 
     @Test
@@ -105,4 +115,10 @@ internal class MessageExtsSpec {
 private enum class TaskStatus {
     OPEN,
     DONE
+}
+
+private fun assertMessageBuilder(newBuilder: () -> Message.Builder) {
+    val builder = newBuilder()
+    builder.build()::class shouldBe MessageWithStringValue::class
+    newBuilder() shouldNotBe newBuilder() // A new instance should always be created.
 }

--- a/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/MessageExtsSpec.kt
@@ -45,8 +45,8 @@ internal class MessageExtsSpec {
         val messageBuilder = builderFor(MessageWithStringValue::class.java)
 
         messageBuilder shouldNotBe null
-        messageBuilder.build().javaClass shouldBe MessageWithStringValue::class.java
         messageBuilder shouldNotBe builderFor(MessageWithStringValue::class.java)
+        messageBuilder.build().javaClass shouldBe MessageWithStringValue::class.java
     }
 
     @Test

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.244")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.245")


### PR DESCRIPTION
This PR adds the following alternatives to `builderFor(messageClass): Message.Builder`:

1. `Class<out Message>.newBuilder()` – to invoke upon Java classes.
2. `KClass<out Message>.newBuilder()` – to invoke upon Kotlin classes.

These extensions enhance readability when writing parametrized JUnit tests upon Protobuf messages that arrive as `KClass<Message>`:

```kotlin
        assertThrows<ValidationException> {
            message.newBuilder()
                .set(field1, fieldValue1)
                .build()
        }
```

Also, I've updated docs wording from `Returns ...` to `Creates ...` because a new instance is actually returned, and new overloadings re-use the original function, so their docs should be consistent.