### PR TITLE
`String.pluralize()` and `toUnix()` extensions

### DIFF
--- a/.github/workflows/ensure-reports-updated.yml
+++ b/.github/workflows/ensure-reports-updated.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          # Configure the checkout of all branches so that it is possible to run the comparison.
+          # Configure the checkout of all branches, so that it is possible to run the comparison.
           fetch-depth: 0
           # Check out the `config` submodule to fetch the required script file.
           submodules: true

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validation:
-    name: Validation
+    name: Gradle Wrapper Validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   validation:
-    name: Gradle Wrapper Validation
+    name: Validation
     runs-on: ubuntu-latest
     steps:
       - name: Checkout latest code

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -40,5 +40,5 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK" />
 </project>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,9 +39,6 @@ plugins {
 
     // https://github.com/jk1/Gradle-License-Report/releases
     id("com.github.jk1.dependency-license-report").version("2.7")
-
-    // https://github.com/johnrengelman/shadow/releases
-    id("com.github.johnrengelman.shadow").version("7.1.2")
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/BuildExtensions.kt
+++ b/buildSrc/src/main/kotlin/BuildExtensions.kt
@@ -184,18 +184,35 @@ fun Project.configureTaskDependencies() {
         val launchTestProtoData = "launchTestProtoData"
         val generateProto = "generateProto"
         val createVersionFile = "createVersionFile"
-        "compileKotlin".dependOn(launchProtoData)
-        "compileTestKotlin".dependOn(launchTestProtoData)
+        val compileKotlin = "compileKotlin"
+        compileKotlin.dependOn(launchProtoData)
+        val compileTestKotlin = "compileTestKotlin"
+        compileTestKotlin.dependOn(launchTestProtoData)
         val sourcesJar = "sourcesJar"
-        sourcesJar.dependOn(generateProto)
-        sourcesJar.dependOn(launchProtoData)
-        sourcesJar.dependOn(createVersionFile)
-        sourcesJar.dependOn("prepareProtocConfigVersions")
+        val kspKotlin = "kspKotlin"
+        sourcesJar.run {
+            dependOn(generateProto)
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+            dependOn(createVersionFile)
+            dependOn("prepareProtocConfigVersions")
+        }
         val dokkaHtml = "dokkaHtml"
-        dokkaHtml.dependOn(generateProto)
-        dokkaHtml.dependOn(launchProtoData)
-        "dokkaJavadoc".dependOn(launchProtoData)
+        dokkaHtml.run {
+            dependOn(generateProto)
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+        }
+        val dokkaJavadoc = "dokkaJavadoc"
+        dokkaJavadoc.run {
+            dependOn(launchProtoData)
+            dependOn(kspKotlin)
+        }
         "publishPluginJar".dependOn(createVersionFile)
+        compileKotlin.dependOn(kspKotlin)
+        compileTestKotlin.dependOn("kspTestKotlin")
+        "compileTestFixturesKotlin".dependOn("kspTestFixturesKotlin")
+        "javadocJar".dependOn(dokkaHtml)
     }
 }
 

