### PR TITLE
Clarify `(range)` option and update its error message

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.303`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.304`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -907,4 +907,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Fri Mar 14 16:24:36 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Mar 21 11:48:00 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.303</version>
+<version>2.0.0-SNAPSHOT.304</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1303,7 +1303,7 @@ message RangeOption {
 
     // The default error message.
     option (default_message) = "The field `${parent.type}.${field.path}` must be within"
-        " the following range: `${range.value}`.";
+        " the following range: `${range.value}`. The passed value: `${field.value}`.";
 
     // The string representation of the range.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1299,6 +1299,8 @@ message IfHasDuplicatesOption {
 //
 // For unbounded ranges, please use `(min)` and `(max) options.
 //
+// The option supports all Protobuf numeric fields.
+//
 message RangeOption {
 
     // The default error message.
@@ -1308,22 +1310,44 @@ message RangeOption {
     // The string representation of the range.
     //
     // The range can be open (not including the endpoint) or closed (including the endpoint) on
-    // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints are
-    // indicated using a square bracket (`[`, `]`).
+    // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints
+    // are indicated using a square bracket (`[`, `]`).
     //
-    // Example: Defining ranges of numeric values.
+    // The lower and upper bounds are separated using either `..` or ` .. ` delimiter.
     //
-    //     message NumRanges {
+    // The definition of the range must be consistent with the field type it describes.
+    //
+    // 1. The range for an integer field must be defined with integer numbers.
+    //    Specifying an integer number using the decimal separator (`.`) is not allowed,
+    //    even if the endpoint value has zero fractional part, i.e., `5.0`.
+    //
+    //    Example: Defining ranges of integer values.
+    //
+    //    message IntegerRanges {
     //         int32 hour = 1 [(range).value = "[0..24)"];
     //         uint32 minute = 2 [(range).value = "[0..59]"];
-    //         float degree = 3 [(range).value = "[0.0..360.0)"];
-    //         double angle = 4 [(range).value = "(0.0..180.0)"];
     //     }
     //
-    // NOTE: That definition of ranges must be consistent with the type they describe.
-    //       An range for an integer field must be defined with integer endpoints.
-    //       A range for a floating point field must be defined with decimal separator (`.`),
-    //       even if the endpoint value does not have a fractional part.
+    // 2. The range for a floating point field must be defined with decimal separator (`.`),
+    //    even if the endpoint value does not have a fractional part. An exponent part
+    //    (`E` or `e` followed by an optional sign and digits) is allowed.
+    //
+    //    Example: Defining ranges of floating-point values.
+    //
+    //     message NumRanges {
+    //         float degree = 1 [(range).value = "[0.0 .. 360.0)"];
+    //         double angle = 2 [(range).value = "(0.0 .. 180.0)"];
+    //     }
+    //
+    // 3. The specified range must not exceed the range of the field type itself.
+    //
+    //    Example: Invalid ranges that do not fit into the range of the field.
+    //
+    //    message OverflowRanges {
+    //        float price = 1 [(range).value = "[0, 5.5E38]"]; // Goes above the `float` maximum.
+    //        uint32 size = 2 [(range).value = "[-5; 10]"]; // Goes below the `uint32` minimum.
+    //    }
+    //
     //
     string value = 1;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1321,7 +1321,7 @@ message RangeOption {
     // - Open bounds exclude the endpoint and are indicated using parentheses (`(`, `)`).
     //   Example: `(0..10)` represents values strictly between 0 and 10.
     //
-    // The lower bound must be strictly less than the upper bound.
+    // The lower bound must be less than or equal to the upper bound.
     //
     // ## Integer Fields
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1309,43 +1309,47 @@ message RangeOption {
 
     // The string representation of the range.
     //
-    // The range can be open (not including the endpoint) or closed (including the endpoint) on
-    // each side. Open endpoints are indicated using a parenthesis (`(`, `)`). Closed endpoints
-    // are indicated using a square bracket (`[`, `]`).
+    // ## Syntax
     //
-    // The lower and upper bounds are separated using either `..` or ` .. ` delimiter.
+    // 1. The range can be open (not including the endpoint) or closed (including the endpoint)
+    //    on each side. Open endpoints are indicated using a parenthesis (`(`, `)`).
+    //    Closed endpoints are indicated using a square bracket (`[`, `]`).
+    // 2. The lower and upper endpoints are separated by either the `..` or ` .. ` delimiter.
+    // 3. The lower bound must be strictly less than the upper bound.
+    //
+    // ## Field type consistency
     //
     // The definition of the range must be consistent with the field type it describes.
     //
-    // 1. The range for an integer field must be defined with integer numbers.
-    //    Specifying an integer number using the decimal separator (`.`) is not allowed,
-    //    even if the endpoint value has zero fractional part, i.e., `5.0`.
+    // 1. A range for an integer field must use integer numbers. Specifying an integer
+    //    with a decimal separator (`.`) is not allowed, even if the value has no
+    //    fractional part (e.g., `5.0`).
     //
-    //    Example: Defining ranges of integer values.
+    //    Example: Defining ranges for integer fields.
     //
     //    message IntegerRanges {
     //         int32 hour = 1 [(range).value = "[0..24)"];
     //         uint32 minute = 2 [(range).value = "[0..59]"];
     //     }
     //
-    // 2. The range for a floating point field must be defined with decimal separator (`.`),
-    //    even if the endpoint value does not have a fractional part. An exponent part
-    //    (`E` or `e` followed by an optional sign and digits) is allowed.
+    // 2. A range for a floating point field must always use a decimal separator (`.`),
+    //    even if the value value has no fractional part. An exponent part
+    //    (`E` or `e`, followed by an optional sign and digits) is allowed.
     //
-    //    Example: Defining ranges of floating-point values.
+    //    Example: Defining ranges for floating-point fields.
     //
-    //     message NumRanges {
+    //     message FloatRanges {
     //         float degree = 1 [(range).value = "[0.0 .. 360.0)"];
     //         double angle = 2 [(range).value = "(0.0 .. 180.0)"];
     //     }
     //
-    // 3. The specified range must not exceed the range of the field type itself.
+    // 3. A range must not exceed the limits of the field type.
     //
-    //    Example: Invalid ranges that do not fit into the range of the field.
+    //    Example: Invalid ranges that exceed the field type limits.
     //
     //    message OverflowRanges {
-    //        float price = 1 [(range).value = "[0, 5.5E38]"]; // Goes above the `float` maximum.
-    //        uint32 size = 2 [(range).value = "[-5; 10]"]; // Goes below the `uint32` minimum.
+    //        float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.
+    //        uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
     //    }
     //
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1309,48 +1309,56 @@ message RangeOption {
 
     // The string representation of the range.
     //
-    // ## Syntax
+    // A range consists of two bounds: a lower bound and an upper bound. These bounds are
+    // separated by either the `..` or ` .. ` delimiter. Each bound can be either open
+    // or closed. The format of the bounds and the valid values depend on the type of field.
     //
-    // 1. The range can be open (not including the endpoint) or closed (including the endpoint)
-    //    on each side. Open endpoints are indicated using a parenthesis (`(`, `)`).
-    //    Closed endpoints are indicated using a square bracket (`[`, `]`).
-    // 2. The lower and upper endpoints are separated by either the `..` or ` .. ` delimiter.
-    // 3. The lower bound must be strictly less than the upper bound.
+    // ## Bound Types
     //
-    // ## Field type consistency
+    // - Closed bounds include the endpoint and are indicated using square brackets (`[`, `]`).
+    //   Example: `[0..10]` represents values from 0 to 10, inclusive.
     //
-    // The definition of the range must be consistent with the field type it describes.
+    // - Open bounds exclude the endpoint and are indicated using parentheses (`(`, `)`).
+    //   Example: `(0..10)` represents values strictly between 0 and 10.
     //
-    // 1. A range for an integer field must use integer numbers. Specifying an integer
-    //    with a decimal separator (`.`) is not allowed, even if the value has no
-    //    fractional part (e.g., `5.0`).
+    // The lower bound must be strictly less than the upper bound.
     //
-    //    Example: Defining ranges for integer fields.
+    // ## Integer Fields
     //
-    //    message IntegerRanges {
-    //         int32 hour = 1 [(range).value = "[0..24)"];
-    //         uint32 minute = 2 [(range).value = "[0..59]"];
-    //     }
+    // A range for an integer field must use integer numbers. Specifying a decimal number
+    // is not allowed, even if it has no fractional part (e.g., `5.0` is invalid).
     //
-    // 2. A range for a floating point field must always use a decimal separator (`.`),
-    //    even if the value value has no fractional part. An exponent part
-    //    (`E` or `e`, followed by an optional sign and digits) is allowed.
+    // Example: Defining ranges for integer fields.
     //
-    //    Example: Defining ranges for floating-point fields.
+    // message IntegerRanges {
+    //      int32 hour = 1 [(range).value = "[0..24)"];
+    //      uint32 minute = 2 [(range).value = "[0..59]"];
+    //  }
     //
-    //     message FloatRanges {
-    //         float degree = 1 [(range).value = "[0.0 .. 360.0)"];
-    //         double angle = 2 [(range).value = "(0.0 .. 180.0)"];
-    //     }
+    // ## Floating-Point Fields
     //
-    // 3. A range must not exceed the limits of the field type.
+    // A range for a floating-point field must use a decimal separator (`.`), even if the value
+    // has no fractional part. An exponent part represented by `E` or `e`, followed by an optional
+    // sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
     //
-    //    Example: Invalid ranges that exceed the field type limits.
+    // Example: Defining ranges for floating-point fields.
     //
-    //    message OverflowRanges {
-    //        float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.
-    //        uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
-    //    }
+    // message FloatRanges {
+    //     float degree = 1 [(range).value = "[0.0 .. 360.0)"];
+    //     double angle = 2 [(range).value = "(0.0 .. 180.0)"];
+    //     float pressure = 3 [(range).value = "[950.0E-2 .. 1050.0E-2]"];
+    // }
+    //
+    // ## Field Type Limitations
+    //
+    // A range must not exceed the limits of the field type.
+    //
+    // Example: Invalid ranges that exceed the field type limits.
+    //
+    // message OverflowRanges {
+    //     float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.
+    //     uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
+    // }
     //
     //
     string value = 1;

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.303")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.304")


### PR DESCRIPTION
This PR updates docs to the `(range)` option and adds the `${field.value}` placeholder to the default error message.