### PR TITLE
Update docs to `(min)` and `(max)` options

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.305`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.306`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -903,4 +903,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Mar 25 16:50:13 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed Mar 26 16:28:49 CET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.305</version>
+<version>2.0.0-SNAPSHOT.306</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -779,7 +779,7 @@ message MinOption {
 
     // The default error message.
     option (default_message) = "The field `${parent.type}.${field.path}`"
-        " must be ${max.operator} ${min.value}. The passed value: `${field.value}`.";
+        " must be ${min.operator} ${min.value}. The passed value: `${field.value}`.";
 
     // The string representation of the minimum field value.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -866,7 +866,7 @@ message MaxOption {
     //
     // Example: Defining maximum values for integer and floating-point fields.
     //
-    // message MinimumValues {
+    // message MaximumValues {
     //     int32 temperature = 1 [(max).value = "270"];
     //     uint32 employees = 2 [(max).value = "1200"];
     //     float degree = 1 [(max).value = "360.0"];

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -275,7 +275,7 @@ extend google.protobuf.FieldOptions {
     // A typical use case involves a field, such as an ID, which remains constant throughout
     // the lifecycle of an entity.
     //
-    // Example: Using `(set_once)` field validation constraint.
+    // Example: using `(set_once)` field validation constraint.
     //
     //     message User {
     //         UserId id = 1 [(set_once) = true];
@@ -303,7 +303,7 @@ extend google.protobuf.FieldOptions {
     // For example, in Java, it is defined by the `equals()` method. No special cases are applied,
     // such as comparing only specific fields like IDs.
     //
-    // Example: Using `(distinct)` constraint for a `repeated` field.
+    // Example: using `(distinct)` constraint for a `repeated` field.
     //
     //    message Blizzard {
     //
@@ -315,7 +315,7 @@ extend google.protobuf.FieldOptions {
     //        repeated Snowflake snowflakes = 1 [(distinct) = true];
     //    }
     //
-    // Example: Using `(distinct)` constraint for a `map` field.
+    // Example: using `(distinct)` constraint for a `map` field.
     //
     //    message UniqueEmails {
     //
@@ -471,7 +471,7 @@ extend google.protobuf.MessageOptions {
     // Field names are separated using the pipe (`|`) symbol. The combination of fields is defined
     // using the ampersand (`&`) symbol.
     //
-    // Example: Pipe syntax for defining alternative required fields.
+    // Example: pipe syntax for defining alternative required fields.
     //
     //     message PersonName {
     //        option (required_field) = "given_name|honorific_prefix & family_name";
@@ -499,7 +499,7 @@ extend google.protobuf.MessageOptions {
     // A target field of an external constraint should be specified using a fully-qualified
     // field name (e.g. `mypackage.MessageName.field_name`).
     //
-    // Example: Defining external validation constraint.
+    // Example: defining external validation constraint.
     //
     //     package io.spine.example;
     //
@@ -556,7 +556,7 @@ extend google.protobuf.MessageOptions {
     // External validation constraints can be applied to fields of several types.
     // To do so, separate fully-qualified references to these fields with comma.
     //
-    // Example: External validation constraints for multiple fields.
+    // Example: external validation constraints for multiple fields.
     //
     //     // External validation constraint for requiring a new value in renaming commands.
     //     message RequireNewName {
@@ -609,7 +609,7 @@ extend google.protobuf.MessageOptions {
 
     // Specifies a characteristic inherent in the the given message type.
     //
-    // Example: Using `(is)` message option.
+    // Example: using `(is)` message option.
     //
     //     message CreateProject {
     //         option (is).java_type = "ProjectCommand";
@@ -692,7 +692,7 @@ extend google.protobuf.FileOptions {
 
     // Specifies a characteristic common for all the message types in the given file.
     //
-    // Example: Marking all the messages using the `(every_is)` file option.
+    // Example: marking all the messages using the `(every_is)` file option.
     // ```
     //     option (every_is).java_type = "ProjectCommand";
     //
@@ -761,7 +761,7 @@ message IfMissingOption {
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
-    // Example: Using the `(if_missing)` option.
+    // Example: using the `(if_missing)` option.
     //
     //    message Student {
     //        Name name = 1 [(required) = true,
@@ -792,7 +792,7 @@ message MinOption {
     // the value has no fractional part. An exponent part represented by `E` or `e`, followed
     // by an optional sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
     //
-    // Example: Defining minimum values for integer and floating-point fields.
+    // Example: defining minimum values for integer and floating-point fields.
     //
     // message MinimumValues {
     //     int32 temperature = 1 [(min).value = "0"];
@@ -806,7 +806,7 @@ message MinOption {
     //
     // A minimum value must not fall below the limits of the field type.
     //
-    // Example: Invalid values that fall below the field type limits.
+    // Example: invalid values that fall below the field type limits.
     //
     // message OverflowValues {
     //     float price = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
@@ -862,7 +862,7 @@ message MaxOption {
     // the value has no fractional part. An exponent part represented by `E` or `e`, followed
     // by an optional sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
     //
-    // Example: Defining maximum values for integer and floating-point fields.
+    // Example: defining maximum values for integer and floating-point fields.
     //
     // message MaximumValues {
     //     int32 temperature = 1 [(max).value = "270"];
@@ -876,7 +876,7 @@ message MaxOption {
     //
     // A maximum value must not exceed the limits of the field type.
     //
-    // Example: Invalid values that exceed the field type limits.
+    // Example: invalid values that exceed the field type limits.
     //
     // message OverflowValues {
     //     float price = 1 [(min).value = "5.5E38"]; // Exceeds the `float` maximum.
@@ -916,7 +916,7 @@ message MaxOption {
 // This option is applicable only to string fields,
 // including those that are repeated.
 //
-// Example: Using the `(pattern)` option.
+// Example: using the `(pattern)` option.
 //
 //     message CreateAccount {
 //         string id = 1 [(pattern).regex = "^[A-Za-z0-9+]+$",
@@ -1051,7 +1051,7 @@ message IfInvalidOption {
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
-    // Example: Using the `(if_invalid)` option.
+    // Example: using the `(if_invalid)` option.
     //
     //     message Transaction {
     //         TransactionDetails details = 1 [(validate) = true,
@@ -1074,7 +1074,7 @@ message IfInvalidOption {
 // - Repeated fields and maps.
 // - `string` and `bytes`.
 //
-// Example: Requiring mutual presence of optional fields.
+// Example: requiring mutual presence of optional fields.
 //
 //    message ScheduledItem {
 //        ...
@@ -1294,7 +1294,7 @@ message IfSetAgainOption {
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
-    // Example: Using the `(set_once)` option.
+    // Example: using the `(set_once)` option.
     //
     //     message User {
     //         UserId id = 1 [(set_once) = true,
@@ -1327,7 +1327,7 @@ message IfHasDuplicatesOption {
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //
-    // Example: Using the `(distinct)` option.
+    // Example: using the `(distinct)` option.
     //
     //    message Blizzard {
     //        repeated Snowflake = 1 [(distinct) = true,
@@ -1370,7 +1370,7 @@ message RangeOption {
     // A range for an integer field must use integer numbers. Specifying a decimal number
     // is not allowed, even if it has no fractional part (e.g., `5.0` is invalid).
     //
-    // Example: Defining ranges for integer fields.
+    // Example: defining ranges for integer fields.
     //
     // message IntegerRanges {
     //      int32 hour = 1 [(range).value = "[0..24)"];
@@ -1383,7 +1383,7 @@ message RangeOption {
     // has no fractional part. An exponent part represented by `E` or `e`, followed by an optional
     // sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
     //
-    // Example: Defining ranges for floating-point fields.
+    // Example: defining ranges for floating-point fields.
     //
     // message FloatRanges {
     //     float degree = 1 [(range).value = "[0.0 .. 360.0)"];
@@ -1395,7 +1395,7 @@ message RangeOption {
     //
     // A range must not exceed the limits of the field type.
     //
-    // Example: Invalid ranges that exceed the field type limits.
+    // Example: invalid ranges that exceed the field type limits.
     //
     // message OverflowRanges {
     //     float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -771,28 +771,49 @@ message IfMissingOption {
     string error_msg = 2;
 }
 
-// The field value must be greater than or equal to the given minimum number.
+// The option to indicate that a numeric field is required to be greater than or equal
+// to the given value.
 //
-// Is applicable only to number fields.
-// Repeated fields are supported.
-//
-// Example: Defining lower boundary for a numeric field.
-//
-//     message KelvinTemperature {
-//         double value = 1 [(min) = {
-//             value: "0.0",
-//             exclusive: true,
-//             error_msg: "The temperature cannot reach `${min.value}K`, but provided `${field.value}`."
-//         }];
-//     }
+// The option supports all singular and repeated numeric fields.
 //
 message MinOption {
 
     // The default error message.
     option (default_message) = "The field `${parent.type}.${field.path}`"
-        " must be ${max.operator} ${min.value}.";
+        " must be ${max.operator} ${min.value}. The passed value: `${field.value}`.";
 
     // The string representation of the minimum field value.
+    //
+    // ## Integer and floating-point values
+    //
+    // A minimum value for an integer field must use an integer number. Specifying a decimal
+    // number is not allowed, even if it has no fractional part (e.g., `5.0` is invalid).
+    //
+    // A minimum value for a floating-point field must use a decimal separator (`.`), even if
+    // the value has no fractional part. An exponent part represented by `E` or `e`, followed
+    // by an optional sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
+    //
+    // Example: Defining minimum values for integer and floating-point fields.
+    //
+    // message MinimumValues {
+    //     int32 temperature = 1 [(min).value = "0"];
+    //     uint32 employees = 2 [(min).value = "5"];
+    //     float degree = 1 [(min).value = "0.0"];
+    //     double angle = 2 [(min).value = "30.0"];
+    //     float pressure = 3 [(min).value = "950.0E-2"];
+    //  }
+    //
+    // ## Field Type Limitations
+    //
+    // A minimum value must not exceed the limits of the field type.
+    //
+    // Example: Invalid values that exceed the field type limits.
+    //
+    // message OverflowValues {
+    //     float price = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
+    //     uint32 size = 2 [(min).value = "-5"]; // Falls below the `uint32` minimum.
+    // }
+    //
     string value = 1;
 
     // Specifies if the field should be strictly greater than the specified minimum.
@@ -1299,7 +1320,7 @@ message IfHasDuplicatesOption {
 //
 // For unbounded ranges, please use `(min)` and `(max) options.
 //
-// The option supports all Protobuf numeric fields.
+// The option supports all singular and repeated numeric fields.
 //
 message RangeOption {
 
@@ -1359,7 +1380,6 @@ message RangeOption {
     //     float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.
     //     uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
     // }
-    //
     //
     string value = 1;
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -771,8 +771,7 @@ message IfMissingOption {
     string error_msg = 2;
 }
 
-// The option to indicate that a numeric field is required to be greater than or equal
-// to the given value.
+// Indicates that the numeric field must be greater than or equal to the specified value.
 //
 // The option supports all singular and repeated numeric fields.
 //
@@ -842,8 +841,7 @@ message MinOption {
     string error_msg = 4;
 }
 
-// The option to indicate that a numeric field is required to be less than or equal
-// to the given value.
+// Indicates that the numeric field must be less than or equal to the specified value.
 //
 // The option supports all singular and repeated numeric fields.
 //
@@ -1339,8 +1337,7 @@ message IfHasDuplicatesOption {
     string error_msg = 1;
 }
 
-// The option to indicate that a numeric field is required to have a value which belongs
-// to the specified bounded range.
+// Indicate that the numeric field must belong to the specified bounded range.
 //
 // For unbounded ranges, please use `(min)` and `(max) options.
 //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -805,9 +805,9 @@ message MinOption {
     //
     // ## Field Type Limitations
     //
-    // A minimum value must not exceed the limits of the field type.
+    // A minimum value must not fall below the limits of the field type.
     //
-    // Example: Invalid values that exceed the field type limits.
+    // Example: Invalid values that fall below the field type limits.
     //
     // message OverflowValues {
     //     float price = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
@@ -842,25 +842,49 @@ message MinOption {
     string error_msg = 4;
 }
 
-// The field value must be less than or equal to the given maximum number.
+// The option to indicate that a numeric field is required to be less than or equal
+// to the given value.
 //
-// Is applicable only to number fields.
-// Repeated fields are supported.
-//
-// Example: Defining upper boundary for a numeric field.
-//
-//     message TowerCrane {
-//         double load = 1 [(max).value = "4.2",
-//                          (max).error_msg = "The crane load in `${parent.type}` can not exceed `${max.value}` tons, but provided `${field.value}`."];
-//     }
+// The option supports all singular and repeated numeric fields.
 //
 message MaxOption {
 
     // The default error message.
     option (default_message) = "The field `${parent.type}.${field.path}`"
-        " must be ${max.operator} ${max.value}.";
+        " must be ${max.operator} ${max.value}. The passed value: `${field.value}`.";
 
     // The string representation of the maximum field value.
+    //
+    // ## Integer and floating-point values
+    //
+    // A maximum value for an integer field must use an integer number. Specifying a decimal
+    // number is not allowed, even if it has no fractional part (e.g., `5.0` is invalid).
+    //
+    // A maximum value for a floating-point field must use a decimal separator (`.`), even if
+    // the value has no fractional part. An exponent part represented by `E` or `e`, followed
+    // by an optional sign and digits is allowed (e.g., `1.2E3`, `0.5e-2`).
+    //
+    // Example: Defining maximum values for integer and floating-point fields.
+    //
+    // message MinimumValues {
+    //     int32 temperature = 1 [(max).value = "270"];
+    //     uint32 employees = 2 [(max).value = "1200"];
+    //     float degree = 1 [(max).value = "360.0"];
+    //     double angle = 2 [(max).value = "90.0"];
+    //     float pressure = 3 [(max).value = "1050.0E-2"];
+    //  }
+    //
+    // ## Field Type Limitations
+    //
+    // A maximum value must not exceed the limits of the field type.
+    //
+    // Example: Invalid values that exceed the field type limits.
+    //
+    // message OverflowValues {
+    //     float price = 1 [(min).value = "5.5E38"]; // Exceeds the `float` maximum.
+    //     int32 size = 2 [(min).value = "2147483648"]; // Exceeds the `int32` maximum.
+    // }
+    //
     string value = 1;
 
     // Specifies if the field should be strictly less than the specified maximum

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.305")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.306")


### PR DESCRIPTION
This PR updates docs to `(min)` and `(max)` options.

The default error messages were also updated to include the field value.