### PR TITLE
Clarify docs to `(validate)` option

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.301`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.302`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -544,6 +544,14 @@
 1.  **Group** : org.apache.httpcomponents.core5. **Name** : httpcore5-h2. **Version** : 5.1.3.
      * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-api. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
+1.  **Group** : org.apache.logging.log4j. **Name** : log4j-core. **Version** : 2.20.0.
+     * **Project URL:** [https://www.apache.org/](https://www.apache.org/)
+     * **License:** [Apache License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.apiguardian. **Name** : apiguardian-api. **Version** : 1.1.2.
      * **Project URL:** [https://github.com/apiguardian-team/apiguardian](https://github.com/apiguardian-team/apiguardian)
      * **License:** [The Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -891,4 +899,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Mar 06 12:07:08 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 12 15:11:11 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.301</version>
+<version>2.0.0-SNAPSHOT.302</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -98,6 +98,12 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>io.spine</groupId>
     <artifactId>spine-logging-smoke-test</artifactId>
+    <version>2.0.0-SNAPSHOT.242</version>
+    <scope>test</scope>
+  </dependency>
+  <dependency>
+    <groupId>io.spine.tools</groupId>
+    <artifactId>spine-logging-testlib</artifactId>
     <version>2.0.0-SNAPSHOT.242</version>
     <scope>test</scope>
   </dependency>

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -211,8 +211,14 @@ extend google.protobuf.FieldOptions {
     //
     //   1. The default instance of `Any` is always valid because there is nothing to unpack
     //      and validate.
-    //   2. Instances with unknown type URLs are considered valid because their Java class cannot
-    //      be determined from `io.spine.KnownTypes`.
+    //   2. Instances with type URLs that are unknown to the application are also valid.
+    //
+    //      Unpacking requires a corresponding Java class to deserialize the message, but if
+    //      the application does not recognize the type URL, it has no way to determine which
+    //      class to use.
+    //
+    //      Such may happen when the packed message comes from a newer app version, an external
+    //      system, or is simply not included in the application’s dependencies.
     //
     bool validate = 73821;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -127,24 +127,32 @@ extend google.protobuf.FieldOptions {
     // See `PatternOption`.
     PatternOption pattern = 73820;
 
-    // Enables validation constraint checking for fields that refer to a message.
+    // Enables in-depth validation for fields that refer to a message.
     //
-    // Default value: `false`.
+    // This option applies only to fields that reference a message:
     //
-    // This option can only be applied to fields that refer to a message. Such fields include:
+    //   1. Singular message fields.
+    //   2. Repeated fields of message types.
+    //   3. Map fields with message types as values.
     //
-    //   1. Message fields.
-    //   2. Map fields with message types as values.
-    //   3. Repeated fields of message types.
+    // When set to `true`, the field is valid only if its value satisfies the validation
+    // constraints defined in the corresponding message type:
     //
-    // When set to `true`, the marked field is considered valid only if the field's value satisfies
-    // the validation constraints defined in the corresponding message type. This means:
+    //   1. For singular message fields: the message must meet its constraints.
+    //      Note: default instances are considered valid even if the message has required fields.
+    //      In such cases, it is unclear whether the field is set with an invalid instance or
+    //      simply unset.
+    //   2. For map fields: each value in the map must meet the constraints of message type.
+    //      Note: Protobuf does not allow messages to be used as map keys.
+    //   3. For repeated fields: every element in the repeated field must meet the constraints
+    //      of its message type.
     //
-    //   1. For message fields: the message value itself must meet its constraints.
-    //   2. For map fields: each value within the map entries must meet the constraints defined
-    //      for its type. Note: Protobuf does not allow messages to be used as map keys.
-    //   3. For repeated fields: every item in the repeated field must satisfy the constraints
-    //      defined for the message type it refers to.
+    // If the field contains `google.protobuf.Any`, the option will first attempt to unpack
+    // the enclosed message, and only then validate it. However, unpacking is not always possible:
+    //
+    //   1. The default instance of `Any` is always valid.
+    //   2. Instances with unknown type URLs are considered valid because their Java class cannot
+    //      be determined from `io.spine.KnownTypes`.
     //
     bool validate = 73821;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -139,18 +139,78 @@ extend google.protobuf.FieldOptions {
     // constraints defined in the corresponding message type:
     //
     //   1. For singular message fields: the message must meet its constraints.
+    //
     //      Note: default instances are considered valid even if the message has required fields.
     //      In such cases, it is unclear whether the field is set with an invalid instance or
     //      simply unset.
-    //   2. For map fields: each value in the map must meet the constraints of message type.
-    //      Note: Protobuf does not allow messages to be used as map keys.
-    //   3. For repeated fields: every element in the repeated field must meet the constraints
+    //
+    //      Example:
+    //
+    //      ```
+    //      // Note that the default instance of `Address` is not valid because the `value` field
+    //      // is mandatory.
+    //      message Address {
+    //          string value = 1 [(required) = true];
+    //      }
+    //
+    //      // However, the default instance of `Address` in `Student.address` is valid, despite
+    //      // having `(validate)` constraint that forces the message to meet its constraints.
+    //      // Since the `address` field is optional for `Student`, `(validate)` would allow
+    //      // default instances for this field treating them as "no value set".
+    //      message Student {
+    //          Address address = 1 [(validate) = true]; // implicit `(required) = false`.
+    //      }
+    //
+    //      // Make the validated field required to avoid this behavior. In this case, `(validate)`
+    //      // continues to bypass default instances, but the `(required)` option will report them.
+    //      message Student {
+    //          Address address = 1 [(validate) = true, (required) = true];
+    //      }
+    //      ```
+    //
+    //   2. For repeated fields: every element in the repeated field must meet the constraints
     //      of its message type.
+    //
+    //      Example:
+    //
+    //      ```
+    //      // Note that the default instance of `PhoneNumber` is not valid because the `value`
+    //      // field is mandatory.
+    //      message PhoneNumber {
+    //          string value = 1 [(required) = true, (pattern).regex = "^\+?[0-9\s\-()]{1,30}$"];
+    //      }
+    //
+    //      // In contrast to singular fields, the default instances in `repeated` will also be
+    //      // reported by the `(validate)` constraint, with those that do not match the pattern.
+    //      message Student {
+    //          repeated PhoneNumber number = 1 [(validate) = true];
+    //      }
+    //      ```
+    //
+    //   3. For map fields: each value in the map must meet the constraints of message type.
+    //      Note: Protobuf does not allow messages to be used as map keys.
+    //
+    //      Example:
+    //
+    //      ```
+    //      // Note that the default instance of `PhoneNumber` is not valid because the `value`
+    //      // field is mandatory.
+    //      message PhoneNumber {
+    //          string value = 1 [(required) = true, (pattern).regex = "^\+?[0-9\s\-()]{1,30}$"];
+    //      }
+    //
+    //      // In contrast to singular fields, the default instances in `map` values will also be
+    //      // reported by the `(validate)` constraint, with those that do not match the pattern.
+    //      message Contacts {
+    //          map<string, PhoneNumber> map = 1 [(validate) = true];
+    //      }
+    //      ```
     //
     // If the field contains `google.protobuf.Any`, the option will first attempt to unpack
     // the enclosed message, and only then validate it. However, unpacking is not always possible:
     //
-    //   1. The default instance of `Any` is always valid.
+    //   1. The default instance of `Any` is always valid because there is nothing to unpack
+    //      and validate.
     //   2. Instances with unknown type URLs are considered valid because their Java class cannot
     //      be determined from `io.spine.KnownTypes`.
     //

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.301")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.302")


### PR DESCRIPTION
This PR adds more details to specification of the `(validate)` option.