### PR TITLE
Clarify `(pattern)` option and implement `restoreProtobufEscapes()` util

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
 
     testImplementation(TestLib.lib)
     testImplementation(Logging.smokeTest)
+    testImplementation(Logging.testLib)?.because("We need `tapConsole`.")
 }
 
 configurations.all {

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.300`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.301`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -891,4 +891,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Mar 02 20:48:54 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Mar 06 12:07:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.300</version>
+<version>2.0.0-SNAPSHOT.301</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -44,7 +44,7 @@ private val ProtobufEscapeSequences = mapOf(
 )
 
 /**
- * Restores the original literal as defined in the Protobuf source file.
+ * Restores the original literal as it was defined in the Protobuf source file.
  *
  * Since control characters are unprintable and cannot be directly typed from the keyboard,
  * most compilers (including Protobuf) use escape sequences (e.g., `\n`) to represent them.
@@ -68,7 +68,7 @@ private val ProtobufEscapeSequences = mapOf(
  *
  * 1. Using a Regex expression from a protobuf source file as a literal in generated code.
  *    If the literal is pre-processed by the Protobuf compiler, it may no longer be printable
- *    text as intended, potentially containing unprintable characters.
+ *    as intended, potentially containing unprintable characters.
  * 2. When reporting problematic Regex expressions in error messages exactly as the user
  *    provided them.
  *
@@ -77,7 +77,7 @@ private val ProtobufEscapeSequences = mapOf(
  *
  * 1. The question mark `?` always remains as is, since Protobuf accepts both `?` and `\?`.
  * 2. Characters specified using Unicode codes, or as octal or hexadecimal byte values,
- *    remain unchanged; the method cannot determine whether these were originally specified
+ *    remain as text; the method cannot determine whether these were originally specified
  *    as text or as escape sequences.
  */
 public fun restoreProtobufEscapes(value: String): String =

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -35,7 +35,7 @@ package io.spine.protobuf
  *
  * Note we don't modify question marks because the Protobuf compiler actually accepts
  * both `?` and `\?` as a question mark. Therefore, it is unclear when to prepend
- * the leading `/` to restore the original literal.
+ * the leading `\` to restore the original literal.
  *
  * Also, we are not restoring Unicode codes, or octal and hexadecimal byte values.
  * The reasons are as follows:

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -27,11 +27,13 @@
 package io.spine.protobuf
 
 /**
- * ASCII control characters escaped by the Protobuf compiler when parsing string literals.
+ * A map of ASCII control characters to their escaping sequences.
  *
- * Escaping rules may differ from one compiler to another, so a more reliable approach
- * is to re-escape strings according to the specifications of the tool that originally
- * performed the escaping.
+ * When processing a string literal from a `.proto` source file, the Protobuf compiler
+ * is expected to substitute these sequences with the corresponding ASCII codes.
+ * This behavior should be the same for all target languages, though there is no official
+ * specification about this, besides a reverse-engineered
+ * [draft spec](https://protobuf.dev/reference/protobuf/textformat-spec/#string).
  *
  * Note we don't modify question marks because the Protobuf compiler actually accepts
  * both `?` and `\?` as a question mark. Therefore, it is unclear when to prepend
@@ -42,8 +44,6 @@ package io.spine.protobuf
  *
  * 1) They do not appear to be expected in our literals.
  * 2) Their escaping is more complex because they have variable length.
- *
- * Source: [Text Format Langauge Specification | String Literals](https://protobuf.dev/reference/protobuf/textformat-spec/#string).
  */
 @Suppress("MagicNumber") // ASCII codes.
 private val ProtobufEscapeSequences = mapOf(
@@ -60,7 +60,7 @@ private val ProtobufEscapeSequences = mapOf(
 )
 
 /**
- * Restores the original literal as it was defined in the source file.
+ * Restores the original literal as it was defined in the Protobuf source file.
  *
  * The method reverses the [escape sequences](https://protobuf.dev/reference/protobuf/textformat-spec/#string)
  * that the Protobuf compiler substituted with ASCII control characters during compilation.

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -55,7 +55,8 @@ private val ProtobufEscapeSequences = mapOf(
  * This method reverses the escape sequences that the Protobuf compiler substituted with
  * ASCII control characters during the compilation. The substitution [rules][ProtobufEscapeSequences]
  * are expected to be consistent across all target languages. However, no official documentation
- * exists on this behavior, aside from a reverse-engineered [draft specification](https://protobuf.dev/reference/protobuf/textformat-spec/#string)
+ * exists on this behavior, aside from a reverse-engineered
+ * [draft specification](https://protobuf.dev/reference/protobuf/textformat-spec/#string)
  * that includes the following disclaimer:
  *
  * ```

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -44,47 +44,41 @@ private val ProtobufEscapeSequences = mapOf(
 )
 
 /**
- * Restores the original literal as it was defined in the Protobuf source file.
+ * Restores the original literal as defined in the Protobuf source file.
  *
- * The method reverses the [escape sequences](https://protobuf.dev/reference/protobuf/textformat-spec/#string)
- * that the Protobuf compiler substituted with ASCII control characters during compilation.
- *
- * Because control characters are unprintable and cannot be directly typed from the keyboard,
+ * Since control characters are unprintable and cannot be directly typed from the keyboard,
  * most compilers (including Protobuf) use escape sequences (e.g., `\n`) to represent them.
  * An escape sequence consists of a backslash followed by one or more symbols. Note that while
  * the backslash is a printable character, it must be escaped too because it introduces
  * an escape sequence.
  *
- * When processing a string literal from the source file, the Protobuf compiler is expected
- * to substitute the escape sequences with the corresponding ASCII codes for runtime
- * representation of the string. The substitution [rules][ProtobufEscapeSequences] should be
- * the same for all target languages, though there is no official specification regarding this,
- * besides a reverse-engineered [draft spec](https://protobuf.dev/reference/protobuf/textformat-spec/#string),
- * for which they state the following:
+ * This method reverses the escape sequences that the Protobuf compiler substituted with
+ * ASCII control characters during the compilation. The substitution [rules][ProtobufEscapeSequences]
+ * are expected to be consistent across all target languages. However, no official documentation
+ * exists on this behavior, aside from a reverse-engineered [draft specification](https://protobuf.dev/reference/protobuf/textformat-spec/#string)
+ * that includes the following disclaimer:
  *
  * ```
  * While an effort has been made to keep text formats consistent across supported languages,
  * incompatibilities are likely to exist.
  * ```
  *
- * Restoring the escaped symbols can be useful for code generation tasks.
- * For example:
+ * Restoring the escaped symbols can be useful for code generation tasks, as it makes a string
+ * literal printable in generated source files (e.g., Java, Kotlin). For example:
  *
- * 1. Using a provided Regex expression as a literal in generated code. If the literal is
- *    pre-processed by the Protobuf compiler, it may no longer be renderable as intended,
- *    potentially containing unprintable characters instead of the escape sequences.
- * 2. Report a problematic Regex expressions in an error message exactly as the user provided it.
+ * 1. Using a Regex expression from a protobuf source file as a literal in generated code.
+ *    If the literal is pre-processed by the Protobuf compiler, it may no longer be printable
+ *    text as intended, potentially containing unprintable characters.
+ * 2. When reporting problematic Regex expressions in error messages exactly as the user
+ *    provided them.
  *
- * Note we don't modify question marks because the Protobuf compiler (particularly, for Java)
- * actually accepts both `?` and `\?` as a question mark. Therefore, it is unclear when
- * to prepend the leading `\` to restore the original literal. The method makes an assumption
- * that users prefer just a question mark.
+ * Please note that a string literal cannot be fully reconstructed after being processed by
+ * the Protobuf compiler due to the following limitations:
  *
- * Also, we are not restoring Unicode codes, or octal and hexadecimal byte values
- * due to the following assumptions:
- *
- * 1) Users will prefer specifying Unicode symbols with text. Protobuf source files support UTF-8.
- * 2) Octal and hexadecimal byte values are unlikely to participate in Regex expressions.
+ * 1. The question mark `?` always remains as is, since Protobuf accepts both `?` and `\?`.
+ * 2. Characters specified using Unicode codes, or as octal or hexadecimal byte values,
+ *    remain unchanged; the method cannot determine whether these were originally specified
+ *    as text or as escape sequences.
  */
 public fun restoreProtobufEscapes(value: String): String =
     buildString {

--- a/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/protobuf/ProtobufLiteral.kt
@@ -24,7 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.string
+package io.spine.protobuf
 
 /**
  * ASCII control characters escaped by the Protobuf compiler when parsing string literals.
@@ -49,14 +49,14 @@ package io.spine.string
 private val ProtobufEscapeSequences = mapOf(
     7 to "\\a",
     8 to "\\b",
-    12 to "\\f",
-    10 to "\\n",
-    13 to "\\r",
     9 to "\\t",
+    10 to "\\n",
     11 to "\\v",
-    92 to "\\\\",
+    12 to "\\f",
+    13 to "\\r",
+    34 to "\\\"",
     39 to "\\'",
-    34 to "\\\""
+    92 to "\\\\",
 )
 
 /**
@@ -75,16 +75,14 @@ private val ProtobufEscapeSequences = mapOf(
  * For example:
  *
  * 1. Report a problematic literal in an error message exactly as the user provided it.
- * 2. Using a provided Regex expression as a literal in generated code. If the literal is pre-processed
- *    by the Protobuf compiler, it may no longer be renderable as intended, potentially containing
- *    unprintable characters instead of the expected escape sequences. An unescaped backslash can
- *    also cause errors in many compilers.
+ * 2. Using a provided Regex expression as a literal in generated code. If the literal is
+ *    pre-processed by the Protobuf compiler, it may no longer be renderable as intended,
+ *    potentially containing unprintable characters instead of the escape sequences.
  *
- * Note that this method does not reverse the escaping for Unicode codes, or for octal
- * and hexadecimal byte values. It only restores ASCII control characters to their printable
- * escape sequences.
+ * Note that this method does not reverse the escaping for Unicode codes, octal and hexadecimal
+ * byte values. It only restores ASCII control characters to their printable escape sequences.
  */
-public fun restoreEscapedSymbols(value: String): String =
+public fun restoreProtobufEscapes(value: String): String =
     buildString {
         value.forEach {
             append(ProtobufEscapeSequences[it.code] ?: it)

--- a/src/main/kotlin/io/spine/string/ProtobufLiteral.kt
+++ b/src/main/kotlin/io/spine/string/ProtobufLiteral.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.string
+
+/**
+ * ASCII control characters escaped by Protobuf compiler when parsing string literals.
+ *
+ * Escaping rules may differ from compiler to compiler, so a more reliable approach is
+ * to re-escape strings in accordance to the specs of a particular tool that previously
+ * performed this escaping.
+ *
+ * Note we don't touch question marks because Protobuf compiler actually accepts both `?`
+ * and `\?` as a question mark. So, it is unclear when we should prepend the leading `/`
+ * to restore the original literal.
+ *
+ * Source: [Text Format Langauge Specification | String Literals](https://protobuf.dev/reference/protobuf/textformat-spec/#string).
+ */
+@Suppress("MagicNumber") // ASCII codes.
+private val ProtobufEscapeSequences = mapOf(
+    7 to "\\a",
+    8 to "\\b",
+    12 to "\\f",
+    10 to "\\n",
+    13 to "\\r",
+    9 to "\\t",
+    11 to "\\v",
+    92 to "\\\\",
+    39 to "\\'",
+    34 to "\\\""
+)
+
+/**
+ * Restores the original literal as it was defined in a source file.
+ *
+ * The method restores [escape sequences](https://protobuf.dev/reference/protobuf/textformat-spec/#string),
+ * which Protobuf compiler substituted with ASCII control characters during the compilation.
+ *
+ * The control characters are unprintable, thus cannot be typed directly from the keyboard.
+ * Most compilers, including Protobuf, use escape sequences to represent such symbols
+ * in string literals (i.e., `\n`). An escape symbol consists of a backslash and another
+ * one or more symbols. The backslash is a printable character itself, but since it is used
+ * to introduce an escape sequence, it requires escaping itself.
+ *
+ * For code generation tasks, this can come handy in the following cases:
+ *
+ * 1. Report the problematic literal in compilation or runtime error messages as it was
+ *    passed by the user. It will help the user to locate the problematic declaration.
+ * 2. Use the passed Regex expressions as literals in the generated code.
+ *    If the passed literal was pre-processed by the compiler, it cannot be longer
+ *    rendered in a source file as literal. Now, it contains unprintable characters instead
+ *    of printable escape sequences, and may contain a non-escaped backslash, which is
+ *    prohibited for literals.
+ *
+ * Note that this method does not roll back Unicode codes, octal and hexadecimal byte values.
+ * Only ASCII control characters are re-escaped.
+ */
+public fun restoreEscapedSymbols(value: String): String =
+    buildString {
+        value.forEach {
+            append(ProtobufEscapeSequences[it.code] ?: it)
+        }
+    }

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -668,8 +668,8 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type"
-        " `${field.type}` must have a non-default value.";
+    option (default_message) = "The field `${parent.type}.${field.path}`"
+        " of the type `${field.type}` must have a non-default value.";
 
     // A user-defined validation error format message.
     //
@@ -715,8 +715,8 @@ message IfMissingOption {
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator}"
-        " ${min.value}.";
+    option (default_message) = "The field `${parent.type}.${field.path}`"
+        " must be ${max.operator} ${min.value}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -762,8 +762,8 @@ message MinOption {
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator}"
-        " ${max.value}.";
+    option (default_message) = "The field `${parent.type}.${field.path}`"
+        " must be ${max.operator} ${max.value}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -809,8 +809,8 @@ message MaxOption {
 message PatternOption {
 
     // The default error message.
-    option (default_message) = "The `${parent.type}.${field.path}` field must match the regular"
-        " expression `${regex.pattern}` (modifiers: `${regex.modifiers}`)."
+    option (default_message) = "The `${parent.type}.${field.path}` field"
+        " must match the regular expression `${regex.pattern}` (modifiers: `${regex.modifiers}`)."
         " The passed value: `${field.value}`.";
 
     // The regular expression that the field value must match.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -668,7 +668,8 @@ extend google.protobuf.ServiceOptions {
 message IfMissingOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` must have a non-default value.";
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type"
+        " `${field.type}` must have a non-default value.";
 
     // A user-defined validation error format message.
     //
@@ -714,7 +715,8 @@ message IfMissingOption {
 message MinOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator} ${min.value}.";
+    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator}"
+        " ${min.value}.";
 
     // The string representation of the minimum field value.
     string value = 1;
@@ -760,7 +762,8 @@ message MinOption {
 message MaxOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator} ${max.value}.";
+    option (default_message) = "The field `${parent.type}.${field.path}` must be ${max.operator}"
+        " ${max.value}.";
 
     // The string representation of the maximum field value.
     string value = 1;
@@ -806,11 +809,13 @@ message MaxOption {
 message PatternOption {
 
     // The default error message.
-    option (default_message) = "The `${parent.type}.${field.path}` field must match the regular expression `${regex.pattern}` (modifiers: `${regex.modifiers}`). The passed value: `${field.value}`.";
+    option (default_message) = "The `${parent.type}.${field.path}` field must match the regular"
+        " expression `${regex.pattern}` (modifiers: `${regex.modifiers}`)."
+        " The passed value: `${field.value}`.";
 
     // The regular expression that the field value must match.
     //
-    // Use the Java regex dialect for the syntax baseline:
+    // Please use the Java regex dialect for the syntax baseline:
     // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html
     //
     // Note: in Java, regex patterns are not wrapped in explicit delimiters like in Perl or PHP.
@@ -909,7 +914,8 @@ message IfInvalidOption {
     option deprecated = true;
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` is invalid. The field value: `${field.value}`.";
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type"
+        " `${field.type}` is invalid. The field value: `${field.value}`.";
 
     // A user-defined validation error format message.
     //
@@ -962,7 +968,8 @@ message IfInvalidOption {
 message GoesOption {
 
     // The default error message.
-    option (default_message) = "The field `${goes.companion}` must also be set when `${field.path}` is set in `${parent.type}`.";
+    option (default_message) = "The field `${goes.companion}` must also be set when `${field.path}`"
+        " is set in `${parent.type}`.";
 
     // The name of the companion field whose presence is required for this field to be valid.
     string with = 1;
@@ -1154,7 +1161,9 @@ message CompareByOption {
 message IfSetAgainOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` already has the value `${field.value}` and cannot be reassigned to `${field.proposed_value}`.";
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type"
+        " `${field.type}` already has the value `${field.value}` and cannot be reassigned"
+        " to `${field.proposed_value}`.";
 
     // A user-defined error message.
     //
@@ -1185,7 +1194,9 @@ message IfSetAgainOption {
 message IfHasDuplicatesOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` of the type `${field.type}` must not contain duplicates. The duplicates found: `${field.duplicates}`.";
+    option (default_message) = "The field `${parent.type}.${field.path}` of the type"
+        " `${field.type}` must not contain duplicates."
+        " The duplicates found: `${field.duplicates}`.";
 
     // A user-defined error message.
     //
@@ -1217,7 +1228,8 @@ message IfHasDuplicatesOption {
 message RangeOption {
 
     // The default error message.
-    option (default_message) = "The field `${parent.type}.${field.path}` must be within the following range: `${range.value}`.";
+    option (default_message) = "The field `${parent.type}.${field.path}` must be within"
+        " the following range: `${range.value}`.";
 
     // The string representation of the range.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -793,8 +793,8 @@ message MaxOption {
 
 // A string field value must match the given regular expression.
 //
-// Is applicable only to string fields.
-// Repeated fields are supported.
+// This option is applicable only to string fields,
+// including those that are repeated.
 //
 // Example: Using the `(pattern)` option.
 //
@@ -808,7 +808,18 @@ message PatternOption {
     // The default error message.
     option (default_message) = "The `${parent.type}.${field.path}` field must match the regular expression `${regex.pattern}` (modifiers: `${regex.modifiers}`). The passed value: `${field.value}`.";
 
-    // The regular expression to match.
+    // The regular expression that the field value must match.
+    //
+    // Use the Java regex dialect for the syntax baseline:
+    // https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/regex/Pattern.html
+    //
+    // Note: in Java, regex patterns are not wrapped in explicit delimiters like in Perl or PHP.
+    // Instead, the pattern is provided as a string literal. Therefore, `/` symbol does not need
+    // to be escaped.
+    //
+    // The provided string literal is passed directly to the regex engine. So, it must be exactly
+    // what you would supply to the `java.util.regex.Pattern.compile()` method.
+    //
     string regex = 1;
 
     reserved 2;

--- a/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.protobuf
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("Protobuf string extensions should")
+internal class ProtobufLiteralSpec {
+
+    @Test
+    fun `restore escaped ASCII control characters`() {
+        // The test string contains a mix of control characters and English letters.
+        val asciiCodes = listOf(7, 8, 101, 102, 9, 10, 11, 72, 73, 12, 13, 111, 34, 39, 92)
+        val asciiString = asciiCodes.map { it.toChar() }.joinToString()
+        val expected = "\\a, \\b, e, f, \\t, \\n, \\v, H, I, \\f, \\r, o, \\\", \\', \\\\"
+        restoreProtobufEscapes(asciiString) shouldBe expected
+    }
+}

--- a/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
@@ -41,12 +41,12 @@ internal class ProtobufLiteralSpec {
         val asciiString = asciiCodes.map { it.toChar() }.joinToString()
 
         val expected = "\\a, \\b, e, f, \\t, \\n, \\v, H, I, \\f, \\r, o, \\\", \\', \\\\"
-        val printed = tapConsole {
+        val result = tapConsole {
             // With restored escape sequences, the test string becomes printable.
-            // Otherwise, the control characters would not be visible.
-            print(restoreProtobufEscapes(asciiString))
+            val escaped = restoreProtobufEscapes(asciiString)
+            print(escaped)
         }
 
-        printed shouldBe expected
+        result shouldBe expected
     }
 }

--- a/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
@@ -30,7 +30,7 @@ import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
-@DisplayName("Protobuf string extensions should")
+@DisplayName("Protobuf string functions should")
 internal class ProtobufLiteralSpec {
 
     @Test

--- a/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
@@ -38,7 +38,13 @@ internal class ProtobufLiteralSpec {
         // The test string contains a mix of control characters and English letters.
         val asciiCodes = listOf(7, 8, 101, 102, 9, 10, 11, 72, 73, 12, 13, 111, 34, 39, 92)
         val asciiString = asciiCodes.map { it.toChar() }.joinToString()
+
         val expected = "\\a, \\b, e, f, \\t, \\n, \\v, H, I, \\f, \\r, o, \\\", \\', \\\\"
-        restoreProtobufEscapes(asciiString) shouldBe expected
+        val escaped = restoreProtobufEscapes(asciiString)
+        escaped shouldBe expected
+
+        // Uncomment these lines to debug the test.
+        // println(asciiString) // Prints whitespaces and English letters.
+        // println(escaped) // => `\a, \b, e, f, \t, \n, \v, H, I, \f, \r, o, \", \', \\`.
     }
 }

--- a/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
+++ b/src/test/kotlin/io/spine/protobuf/ProtobufLiteralSpec.kt
@@ -27,6 +27,7 @@
 package io.spine.protobuf
 
 import io.kotest.matchers.shouldBe
+import io.spine.logging.testing.tapConsole
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -40,11 +41,12 @@ internal class ProtobufLiteralSpec {
         val asciiString = asciiCodes.map { it.toChar() }.joinToString()
 
         val expected = "\\a, \\b, e, f, \\t, \\n, \\v, H, I, \\f, \\r, o, \\\", \\', \\\\"
-        val escaped = restoreProtobufEscapes(asciiString)
-        escaped shouldBe expected
+        val printed = tapConsole {
+            // With restored escape sequences, the test string becomes printable.
+            // Otherwise, the control characters would not be visible.
+            print(restoreProtobufEscapes(asciiString))
+        }
 
-        // Uncomment these lines to debug the test.
-        // println(asciiString) // Prints whitespaces and English letters.
-        // println(escaped) // => `\a, \b, e, f, \t, \n, \v, H, I, \f, \r, o, \", \', \\`.
+        printed shouldBe expected
     }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.300")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.301")


### PR DESCRIPTION
This PR does the following:

1. Clarifies docs to `(pattern)` option, mentioning which Regex dialect is expected by the option.
2. Implements `restoreProtobufEscapes()` function that allows to restore originally passed users' string literals, so that these literals could be rendered as literals in source files by `validation`.