### PR TITLE
Force JUnit as a platform

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -50,7 +50,6 @@ import io.spine.dependency.lib.Slf4J
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.Spine
 import io.spine.dependency.test.Hamcrest
-import io.spine.dependency.test.JUnit
 import io.spine.dependency.test.Kotest
 import io.spine.dependency.test.OpenTest4J
 import io.spine.dependency.test.Truth

--- a/buildSrc/src/main/kotlin/DependencyResolution.kt
+++ b/buildSrc/src/main/kotlin/DependencyResolution.kt
@@ -113,11 +113,6 @@ private fun ResolutionStrategy.forceProductionDependencies() {
 private fun ResolutionStrategy.forceTestDependencies() {
     force(
         Guava.testLib,
-        JUnit.api,
-        JUnit.bom,
-        JUnit.Platform.commons,
-        JUnit.Platform.launcher,
-        JUnit.legacy,
         Truth.libs,
         Kotest.assertions,
     )
@@ -140,9 +135,6 @@ private fun ResolutionStrategy.forceTransitiveDependencies() {
         Gson.lib,
         Hamcrest.core,
         J2ObjC.annotations,
-        JUnit.Platform.engine,
-        JUnit.Platform.suiteApi,
-        JUnit.runner,
         Jackson.annotations,
         Jackson.bom,
         Jackson.core,

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -30,6 +30,20 @@ package io.spine.dependency.test
 @Suppress("unused", "ConstPropertyName")
 object JUnit {
     const val version = "5.12.2"
+
+    /**
+     * The BOM of JUnit.
+     *
+     * This one should be forced in a project via:
+     *
+     * ```kotlin
+     * dependencies {
+     *     testImplementation(enforcedPlatform(JUnit.bom))
+     * }
+     * ```
+     */
+    const val bom = "org.junit:junit-bom:$version"
+
     private const val legacyVersion = "4.13.1"
 
     // https://github.com/apiguardian-team/apiguardian
@@ -37,30 +51,40 @@ object JUnit {
 
     // https://github.com/junit-pioneer/junit-pioneer
     private const val pioneerVersion = "2.3.0"
+    const val pioneer = "org.junit-pioneer:junit-pioneer:$pioneerVersion"
 
     const val legacy = "junit:junit:$legacyVersion"
 
-    const val bom = "org.junit:junit-bom:$version"
-
+    @Deprecated("Use JUnit.Jupiter.api instead", ReplaceWith("JUnit.Jupiter.api"))
     val api = listOf(
         "org.apiguardian:apiguardian-api:$apiGuardianVersion",
         "org.junit.jupiter:junit-jupiter-api:$version",
         "org.junit.jupiter:junit-jupiter-params:$version"
     )
 
+    @Deprecated("Use JUnit.Jupiter.engine instead", ReplaceWith("JUnit.Jupiter.engine"))
     const val runner = "org.junit.jupiter:junit-jupiter-engine:$version"
-    const val params = "org.junit.jupiter:junit-jupiter-params:$version"
 
-    const val pioneer = "org.junit-pioneer:junit-pioneer:$pioneerVersion"
+    @Deprecated("Use JUnit.Jupiter.params instead", ReplaceWith("JUnit.Jupiter.params"))
+    const val params = "org.junit.jupiter:junit-jupiter-params:$version"
+    
+    object Jupiter {
+        const val group = "org.junit.jupiter"
+        private const val infix = "junit-jupiter"
+
+        // We do not use versions because they are forced via BOM.
+        const val api = "$group:$infix-api"
+        const val params = "$group:$infix-params"
+        const val engine = "$group:$infix-engine"
+    }
 
     object Platform {
         // https://junit.org/junit5/
-        const val version = "1.12.2"
         internal const val group = "org.junit.platform"
         private const val infix = "junit-platform"
-        const val commons = "$group:$infix-commons:$version"
-        const val launcher = "$group:$infix-launcher:$version"
-        const val engine = "$group:$infix-engine:$version"
-        const val suiteApi = "$group:$infix-suite-api:$version"
+        const val commons = "$group:$infix-commons"
+        const val launcher = "$group:$infix-launcher"
+        const val engine = "$group:$infix-engine"
+        const val suiteApi = "$group:$infix-suite-api"
     }
 }

--- a/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/test/JUnit.kt
@@ -40,12 +40,13 @@ object JUnit {
 
     const val legacy = "junit:junit:$legacyVersion"
 
+    const val bom = "org.junit:junit-bom:$version"
+
     val api = listOf(
         "org.apiguardian:apiguardian-api:$apiGuardianVersion",
         "org.junit.jupiter:junit-jupiter-api:$version",
         "org.junit.jupiter:junit-jupiter-params:$version"
     )
-    const val bom = "org.junit:junit-bom:$version"
 
     const val runner = "org.junit.jupiter:junit-jupiter-engine:$version"
     const val params = "org.junit.jupiter:junit-jupiter-params:$version"
@@ -56,9 +57,10 @@ object JUnit {
         // https://junit.org/junit5/
         const val version = "1.12.2"
         internal const val group = "org.junit.platform"
-        const val commons = "$group:junit-platform-commons:$version"
-        const val launcher = "$group:junit-platform-launcher:$version"
-        const val engine = "$group:junit-platform-engine:$version"
-        const val suiteApi = "$group:junit-platform-suite-api:$version"
+        private const val infix = "junit-platform"
+        const val commons = "$group:$infix-commons:$version"
+        const val launcher = "$group:$infix-launcher:$version"
+        const val engine = "$group:$infix-engine:$version"
+        const val suiteApi = "$group:$infix-suite-api:$version"
     }
 }

--- a/buildSrc/src/main/kotlin/module-testing.gradle.kts
+++ b/buildSrc/src/main/kotlin/module-testing.gradle.kts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import io.spine.dependency.lib.Guava
+import io.spine.dependency.local.TestLib
+import io.spine.dependency.test.JUnit
+import io.spine.dependency.test.Kotest
+import io.spine.dependency.test.Truth
+import io.spine.gradle.testing.configureLogging
+import io.spine.gradle.testing.registerTestTasks
+
+plugins {
+    `java-library`
+}
+
+project.run {
+    setupTests()
+    forceTestDependencies()
+}
+
+dependencies {
+    forceJunitPlatform()
+
+    testImplementation(JUnit.Jupiter.api)
+    testImplementation(JUnit.pioneer)
+
+    testImplementation(Guava.testLib)
+
+    testImplementation(TestLib.lib)
+    testImplementation(Kotest.assertions)
+    testImplementation(Kotest.datatest)
+
+    testRuntimeOnly(JUnit.Jupiter.engine)
+}
+
+/**
+ * Forces the version of [JUnit] platform and its dependencies via [JUnit.bom].
+ */
+private fun DependencyHandlerScope.forceJunitPlatform() {
+    testImplementation(enforcedPlatform(JUnit.bom))
+}
+
+typealias Module = Project
+
+/**
+ * Configure this module to run JUnit-based tests.
+ */
+fun Module.setupTests() {
+    tasks {
+        registerTestTasks()
+        test.configure {
+            useJUnitPlatform {
+                includeEngines("junit-jupiter")
+            }
+            configureLogging()
+        }
+    }
+}
+
+/**
+ * Forces the versions of task dependencies that are used _in addition_ to
+ * the forced JUnit platform.
+ */
+@Suppress(
+    /* We're OK with incubating API for configurations. It does not seem to change recently. */
+    "UnstableApiUsage"
+)
+fun Module.forceTestDependencies() {
+    configurations {
+        all {
+            resolutionStrategy {
+                forceTestDependencies()
+            }
+        }
+    }
+}
+
+private fun ResolutionStrategy.forceTestDependencies() {
+    force(
+        Guava.testLib,
+        Truth.libs,
+        Kotest.assertions,
+    )
+}

--- a/buildSrc/src/main/kotlin/module.gradle.kts
+++ b/buildSrc/src/main/kotlin/module.gradle.kts
@@ -25,19 +25,14 @@
  */
 
 import BuildSettings.javaVersion
-import Module_gradle.Module
 import io.spine.dependency.build.CheckerFramework
 import io.spine.dependency.build.Dokka
 import io.spine.dependency.build.ErrorProne
 import io.spine.dependency.build.JSpecify
-import io.spine.dependency.lib.Guava
 import io.spine.dependency.local.Base
 import io.spine.dependency.local.Logging
 import io.spine.dependency.local.Reflect
-import io.spine.dependency.local.TestLib
-import io.spine.dependency.test.JUnit
 import io.spine.dependency.test.Jacoco
-import io.spine.dependency.test.Kotest
 import io.spine.gradle.checkstyle.CheckStyleConfig
 import io.spine.gradle.github.pages.updateGitHubPages
 import io.spine.gradle.javac.configureErrorProne
@@ -46,11 +41,10 @@ import io.spine.gradle.javadoc.JavadocConfig
 import io.spine.gradle.kotlin.applyJvmToolchain
 import io.spine.gradle.kotlin.setFreeCompilerArgs
 import io.spine.gradle.report.license.LicenseReporter
-import io.spine.gradle.testing.configureLogging
-import io.spine.gradle.testing.registerTestTasks
 
 plugins {
     `java-library`
+    id("module-testing")
     id("net.ltgt.errorprone")
     id("pmd-settings")
     id("project-report")
@@ -72,7 +66,6 @@ project.run {
 
     val generatedDir = "$projectDir/generated"
     setTaskDependencies(generatedDir)
-    setupTests()
 
     configureGitHubPages()
 }
@@ -130,15 +123,6 @@ fun Module.addDependencies() = dependencies {
 
     // https://jspecify.dev/docs/using/#gradle
     api(JSpecify.annotations)
-
-    testImplementation(Guava.testLib)
-    testImplementation(JUnit.runner)
-    testImplementation(JUnit.pioneer)
-    JUnit.api.forEach { testImplementation(it) }
-
-    testImplementation(TestLib.lib)
-    testImplementation(Kotest.assertions)
-    testImplementation(Kotest.datatest)
 }
 
 fun Module.forceConfigurations() {
@@ -148,26 +132,12 @@ fun Module.forceConfigurations() {
         all {
             resolutionStrategy {
                 force(
-                    JUnit.bom,
-                    JUnit.runner,
                     Dokka.BasePlugin.lib,
                     Reflect.lib,
                     Base.lib,
                     Logging.lib,
                 )
             }
-        }
-    }
-}
-
-fun Module.setupTests() {
-    tasks {
-        registerTestTasks()
-        test.configure {
-            useJUnitPlatform {
-                includeEngines("junit-jupiter")
-            }
-            configureLogging()
         }
     }
 }

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.311`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.312`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -439,7 +439,7 @@
      * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
      * **Project URL:** [http://junit.org](http://junit.org)
      * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
 
@@ -840,12 +840,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 15 19:40:14 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 17 12:13:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.311`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.312`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1323,7 +1323,7 @@ This report was generated on **Tue Apr 15 19:40:14 WEST 2025** using [Gradle-Lic
      * **Project URL:** [http://code.google.com/p/atinject/](http://code.google.com/p/atinject/)
      * **License:** [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-1.  **Group** : junit. **Name** : junit. **Version** : 4.13.1.
+1.  **Group** : junit. **Name** : junit. **Version** : 4.13.2.
      * **Project URL:** [http://junit.org](http://junit.org)
      * **License:** [Eclipse Public License 1.0](http://www.eclipse.org/legal/epl-v10.html)
 
@@ -1700,4 +1700,4 @@ This report was generated on **Tue Apr 15 19:40:14 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Apr 15 19:40:15 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Thu Apr 17 12:13:22 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.311</version>
+<version>2.0.0-SNAPSHOT.312</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -150,9 +150,9 @@ all modules and does not describe the project structure per-subproject.
     <scope>test</scope>
   </dependency>
   <dependency>
-    <groupId>org.apiguardian</groupId>
-    <artifactId>apiguardian-api</artifactId>
-    <version>1.1.2</version>
+    <groupId>org.junit</groupId>
+    <artifactId>junit-bom</artifactId>
+    <version>5.12.2</version>
     <scope>test</scope>
   </dependency>
   <dependency>
@@ -164,19 +164,13 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-api</artifactId>
-    <version>5.12.2</version>
+    <version>null</version>
     <scope>test</scope>
   </dependency>
   <dependency>
     <groupId>org.junit.jupiter</groupId>
     <artifactId>junit-jupiter-engine</artifactId>
-    <version>5.12.2</version>
-    <scope>test</scope>
-  </dependency>
-  <dependency>
-    <groupId>org.junit.jupiter</groupId>
-    <artifactId>junit-jupiter-params</artifactId>
-    <version>5.12.2</version>
+    <version>null</version>
     <scope>test</scope>
   </dependency>
   <dependency>

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.311")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.312")


### PR DESCRIPTION
This PR improves the way we force JUnit components. In details:

  * `JUnit` dependency object was refactored to introduce `Jupiter` nested object. Properties referring to Jupiter were deprecated.
  * Versions were removed from the standard artifact constants because we now force the versions via `testImplementation(enforcedPlatform(JUnit.bom))`.
  * Conventions script plugin `module-testing` was introduced. The script gathers all aspects of testing of a module.
  * The `module` script now adds `module-testing` as its plugin. 
  * `DependencyResolution.kt` was updated removing forcing JUnit component versions.
  
The plan is to refactor our `jvm-module` and similar code into convention plugins that `module` scripts (that are project-depndant) would apply as their plugins adding project-specific code where appropriate.