--- a/buildSrc/src/main/kotlin/BuildSettings.kt
+++ b/buildSrc/src/main/kotlin/BuildSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+import org.gradle.api.JavaVersion
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -34,6 +35,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 object BuildSettings {
     private const val JVM_VERSION = 17
     val javaVersion: JavaLanguageVersion = JavaLanguageVersion.of(JVM_VERSION)
+    val javaVersionCompat = JavaVersion.toVersion(JVM_VERSION)
     val jvmTarget = JvmTarget.JVM_17
     const val REMOTE_DEBUG_PORT = 5566
 }

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -199,7 +199,7 @@ fun Project.forceSpineBase() {
 @Suppress("unused")
 fun Project.forceBaseInProtoTasks() {
     configurations.configureEach {
-        if (name.lowercased().contains("proto")) {
+        if (name.lowercase().contains("proto")) {
             resolutionStrategy {
                 force(Base.libForBuildScript)
             }

--- a/buildSrc/src/main/kotlin/DokkaExts.kt
+++ b/buildSrc/src/main/kotlin/DokkaExts.kt
@@ -186,9 +186,7 @@ fun Project.dokkaKotlinJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaKotlin
  */
 fun AbstractDokkaTask.isInPublishingGraph(): Boolean =
     project.gradle.taskGraph.allTasks.any {
-        with(it.name) {
-            startsWith("publish") && !startsWith("publishToMavenLocal")
-        }
+        it.name == "publish"
     }
 
 /**
@@ -217,7 +215,7 @@ fun Project.dokkaJavaJar(): TaskProvider<Jar> = tasks.getOrCreate("dokkaJavaJar"
 fun Project.disableDocumentationTasks() {
     gradle.taskGraph.whenReady {
         tasks.forEach { task ->
-            val lowercaseName = task.name.lowercased()
+            val lowercaseName = task.name.lowercase()
             if (lowercaseName.contains("dokka") || lowercaseName.contains("javadoc")) {
                 task.enabled = false
             }

--- a/buildSrc/src/main/kotlin/Strings.kt
+++ b/buildSrc/src/main/kotlin/Strings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,19 +41,10 @@ private const val ABOUT = ""
 /**
  * Makes the first character come in the title case.
  */
-fun String.titleCaseFirstChar(): String {
-     return replaceFirstChar { it.titlecase() }
-    // OR for earlier Kotlin versions:
-    //   1. add import of `org.gradle.configurationcache.extensions.capitalized`
-    //   2. call `capitalized()` instead of `replaceFirstChar` above.
-    //    return capitalized()
-}
+fun String.titleCaseFirstChar(): String = replaceFirstChar { it.titlecase() }
 
 /**
  * Converts this string to lowercase.
  */
-fun String.lowercased(): String {
-        return lowercase()
-    // OR for earlier Kotlin versions call:
-    // return toLowerCase()
-}
+@Deprecated(message = "Please use `lowercase()` instead.", replaceWith = ReplaceWith("lowercase"))
+fun String.lowercased(): String = lowercase()

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/ErrorProne.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/build/Ksp.kt
@@ -31,23 +31,13 @@ package io.spine.dependency.build
  *
  * @see <a href="https://github.com/google/ksp">KSP GitHub repository</a>
  */
-@Suppress("ConstPropertyName")
+@Suppress("ConstPropertyName", "unused")
 object Ksp {
-
-    /**
-     * The latest version compatible with Kotlin v1.8.22, which is bundled with Gradle 7.6.4.
-     *
-     * We need to stick to this version until we migrate to newer Gradle.
-     * Trying to use a newer version results in the following console output:
-     * ```
-     * ksp-1.9.24-1.0.20 is too new for kotlin-1.8.22. Please upgrade kotlin-gradle-plugin to 1.9.24.
-     * ```
-     *
-     * The version compatible with Kotlin v1.9.24 compiler is 1.9.24-1.0.20.
-     */
     const val version = "2.1.10-1.0.31"
     const val id = "com.google.devtools.ksp"
     const val group = "com.google.devtools.ksp"
     const val symbolProcessingApi = "$group:symbol-processing-api:$version"
     const val symbolProcessing = "$group:symbol-processing:$version"
+    const val symbolProcessingAaEmb = "$group:symbol-processing-aa-embeddable:$version"
+    const val symbolProcessingCommonDeps = "$group:symbol-processing-common-deps:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/Kotlin.kt
@@ -54,8 +54,11 @@ object Kotlin {
 
     private const val group = "org.jetbrains.kotlin"
 
+    const val scriptRuntime = "$group:kotlin-script-runtime:$runtimeVersion"
     const val stdLib       = "$group:kotlin-stdlib:$runtimeVersion"
     const val stdLibCommon = "$group:kotlin-stdlib-common:$runtimeVersion"
+
+    const val toolingCore = "$group:kotlin-tooling-core:$runtimeVersion"
 
     @Deprecated("Please use `stdLib` instead.")
     const val stdLibJdk7   = "$group:kotlin-stdlib-jdk7:$runtimeVersion"
@@ -66,12 +69,22 @@ object Kotlin {
     const val reflect    = "$group:kotlin-reflect:$runtimeVersion"
     const val testJUnit5 = "$group:kotlin-test-junit5:$runtimeVersion"
 
+    @Deprecated(message = "Please use `GradlePlugin.api` instead.", ReplaceWith("GradlePlugin.api"))
     const val gradlePluginApi = "$group:kotlin-gradle-plugin-api:$runtimeVersion"
+
+    @Deprecated(message = "Please use `GradlePlugin.lib` instead.", ReplaceWith("GradlePlugin.lib"))
     const val gradlePluginLib = "$group:kotlin-gradle-plugin:$runtimeVersion"
 
     const val jetbrainsAnnotations = "org.jetbrains:annotations:$annotationsVersion"
 
     object Compiler {
-        const val embeddable = "$group:kotlin-compiler-embeddable:$embeddedVersion"
+        const val embeddable = "$group:kotlin-compiler-embeddable:$runtimeVersion"
+    }
+
+    object GradlePlugin {
+        const val version = Kotlin.runtimeVersion
+        const val api = "$group:kotlin-gradle-plugin-api:$version"
+        const val lib = "$group:kotlin-gradle-plugin:$version"
+        const val model = "$group:kotlin-gradle-model:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/lib/KotlinX.kt
@@ -34,7 +34,7 @@ object KotlinX {
     object Coroutines {
 
         // https://github.com/Kotlin/kotlinx.coroutines
-        const val version = "1.9.0"
+        const val version = "1.10.1"
         const val bom = "$group:kotlinx-coroutines-bom:$version"
         const val core = "$group:kotlinx-coroutines-core:$version"
         const val coreJvm = "$group:kotlinx-coroutines-core-jvm:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.240"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.240"
+    const val version = "2.0.0-SNAPSHOT.301"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.301"
     const val group = Spine.group
     const val artifact = "spine-base"
     const val lib = "$group:$artifact:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJava.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object CoreJava {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.201"
+    const val version = "2.0.0-SNAPSHOT.206"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/McJava.kt
@@ -42,12 +42,12 @@ object McJava {
     /**
      * The version used to in the build classpath.
      */
-    const val dogfoodingVersion = "2.0.0-SNAPSHOT.262"
+    const val dogfoodingVersion = "2.0.0-SNAPSHOT.300"
 
     /**
      * The version to be used for integration tests.
      */
-    const val version = "2.0.0-SNAPSHOT.262"
+    const val version = "2.0.0-SNAPSHOT.300"
 
     /**
      * The ID of the Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoData.kt
@@ -73,7 +73,7 @@ object ProtoData {
      * The version of ProtoData dependencies.
      */
     val version: String
-    private const val fallbackVersion = "0.91.5"
+    private const val fallbackVersion = "0.92.11"
 
     /**
      * The distinct version of ProtoData used by other build tools.
@@ -82,7 +82,7 @@ object ProtoData {
      * transitional dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "0.91.4"
+    private const val fallbackDfVersion = "0.92.11"
 
     /**
      * The artifact for the ProtoData Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ProtoTap.kt
@@ -38,7 +38,7 @@ package io.spine.dependency.local
 )
 object ProtoTap {
     const val group = "io.spine.tools"
-    const val version = "0.8.7"
+    const val version = "0.9.1"
     const val gradlePluginId = "io.spine.prototap"
     const val api = "$group:prototap-api:$version"
     const val gradlePlugin = "$group:prototap-gradle-plugin:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/ToolBase.kt
@@ -34,7 +34,7 @@ package io.spine.dependency.local
 @Suppress("ConstPropertyName", "unused")
 object ToolBase {
     const val group = Spine.toolsGroup
-    const val version = "2.0.0-SNAPSHOT.244"
+    const val version = "2.0.0-SNAPSHOT.300"
 
     const val lib = "$group:spine-tool-base:$version"
     const val pluginBase = "$group:spine-plugin-base:$version"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Validation.kt
@@ -36,7 +36,7 @@ object Validation {
     /**
      * The version of the Validation library artifacts.
      */
-    const val version = "2.0.0-SNAPSHOT.192"
+    const val version = "2.0.0-SNAPSHOT.301"
 
     const val group = "io.spine.validation"
     private const val prefix = "spine-validation"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/Kotest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/KotlinCompileTesting.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/KotlinCompileTesting.kt
@@ -29,12 +29,12 @@ package io.spine.dependency.test
 /**
  * A library for in-process compilation of Kotlin and Java code compilation.
  *
- * @see <a href="https://github.com/tschuchortdev/kotlin-compile-testing">GitHub repo</a>
+ * @see <a href="https://github.com/zacsweers/kotlin-compile-testing">GitHub repo</a>
  */
 @Suppress("unused", "ConstPropertyName")
 object KotlinCompileTesting {
-    private const val version = "1.5.0" // Compatible with Kotlin Compiler 1.8.22.
-    private const val group = "com.github.tschuchortdev"
-    const val lib = "$group:kotlin-compile-testing:$version"
-    const val libKsp = "$group:kotlin-compile-testing-ksp:$version"
+    private const val version = "0.7.0"
+    private const val group = "dev.zacsweers.kctfork"
+    const val libCore = "$group:core:$version"
+    const val libKsp = "$group:ksp:$version"
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunBuild.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunBuild.kt
@@ -32,6 +32,6 @@ package io.spine.gradle
 open class RunBuild : RunGradle() {
 
     init {
-        task("build")
+        task("clean", "build")
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/RunGradle.kt
@@ -100,7 +100,7 @@ open class RunGradle : DefaultTask() {
     }
 
     @TaskAction
-    private fun execute() {
+    public fun execute() {
         // Ensure build error output log.
         // Since we're executing this task in another process, we redirect error output to
         // the file under the `_out` directory. Using the `build` directory for this purpose

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javac/ErrorProne.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javac/ErrorProne.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsContext.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/JsContext.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/javascript/plugin/Protobuf.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/javascript/plugin/Protobuf.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/kotlin/KotlinConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,26 +51,19 @@ fun KotlinJvmProjectExtension.applyJvmToolchain(version: String) =
 /**
  * Opts-in to experimental features that we use in our codebase.
  */
-@Suppress("unused", "MagicNumber" /* Kotlin Compiler version. */)
+@Suppress("unused")
 fun KotlinJvmCompilerOptions.setFreeCompilerArgs() {
-    // Avoid the "unsupported flag warning" for Kotlin compilers pre 1.9.20 and after 2.0.0.
-    // See: https://youtrack.jetbrains.com/issue/KT-61573
-    val expectActualClasses = KotlinVersion.CURRENT.run {
-        if (isAtLeast(1, 9, 20) && major < 2) "-Xexpect-actual-classes"
-        else ""
-    }
     freeCompilerArgs.addAll(
         listOf(
             "-Xskip-prerelease-check",
             "-Xjvm-default=all",
             "-Xinline-classes",
-            expectActualClasses,
             "-opt-in=" +
                     "kotlin.contracts.ExperimentalContracts," +
                     "kotlin.io.path.ExperimentalPathApi," +
                     "kotlin.ExperimentalUnsignedTypes," +
                     "kotlin.ExperimentalStdlibApi," +
                     "kotlin.experimental.ExperimentalTypeInference",
-        ).filter { it.isNotBlank() }
+        )
     )
 }

--- a/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/protobuf/ProtoTaskExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,10 +105,14 @@ private fun GenerateProtoTask.generatedDir(language: String = ""): File {
 fun GenerateProtoTask.setup() {
     builtins.maybeCreate("kotlin")
     setupDescriptorSetFileCreation()
+
+    doFirst {
+        excludeProtocOutput()
+    }
     doLast {
         copyGeneratedFiles()
     }
-    excludeProtocOutput()
+
     setupKotlinCompile()
     dependOnProcessResourcesTask()
     makeDirsForIdeaModule()

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/DependencyWriter.kt
@@ -182,8 +182,8 @@ private fun Project.deduplicate(dependencies: Set<ModuleDependency>): List<Modul
     logDuplicates(groups)
 
     val filtered = groups.map { group ->
-        group.value.maxByOrNull { dep -> dep.version }!!
-    }
+        group.value.maxByOrNull { dep -> dep.version ?: "" }
+    }.filterNotNull()
     return filtered
 }
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ModuleDependency.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/report/pom/ModuleDependency.kt
@@ -40,7 +40,7 @@ internal class ModuleDependency(
     val project: Project,
     val configuration: Configuration,
     private val dependency: Dependency,
-    private val factualVersion: String = dependency.version!!
+    private val factualVersion: String? = dependency.version
 
 ) : Dependency by dependency, Comparable<ModuleDependency> {
 
@@ -52,7 +52,7 @@ internal class ModuleDependency(
             .thenBy { it.factualVersion }
     }
 
-    override fun getVersion(): String = factualVersion
+    override fun getVersion(): String? = factualVersion
 
     /**
      * A project dependency with its [scope][DependencyScope].

--- a/buildSrc/src/main/kotlin/jvm-module.gradle.kts
+++ b/buildSrc/src/main/kotlin/jvm-module.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/buildSrc/src/main/kotlin/write-manifest.gradle.kts
+++ b/buildSrc/src/main/kotlin/write-manifest.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.302`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.303`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -241,6 +241,10 @@
 1.  **Group** : com.puppycrawl.tools. **Name** : checkstyle. **Version** : 10.12.1.
      * **Project URL:** [https://checkstyle.org/](https://checkstyle.org/)
      * **License:** [LGPL-2.1+](http://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt)
+
+1.  **Group** : com.soywiz.korlibs.korte. **Name** : korte-jvm. **Version** : 4.0.10.
+     * **Project URL:** [https://github.com/korlibs/korge-next](https://github.com/korlibs/korge-next)
+     * **License:** [MIT](https://raw.githubusercontent.com/korlibs/korge-next/master/korge/LICENSE.txt)
 
 1.  **Group** : com.squareup. **Name** : kotlinpoet. **Version** : 1.17.0.
      * **Project URL:** [https://github.com/square/kotlinpoet](https://github.com/square/kotlinpoet)
@@ -632,6 +636,10 @@
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
 
+1.  **Group** : org.jetbrains.dokka. **Name** : javadoc-plugin. **Version** : 1.9.20.
+     * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
+     * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
+
 1.  **Group** : org.jetbrains.dokka. **Name** : kotlin-as-java-plugin. **Version** : 1.9.20.
      * **Project URL:** [https://github.com/Kotlin/dokka](https://github.com/Kotlin/dokka)
      * **License:** [The Apache Software License, Version 2.0](https://www.apache.org/licenses/LICENSE-2.0.txt)
@@ -899,4 +907,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 12 15:11:11 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 14 14:09:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -907,4 +907,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 14 14:51:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 14 15:49:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -907,4 +907,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 14 14:09:00 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 14 14:51:34 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/dependencies.md
+++ b/dependencies.md
@@ -907,4 +907,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 14 15:49:06 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 14 16:24:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/gradlew
+++ b/gradlew
@@ -7,15 +7,13 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      https://www.apache.org/licenses/LICENSE-2.0
+# https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# SPDX-License-Identifier: Apache-2.0
 #
 
 ##############################################################################

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.302</version>
+<version>2.0.0-SNAPSHOT.303</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -251,6 +251,11 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.jetbrains.dokka</groupId>
     <artifactId>dokka-core</artifactId>
+    <version>1.9.20</version>
+  </dependency>
+  <dependency>
+    <groupId>org.jetbrains.dokka</groupId>
+    <artifactId>javadoc-plugin</artifactId>
     <version>1.9.20</version>
   </dependency>
   <dependency>

--- a/src/main/kotlin/io/spine/io/Files.kt
+++ b/src/main/kotlin/io/spine/io/Files.kt
@@ -47,7 +47,7 @@ public fun File.replaceExtension(newExtension: String): File {
 /**
  * Obtains the path with [Unix][Separator.Unix] separators.
  *
- * @return `this` if the file is already delimited as required, otherwise creates
+ * @return `this` if the file path is already delimited as required, otherwise creates
  *  a new instance with [Windows][Separator.Windows] file separators replaced.
  */
 public fun File.toUnix(): File =

--- a/src/main/kotlin/io/spine/io/Files.kt
+++ b/src/main/kotlin/io/spine/io/Files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ import java.io.File
  * The function does not check the presence of the file.
  * It does not check if this path represents a directory, either.
  *
- * @param newExtension
- *         a new file extension with or without leading `"."`.
+ * @param newExtension The new file extension with or without leading `"."`.
  */
 public fun File.replaceExtension(newExtension: String): File {
     val newExt = newExtension.ensureDotPrefix()
@@ -46,10 +45,23 @@ public fun File.replaceExtension(newExtension: String): File {
 }
 
 /**
+ * Obtains the path with [Unix][Separator.Unix] separators.
+ *
+ * @return `this` if the file is already delimited as required, otherwise creates
+ *  a new instance with [Windows][Separator.Windows] file separators replaced.
+ */
+public fun File.toUnix(): File =
+    if (path.contains(Separator.Windows)) {
+        File(path.toUnix())
+    } else {
+        this
+    }
+
+/**
  * Ensures that the prefix `.` exists in this string if it is not empty.
  *
  * @return this string if it is already prefixed or is empty,
- *         otherwise returns new prefixed string.
+ *  otherwise returns the new prefixed string.
  */
 internal fun String.ensureDotPrefix() =
     if (isEmpty()) {

--- a/src/main/kotlin/io/spine/io/Paths.kt
+++ b/src/main/kotlin/io/spine/io/Paths.kt
@@ -29,8 +29,11 @@
 package io.spine.io
 
 import io.spine.string.toBase64Encoded
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.nameWithoutExtension
+import kotlin.io.path.pathString
+import kotlin.io.path.Path
 
 /**
  * Converts this path to a Base64-encoded string.
@@ -52,3 +55,43 @@ public fun Path.replaceExtension(newExtension: String): Path {
     val newExt = newExtension.ensureDotPrefix()
     return resolveSibling(nameWithoutExtension + newExt)
 }
+
+/**
+ * Obtains the path with [Unix][Separator.Unix] separators.
+ *
+ * @return `this` if the path is already delimited as required, otherwise creates
+ *  a new instance with [Windows][Separator.Windows] file separators replaced.
+ */
+public fun Path.toUnix(): Path =
+    if (pathString.contains(Separator.Windows)) {
+        Path(pathString.toUnix())
+    } else {
+        this
+    }
+
+/**
+ * Provides values of separators used to delimit directories in a file path.
+ */
+@Suppress("ConstPropertyName") // We use capitalized OS names for constants.
+public object Separator {
+
+    /**
+     * The separator used by the current OS.
+     */
+    public val system: Char = File.separatorChar
+
+    /**
+     * The separator used in Unix-based systems.
+     */
+    public const val Unix: Char = '/'
+
+    /**
+     * The separator used in Windows OS family.
+     */
+    public const val Windows: Char = '\\'
+}
+
+/**
+ * Replaces Windows path separators (`\\`) with those used in Unix-based systems (`/`).
+ */
+internal fun String.toUnix(): String = replace(Separator.Windows, Separator.Unix)

--- a/src/main/kotlin/io/spine/io/Paths.kt
+++ b/src/main/kotlin/io/spine/io/Paths.kt
@@ -94,4 +94,8 @@ public object Separator {
 /**
  * Replaces Windows path separators (`\\`) with those used in Unix-based systems (`/`).
  */
-internal fun String.toUnix(): String = replace(Separator.Windows, Separator.Unix)
+public fun String.toUnix(): String = if (contains(Separator.Windows)) {
+    replace(Separator.Windows, Separator.Unix)
+} else {
+    this
+}

--- a/src/main/kotlin/io/spine/string/Separator.kt
+++ b/src/main/kotlin/io/spine/string/Separator.kt
@@ -90,13 +90,13 @@ public enum class Separator(
          */
         @JvmStatic
         public fun nonSystem(): Iterable<Separator> =
-            values().filter { !it.isSystem() }
+            entries.filter { !it.isSystem() }
 
         /**
          * Finds a separator which value is equal to the given string.
          */
         @JvmStatic
         internal fun findMatching(str: String): Separator? =
-            values().find { str == it.value }
+            entries.find { str == it.value }
     }
 }

--- a/src/main/kotlin/io/spine/string/Strings.kt
+++ b/src/main/kotlin/io/spine/string/Strings.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024, TeamDev. All rights reserved.
+ * Copyright 2025, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -147,7 +147,7 @@ public fun String.pi(indent: String = Indent.defaultJavaIndent.value): String =
 /**
  * Joins the elements of this `Iterable` into a single string having each item on a separate line.
  *
- * The lines are delimited with system line separator.
+ * The lines are delimited with the system line separator.
  */
 public fun Iterable<*>.joinByLines(): String =
     joinToString(separator = NL)
@@ -157,10 +157,8 @@ public fun Iterable<*>.joinByLines(): String =
  *
  * Similar to [prependIndent] but with system-dependent line separator.
  *
- * @param step
- *         the indentation of each level.
- * @param level
- *         the number of indentation levels to add. If zero, no indentation would be added.
+ * @param step The indentation of each level.
+ * @param level The number of indentation levels to add. If zero, no indentation would be added.
  * @see String.pi
  */
 public fun Iterable<String>.indent(step: Indent, level: Int): String {
@@ -171,7 +169,7 @@ public fun Iterable<String>.indent(step: Indent, level: Int): String {
 }
 
 /**
- * Converts this string to Base64-encoded version using UTF-8 charset.
+ * Converts this string to the Base64-encoded version using UTF-8 charset.
  *
  * @see Base64
  */
@@ -198,8 +196,7 @@ public fun String.decodeBase64(): String {
  * The function counts non-overlapping occurrences.
  * For example, the result for the `"aba"` substring in `"ababababa"` would be 2.
  *
- * @param substring
- *         the substring to look for in this one.
+ * @param substring The substring to look for in this one.
  */
 public fun String.count(substring: String): Int {
     var count = 0
@@ -218,6 +215,8 @@ public fun String.count(substring: String): Int {
 
 /**
  * Ensures that this string starts with the given prefix.
+ *
+ * @param prefix The prefix to add to this string if it is not already present.
  */
 public fun String.ensurePrefix(prefix: String): String {
     require(prefix.isNotEmpty()) {
@@ -239,3 +238,19 @@ public inline  fun <reified T> simply(): String = T::class.simpleName!!
  * A shortcut for [shortDebugString] call.
  */
 public fun com.google.protobuf.Message.shortly(): String = shortDebugString()
+
+/**
+ * Transform this string into a plural form if the count is greater than one.
+ *
+ * The function uses English grammar for simple plural forms, if the [pluralForm] parameter
+ * is not specified. So, if `count > 1` and `pluralForm == null`, "${this}s" will be returned.
+ *
+ * Therefore, if the language is not English or the singular word has a non-regular plural form,
+ * please do specify the [pluralForm] parameter.
+ *
+ * @param pluralForm Optional parameter to be used for count > 1.
+ * @return this string if count == 1, [pluralForm], if specified, "${this}s" otherwise.
+ */
+public fun String.pluralize(count: Int, pluralForm: String? = null): String {
+    return if (count == 1) this else pluralForm ?: "${this}s"
+}

--- a/src/main/kotlin/io/spine/string/Strings.kt
+++ b/src/main/kotlin/io/spine/string/Strings.kt
@@ -240,7 +240,7 @@ public inline  fun <reified T> simply(): String = T::class.simpleName!!
 public fun com.google.protobuf.Message.shortly(): String = shortDebugString()
 
 /**
- * Transform this string into a plural form if the count is greater than one.
+ * Transforms this string into a plural form if the count is greater than one.
  *
  * The function uses English grammar for simple plural forms, if the [pluralForm] parameter
  * is not specified. So, if `count > 1` and `pluralForm == null`, "${this}s" will be returned.

--- a/src/test/kotlin/io/spine/io/FilesSpec.kt
+++ b/src/test/kotlin/io/spine/io/FilesSpec.kt
@@ -27,8 +27,11 @@
 package io.spine.io
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import java.io.File
+import kotlin.io.path.Path
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("Extensions for `File` should")
@@ -41,5 +44,21 @@ internal class FilesSpec {
         File("file").replaceExtension("txt") shouldBe File("file.txt")
         File("file.txt").replaceExtension("") shouldBe File("file")
         File("file.").replaceExtension("") shouldBe File("file")
+    }
+
+    @Nested inner class
+    `convert path separators to those from Unix` {
+
+        @Test
+        fun `returning the same instance of the file already has Unix separators`() {
+            val file = File("/my/unix/path")
+            file.toUnix() shouldBeSameInstanceAs file
+        }
+
+        @Test
+        fun `create new instance when Windows separators are present`() {
+            val file = File("C:\\Windows\\path")
+            file.toUnix() shouldBe File("C:/Windows/path")
+        }
     }
 }

--- a/src/test/kotlin/io/spine/io/FilesSpec.kt
+++ b/src/test/kotlin/io/spine/io/FilesSpec.kt
@@ -45,20 +45,4 @@ internal class FilesSpec {
         File("file.txt").replaceExtension("") shouldBe File("file")
         File("file.").replaceExtension("") shouldBe File("file")
     }
-
-    @Nested inner class
-    `convert path separators to those from Unix` {
-
-        @Test
-        fun `returning the same instance of the file already has Unix separators`() {
-            val file = File("/my/unix/path")
-            file.toUnix() shouldBeSameInstanceAs file
-        }
-
-        @Test
-        fun `create new instance when Windows separators are present`() {
-            val file = File("C:\\Windows\\path")
-            file.toUnix() shouldBe File("C:/Windows/path")
-        }
-    }
 }

--- a/src/test/kotlin/io/spine/io/PathsSpec.kt
+++ b/src/test/kotlin/io/spine/io/PathsSpec.kt
@@ -27,12 +27,15 @@
 package io.spine.io
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.spine.string.decodeBase64
 import io.spine.testing.TestValues.randomString
+import java.io.File
 import java.nio.file.Paths
 import kotlin.io.path.Path
 import kotlin.io.path.div
 import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @DisplayName("Extensions for `Path` should")
@@ -54,5 +57,26 @@ internal class PathsSpec {
         Path("file").replaceExtension("txt") shouldBe Path("file.txt")
         Path("file.txt").replaceExtension("") shouldBe Path("file")
         Path("file.").replaceExtension("") shouldBe Path("file")
+    }
+
+    @Test
+    fun `provide current system path separator`() {
+        Separator.system shouldBe File.separatorChar
+    }
+
+    @Nested inner class
+    `convert path separators to those from Unix` {
+
+        @Test
+        fun `returning the same instance of the path already has Unix separators`() {
+            val path = Path("/my/unix/path")
+            path.toUnix() shouldBeSameInstanceAs path
+        }
+
+        @Test
+        fun `create new instance when Windows separators are present`() {
+            val path = Path("C:\\Windows\\path")
+            path.toUnix() shouldBe Path("C:/Windows/path")
+        }
     }
 }

--- a/src/test/kotlin/io/spine/io/PathsSpec.kt
+++ b/src/test/kotlin/io/spine/io/PathsSpec.kt
@@ -64,19 +64,11 @@ internal class PathsSpec {
         Separator.system shouldBe File.separatorChar
     }
 
-    @Nested inner class
-    `convert path separators to those from Unix` {
+    @Test
+    fun `provide extension for replacing Windows file separators`() {
+        "C:\\Windows\\path".toUnix() shouldBe "C:/Windows/path"
 
-        @Test
-        fun `returning the same instance of the path already has Unix separators`() {
-            val path = Path("/my/unix/path")
-            path.toUnix() shouldBeSameInstanceAs path
-        }
-
-        @Test
-        fun `create new instance when Windows separators are present`() {
-            val path = Path("C:\\Windows\\path")
-            path.toUnix() shouldBe Path("C:/Windows/path")
-        }
+        val path = "/my/unix/path"
+        path.toUnix() shouldBeSameInstanceAs path
     }
 }

--- a/src/test/kotlin/io/spine/string/StringsSpec.kt
+++ b/src/test/kotlin/io/spine/string/StringsSpec.kt
@@ -169,4 +169,11 @@ class StringsSpec {
     fun `provide shortcut for 'shortDebugString'`() {
         stringValue { value = "Hey" }.shortly() shouldBe "value: \"Hey\""
     }
+
+    @Test
+    fun `provide utility for pluralizing a string`() {
+        "dog".pluralize(2) shouldBe "dogs"
+        "mouse".pluralize(3, "mice") shouldBe "mice"
+        "cat".pluralize(1) shouldBe "cat"
+    }
 }

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.302")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.303")


### PR DESCRIPTION
This PR introduces extensions for `String`, `File`, and `Path` classes.

### Changes in details
 * `String.pluralize()` function is a helper for building messages that depend on a number of countable things.
 * `String.toUnix()` extension aims to help path strings with Unix file separators. This is usually needed in ProtoData and McJava tests or when creating `io.spine.protodata.ast.File` instances.
 * `GenerateProtoTask.setup()` extension under `buildSrc` was modified to call `excludeProtocOutput()` in the `doFirst` block to avoid concurrent modification exception during project configuration in which KSP plugin is applied.
 * Latest `config` was also updated. 
