### PR TITLE
Add `ChoiceOption` and `RequireOption`

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.307`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.308`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -903,4 +903,4 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Mar 26 17:19:58 WET 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Fri Apr 04 12:32:05 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base</artifactId>
-<version>2.0.0-SNAPSHOT.307</version>
+<version>2.0.0-SNAPSHOT.308</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1404,7 +1404,7 @@ message RangeOption {
 // Controls whether a `oneof` group must always have one of its fields set.
 //
 // Note that unlike the `(required)` constraint, this option supports any field types
-// of the `oneof` cases.
+// within the group cases.
 //
 message ChoiceOption {
 
@@ -1427,7 +1427,8 @@ message ChoiceOption {
     string error_msg = 2;
 }
 
-// The constraint to require at least one of the fields or combinations of fields.
+// The constraint to require at least one of the fields or combinations of fields
+// to be set.
 //
 // Unlike the `(required)` field constraint, which requires the presence of a specific
 // field, this option allows to specify alternative fields or combinations of them.
@@ -1438,19 +1439,19 @@ message RequireOption {
     option (default_message) = "The message `${message.type}` must have at least one of"
         " the following fields or combinations of them specified: `${require.fields}`.";
 
-    // A set of fields or combinations of fields, at least one of which must be set.
+    // A set of fields or combinations of fields, at least one of which must be specified.
     //
     // Fields are separated using the pipe (`|`) symbol. The combination of fields is defined
     // using the ampersand (`&`) symbol. `oneof` group names are also valid and can be used
     // as alternatives.
     //
-    // The field type determines when the field is considered set:
+    // The field type determines when the field is considered specified:
     //
     // 1. For message or enum fields, it must have a non-default instance.
     // 2. For `string` and `bytes` fields, it must be non-empty.
     // 3. For repeated fields and maps, it must contain at least one element.
     //
-    // Field of other types are not supported by this option.
+    // Fields of other types are not supported by this option.
     //
     // For `oneof` groups, the restrictions above do not apply. Any `oneof` group can be used
     // without considering the field types, and its value will be checked directly without

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -461,28 +461,8 @@ extend google.protobuf.MessageOptions {
     //
     string default_message = 73901 [(internal) = true];
 
-    // The constraint to require at least one of the fields or a combination of fields.
-    //
-    // Unlike the `required` field constraint which always requires corresponding field,
-    // this message option allows to require alternative fields or a combination of them as
-    // an alternative. Field names and `oneof` group names are acceptable.
-    //
-    // Field names are separated using the pipe (`|`) symbol. The combination of fields is defined
-    // using the ampersand (`&`) symbol.
-    //
-    // Example: pipe syntax for defining alternative required fields.
-    //
-    //     message PersonName {
-    //        option (required_field) = "given_name|honorific_prefix & family_name";
-    //
-    //        string honorific_prefix = 1;
-    //        string given_name = 2;
-    //        string middle_name = 3;
-    //        string family_name = 4;
-    //        string honorific_suffix = 5;
-    //     }
-    //
-    string required_field = 73902;
+    // Deprecated: use the `(require)` option instead.
+    string required_field = 73902 [deprecated = true];
 
     // See `EntityOption`.
     EntityOption entity = 73903;
@@ -640,7 +620,10 @@ extend google.protobuf.MessageOptions {
     //
     CompareByOption compare_by = 73923;
 
-    // Reserved 73924 to 73938 for future options.
+    // The constraint to require at least one of the fields or combinations of fields.
+    RequireOption require = 73924;
+
+    // Reserved 73925 to 73938 for future options.
 
     // Reserved 73939 and 73940 for the deleted options `events` and `rejections`.
 }
@@ -1419,11 +1402,15 @@ message RangeOption {
 }
 
 // Controls whether a `oneof` group must always have one of its fields set.
+//
+// Note that unlike the `(required)` constraint, this option supports any field types
+// of the `oneof` cases.
+//
 message ChoiceOption {
 
     // The default error message.
     option (default_message) = "The `oneof` group `${parent.type}.${group.path}` must"
-        "have one of its fields set.";
+        " have one of its fields set.";
 
     // Enables or disables the requirement for the `oneof` group to have a value.
     bool required = 1;
@@ -1434,6 +1421,64 @@ message ChoiceOption {
     //
     // 1. `${group.path}` – the group path.
     // 2. `${parent.type}` – the fully qualified name of the validated message.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 2;
+}
+
+// The constraint to require at least one of the fields or combinations of fields.
+//
+// Unlike the `(required)` field constraint, which requires the presence of a specific
+// field, this option allows to specify alternative fields or combinations of them.
+//
+message RequireOption {
+
+    // The default error message.
+    option (default_message) = "The message `${message.type}` must have at least one of"
+        " the following fields or combinations of them specified: `${require.fields}`.";
+
+    // A set of fields or combinations of fields, at least one of which must be set.
+    //
+    // Fields are separated using the pipe (`|`) symbol. The combination of fields is defined
+    // using the ampersand (`&`) symbol. `oneof` group names are also valid and can be used
+    // as alternatives.
+    //
+    // The field type determines when the field is considered set:
+    //
+    // 1. For message or enum fields, it must have a non-default instance.
+    // 2. For `string` and `bytes` fields, it must be non-empty.
+    // 3. For repeated fields and maps, it must contain at least one element.
+    //
+    // Field of other types are not supported by this option.
+    //
+    // For `oneof` groups, the restrictions above do not apply. Any `oneof` group can be used
+    // without considering the field types, and its value will be checked directly without
+    // relying on the default values of the fields within the group.
+    //
+    // Example: defining alternative required fields.
+    //
+    //     message PersonName {
+    //         option (required_field) = "given_name | honorific_prefix & family_name";
+    //
+    //         string honorific_prefix = 1;
+    //         string given_name = 2;
+    //         string middle_name = 3;
+    //         string family_name = 4;
+    //         string honorific_suffix = 5;
+    //     }
+    //
+    // In this example, at least `given_name` or a combination of `honorific_prefix`
+    // and `family_name` must be set.
+    //
+    string fields = 1;
+
+    // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `${message.type}` – the fully qualified name of the validated message.
+    // 2. `${require.fields}` – the specified set of fields and combinations of them.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -1460,7 +1460,7 @@ message RequireOption {
     // Example: defining alternative required fields.
     //
     //     message PersonName {
-    //         option (required_field) = "given_name | honorific_prefix & family_name";
+    //         option (require).fields = "given_name | honorific_prefix & family_name";
     //
     //         string honorific_prefix = 1;
     //         string given_name = 2;

--- a/src/main/proto/spine/options.proto
+++ b/src/main/proto/spine/options.proto
@@ -425,14 +425,13 @@ extend google.protobuf.FieldOptions {
 
 extend google.protobuf.OneofOptions {
 
-    // Marks a `oneof` group, in which one field *must* be set.
-    //
-    // Alternative to `(required_field)` with all the field in the group
-    // joined with the OR operator.
-    //
-    bool is_required = 73891;
+    // Deprecated: use the `(choice)` option instead.
+    bool is_required = 73891 [deprecated = true];
 
-    // Reserved 73892 to 73899 for future options.
+    // Controls whether a `oneof` group must always have one of its fields set.
+    ChoiceOption choice = 73892;
+
+    // Reserved 73893 to 73899 for future options.
 }
 
 extend google.protobuf.MessageOptions {
@@ -1413,6 +1412,28 @@ message RangeOption {
     // 3. `${field.type}` – the fully qualified name of the field type.
     // 4. `${parent.type}` – the fully qualified name of the validated message.
     // 5. `${range.value}` – the specified range.
+    //
+    // The placeholders will be replaced at runtime when the error is constructed.
+    //
+    string error_msg = 2;
+}
+
+// Controls whether a `oneof` group must always have one of its fields set.
+message ChoiceOption {
+
+    // The default error message.
+    option (default_message) = "The `oneof` group `${parent.type}.${group.path}` must"
+        "have one of its fields set.";
+
+    // Enables or disables the requirement for the `oneof` group to have a value.
+    bool required = 1;
+
+    // A user-defined error message.
+    //
+    // The specified message may include the following placeholders:
+    //
+    // 1. `${group.path}` – the group path.
+    // 2. `${parent.type}` – the fully qualified name of the validated message.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.307")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.308")


### PR DESCRIPTION
This PR deprecates `(is_required)` and `(required_fields)` in favor of `(choice)` and `(require)` options, which are message-based now.

Please note that I retained `error_msg` field instead of `if_missing` to be in sync with the used convention. All companion fields ~ `(if_missing).error_msg` and message options ~ `(pattern).error_msg` already use this name.