### PR TITLE
Re-brand `field combinations` to `field groups`

### DIFF
--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -1427,25 +1427,24 @@ message ChoiceOption {
     string error_msg = 2;
 }
 
-// The constraint to require at least one of the fields or combinations of fields
-// to be set.
+// Declares the field groups, at least one of which must have all of its fields set.
 //
-// Unlike the `(required)` field constraint, which requires the presence of a specific
-// field, this option allows to specify alternative fields or combinations of them.
+// Unlike the `(required)` field constraint, which requires the presence of
+// a specific field, this option allows to specify alternative field groups.
 //
 message RequireOption {
 
     // The default error message.
     option (default_message) = "The message `${message.type}` must have at least one of"
-        " the following fields or combinations of them specified: `${require.fields}`.";
+        " the following field groups set: `${require.fields}`.";
 
-    // A set of fields or combinations of fields, at least one of which must be specified.
+    // A set of field groups, at least one of which must have all of its fields set.
     //
-    // Fields are separated using the pipe (`|`) symbol. The combination of fields is defined
-    // using the ampersand (`&`) symbol. `oneof` group names are also valid and can be used
-    // as alternatives.
+    // A field group can include one or more fields joined by the ampersand (`&`) symbol.
+    // `oneof` group names are also valid and can be used along with field names.
+    // Groups are separated using the pipe (`|`) symbol.
     //
-    // The field type determines when the field is considered specified:
+    // The field type determines when the field is considered set:
     //
     // 1. For message or enum fields, it must have a non-default instance.
     // 2. For `string` and `bytes` fields, it must be non-empty.
@@ -1453,11 +1452,11 @@ message RequireOption {
     //
     // Fields of other types are not supported by this option.
     //
-    // For `oneof` groups, the restrictions above do not apply. Any `oneof` group can be used
+    // For `oneof`s, the restrictions above do not apply. Any `oneof` group can be used
     // without considering the field types, and its value will be checked directly without
-    // relying on the default values of the fields within the group.
+    // relying on the default values of the fields within the `oneof`.
     //
-    // Example: defining alternative required fields.
+    // Example: defining two field groups.
     //
     //     message PersonName {
     //         option (require).fields = "given_name | honorific_prefix & family_name";
@@ -1469,8 +1468,8 @@ message RequireOption {
     //         string honorific_suffix = 5;
     //     }
     //
-    // In this example, at least `given_name` or a combination of `honorific_prefix`
-    // and `family_name` must be set.
+    // In this example, at least `given_name` or a group of `honorific_prefix`
+    // and `family_name` fields must be set.
     //
     string fields = 1;
 
@@ -1479,7 +1478,7 @@ message RequireOption {
     // The specified message may include the following placeholders:
     //
     // 1. `${message.type}` – the fully qualified name of the validated message.
-    // 2. `${require.fields}` – the specified set of fields and combinations of them.
+    // 2. `${require.fields}` – the specified field groups.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -857,12 +857,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 17 13:02:25 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 22 17:38:38 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.312`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.313`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1758,4 +1758,4 @@ This report was generated on **Thu Apr 17 13:02:25 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Apr 17 13:02:26 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Tue Apr 22 17:38:48 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.312</version>
+<version>2.0.0-SNAPSHOT.313</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.312")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.313")


### PR DESCRIPTION
This PR re-brands `field combinations` from the `(require)` option to `field groups`.