### PR TITLE
Update specs to numeric options to add field reference support

### DIFF
--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -810,7 +810,7 @@ message MinOption {
     //     Limits limits = 3;
     //     int32 temperature = 4 [(min).value = "limits.min_temperature"];
     //     float pressure = 5 [(min).value = "limits.min_pressure"];
-    //  }
+    // }
     //
     // message Limits {
     //     int32 min_temperature = 1;
@@ -820,7 +820,6 @@ message MinOption {
     // Note: Field type compatibility is not required in this case; the value is
     // automatically converted. However, only numeric fields can be referenced.
     // Repeated and map fields are not supported.
-    //
     //
     string value = 1;
 
@@ -908,7 +907,7 @@ message MaxOption {
     //     Limits limits = 3;
     //     int32 temperature = 4 [(max).value = "limits.max_temperature"];
     //     float pressure = 5 [(max).value = "limits.max_pressure"];
-    //  }
+    // }
     //
     // message Limits {
     //     int32 max_temperature = 1;
@@ -1453,7 +1452,7 @@ message RangeOption {
     //
     //     Limits limits = 3;
     //     int32 temperature = 4 [(range).value = "[limits.low_temp .. limits.high_temp]"];
-    //  }
+    // }
     //
     // message Limits {
     //     int32 low_temp = 1;
@@ -1463,7 +1462,6 @@ message RangeOption {
     // Note: Field type compatibility is not required in this case; the value is
     // automatically converted. However, only numeric fields can be referenced.
     // Repeated and map fields are not supported.
-    //
     //
     string value = 1;
 

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -779,9 +779,9 @@ message MinOption {
     // message MinimumValues {
     //     int32 temperature = 1 [(min).value = "0"];
     //     uint32 employees = 2 [(min).value = "5"];
-    //     float degree = 1 [(min).value = "0.0"];
-    //     double angle = 2 [(min).value = "30.0"];
-    //     float pressure = 3 [(min).value = "950.0E-2"];
+    //     float degree = 3 [(min).value = "0.0"];
+    //     double angle = 4 [(min).value = "30.0"];
+    //     float pressure = 5 [(min).value = "950.0E-2"];
     //  }
     //
     // ## Field Type Limitations
@@ -794,6 +794,33 @@ message MinOption {
     //     float price = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
     //     uint32 size = 2 [(min).value = "-5"]; // Falls below the `uint32` minimum.
     // }
+    //
+    // ## Field references
+    //
+    // Instead of numeric literals, you can reference another numeric field.
+    // At runtime, the field’s value will be used as the bound. Nested fields are supported.
+    //
+    // Example: defining minimum values using field references.
+    //
+    // message MinimumValues {
+    //
+    //     int32 min_employees = 1;
+    //     int32 employees = 2 [(min).value = "min_employees"];
+    //
+    //     Thresholds thresholds = 3;
+    //     int32 temperature = 4 [(min).value = "thresholds.temperature"];
+    //     float pressure = 5 [(min).value = "thresholds.pressure"];
+    //  }
+    //
+    // message Thresholds {
+    //     int32 temperature = 1;
+    //     float pressure = 2;
+    // }
+    //
+    // Note: Field type compatibility is not required in this case; the value is
+    // automatically converted. However, only numeric fields can be referenced.
+    // Repeated and map fields are not supported.
+    //
     //
     string value = 1;
 
@@ -814,7 +841,8 @@ message MinOption {
     // 2. `${field.path}` – the field path.
     // 3. `${field.type}` – the fully qualified name of the field type.
     // 4. `${parent.type}` – the fully qualified name of the validated message.
-    // 5. `${min.value}` – the specified minimum `value`.
+    // 5. `${min.value}` – the specified minimum `value`. For referenced fields, the actual
+    //    field value is also printed in round brackets along with the reference itself.
     // 6. `${min.operator}` – if `exclusive` is set to `true`, this placeholder equals to ">".
     //    Otherwise, ">=".
     //
@@ -849,9 +877,9 @@ message MaxOption {
     // message MaximumValues {
     //     int32 temperature = 1 [(max).value = "270"];
     //     uint32 employees = 2 [(max).value = "1200"];
-    //     float degree = 1 [(max).value = "360.0"];
-    //     double angle = 2 [(max).value = "90.0"];
-    //     float pressure = 3 [(max).value = "1050.0E-2"];
+    //     float degree = 3 [(max).value = "360.0"];
+    //     double angle = 4 [(max).value = "90.0"];
+    //     float pressure = 5 [(max).value = "1050.0E-2"];
     //  }
     //
     // ## Field Type Limitations
@@ -864,6 +892,32 @@ message MaxOption {
     //     float price = 1 [(min).value = "5.5E38"]; // Exceeds the `float` maximum.
     //     int32 size = 2 [(min).value = "2147483648"]; // Exceeds the `int32` maximum.
     // }
+    //
+    // ## Field references
+    //
+    // Instead of numeric literals, you can reference another numeric field.
+    // At runtime, the field’s value will be used as the bound. Nested fields are supported.
+    //
+    // Example: defining maximum values using field references.
+    //
+    // message MaximumValues {
+    //
+    //     int32 max_employees = 1;
+    //     int32 employees = 2 [(max).value = "max_employees"];
+    //
+    //     Thresholds thresholds = 3;
+    //     int32 temperature = 4 [(max).value = "thresholds.temperature"];
+    //     float pressure = 5 [(max).value = "thresholds.pressure"];
+    //  }
+    //
+    // message Thresholds {
+    //     int32 temperature = 1;
+    //     float pressure = 2;
+    // }
+    //
+    // Note: Field type compatibility is not required in this case; the value is
+    // automatically converted. However, only numeric fields can be referenced.
+    // Repeated and map fields are not supported.
     //
     string value = 1;
 
@@ -884,7 +938,8 @@ message MaxOption {
     // 2. `${field.value}` - the field value.
     // 3. `${field.type}` – the fully qualified name of the field type.
     // 4. `${parent.type}` – the fully qualified name of the validated message.
-    // 5. `${max.value}` – the specified maximum `value`.
+    // 5. `${max.value}` – the specified maximum `value`. For referenced fields, the actual
+    //    field value is also printed in round brackets along with the reference itself.
     // 6. `${max.operator}` – if `exclusive` is set to `true`, this placeholder equals to "<".
     //    Otherwise, "<=".
     //

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -776,9 +776,9 @@ message MinOption {
     //
     // Example: defining minimum values for integer and floating-point fields.
     //
-    // message MinimumValues {
+    // message Measurements {
     //     int32 temperature = 1 [(min).value = "0"];
-    //     uint32 employees = 2 [(min).value = "5"];
+    //     uint32 mass = 2 [(min).value = "5"];
     //     float degree = 3 [(min).value = "0.0"];
     //     double angle = 4 [(min).value = "30.0"];
     //     float pressure = 5 [(min).value = "950.0E-2"];
@@ -790,9 +790,9 @@ message MinOption {
     //
     // Example: invalid values that fall below the field type limits.
     //
-    // message OverflowValues {
-    //     float price = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
-    //     uint32 size = 2 [(min).value = "-5"]; // Falls below the `uint32` minimum.
+    // message OverflowMeasurements {
+    //     float pressure = 1 [(min).value = "-5.5E38"]; // Falls below the `float` minimum.
+    //     uint32 mass = 2 [(min).value = "-5"]; // Falls below the `uint32` minimum.
     // }
     //
     // ## Field references
@@ -802,19 +802,19 @@ message MinOption {
     //
     // Example: defining minimum values using field references.
     //
-    // message MinimumValues {
+    // message Measurements {
     //
-    //     int32 min_employees = 1;
-    //     int32 employees = 2 [(min).value = "min_employees"];
+    //     int32 min_length = 1;
+    //     int32 length = 2 [(min).value = "min_length"];
     //
-    //     Thresholds thresholds = 3;
-    //     int32 temperature = 4 [(min).value = "thresholds.temperature"];
-    //     float pressure = 5 [(min).value = "thresholds.pressure"];
+    //     Limits limits = 3;
+    //     int32 temperature = 4 [(min).value = "limits.min_temperature"];
+    //     float pressure = 5 [(min).value = "limits.min_pressure"];
     //  }
     //
-    // message Thresholds {
-    //     int32 temperature = 1;
-    //     float pressure = 2;
+    // message Limits {
+    //     int32 min_temperature = 1;
+    //     float min_pressure = 2;
     // }
     //
     // Note: Field type compatibility is not required in this case; the value is
@@ -874,9 +874,9 @@ message MaxOption {
     //
     // Example: defining maximum values for integer and floating-point fields.
     //
-    // message MaximumValues {
+    // message Measurements {
     //     int32 temperature = 1 [(max).value = "270"];
-    //     uint32 employees = 2 [(max).value = "1200"];
+    //     uint32 mass = 2 [(max).value = "1200"];
     //     float degree = 3 [(max).value = "360.0"];
     //     double angle = 4 [(max).value = "90.0"];
     //     float pressure = 5 [(max).value = "1050.0E-2"];
@@ -888,9 +888,9 @@ message MaxOption {
     //
     // Example: invalid values that exceed the field type limits.
     //
-    // message OverflowValues {
-    //     float price = 1 [(min).value = "5.5E38"]; // Exceeds the `float` maximum.
-    //     int32 size = 2 [(min).value = "2147483648"]; // Exceeds the `int32` maximum.
+    // message OverflowMeasurements {
+    //     float pressure = 1 [(min).value = "5.5E38"]; // Exceeds the `float` maximum.
+    //     int32 mass = 2 [(min).value = "2147483648"]; // Exceeds the `int32` maximum.
     // }
     //
     // ## Field references
@@ -900,19 +900,19 @@ message MaxOption {
     //
     // Example: defining maximum values using field references.
     //
-    // message MaximumValues {
+    // message Measurements {
     //
-    //     int32 max_employees = 1;
-    //     int32 employees = 2 [(max).value = "max_employees"];
+    //     int32 max_length = 1;
+    //     int32 length = 2 [(max).value = "max_length"];
     //
-    //     Thresholds thresholds = 3;
-    //     int32 temperature = 4 [(max).value = "thresholds.temperature"];
-    //     float pressure = 5 [(max).value = "thresholds.pressure"];
+    //     Limits limits = 3;
+    //     int32 temperature = 4 [(max).value = "limits.max_temperature"];
+    //     float pressure = 5 [(max).value = "limits.max_pressure"];
     //  }
     //
-    // message Thresholds {
-    //     int32 temperature = 1;
-    //     float pressure = 2;
+    // message Limits {
+    //     int32 max_temperature = 1;
+    //     float max_pressure = 2;
     // }
     //
     // Note: Field type compatibility is not required in this case; the value is
@@ -1409,9 +1409,9 @@ message RangeOption {
     //
     // Example: defining ranges for integer fields.
     //
-    // message IntegerRanges {
-    //      int32 hour = 1 [(range).value = "[0..24)"];
-    //      uint32 minute = 2 [(range).value = "[0..59]"];
+    // message Measurements {
+    //      int32 length = 1 [(range).value = "[0..100)"];
+    //      uint32 mass = 2 [(range).value = "(0..100]"];
     //  }
     //
     // ## Floating-Point Fields
@@ -1422,7 +1422,7 @@ message RangeOption {
     //
     // Example: defining ranges for floating-point fields.
     //
-    // message FloatRanges {
+    // message Measurements {
     //     float degree = 1 [(range).value = "[0.0 .. 360.0)"];
     //     double angle = 2 [(range).value = "(0.0 .. 180.0)"];
     //     float pressure = 3 [(range).value = "[950.0E-2 .. 1050.0E-2]"];
@@ -1434,7 +1434,7 @@ message RangeOption {
     //
     // Example: invalid ranges that exceed the field type limits.
     //
-    // message OverflowRanges {
+    // message OverflowMeasurements {
     //     float price = 1 [(range).value = "[0, 5.5E38]"]; // Exceeds the `float` maximum.
     //     uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
     // }
@@ -1446,18 +1446,18 @@ message RangeOption {
     //
     // Example: defining ranges using field references.
     //
-    // message Ranges {
+    // message Measurements {
     //
-    //     int32 max_employees = 1;
-    //     int32 employees = 2 [(range).value = "[1 .. max_employees"];
+    //     int32 max_length = 1;
+    //     int32 length = 2 [(range).value = "[1 .. max_length"];
     //
-    //     TempLimits limits = 3;
-    //     int32 temperature = 4 [(range).value = "[limits.low .. limits.high]"];
+    //     Limits limits = 3;
+    //     int32 temperature = 4 [(range).value = "[limits.low_temp .. limits.high_temp]"];
     //  }
     //
-    // message TempLimits {
-    //     int32 low = 1;
-    //     int32 high = 2;
+    // message Limits {
+    //     int32 low_temp = 1;
+    //     int32 high_temp = 2;
     // }
     //
     // Note: Field type compatibility is not required in this case; the value is

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -1475,7 +1475,8 @@ message RangeOption {
     // 2. `${field.value}` - the field value.
     // 3. `${field.type}` – the fully qualified name of the field type.
     // 4. `${parent.type}` – the fully qualified name of the validated message.
-    // 5. `${range.value}` – the specified range.
+    // 5. `${range.value}` – the specified range. For referenced fields, the actual
+    //    field value is also printed in round brackets along with the reference itself.
     //
     // The placeholders will be replaced at runtime when the error is constructed.
     //

--- a/base/src/main/proto/spine/options.proto
+++ b/base/src/main/proto/spine/options.proto
@@ -1439,6 +1439,32 @@ message RangeOption {
     //     uint32 size = 2 [(range).value = "[-5; 10]"]; // Falls below the `uint32` minimum.
     // }
     //
+    // ## Field references
+    //
+    // Instead of numeric literals, you can reference another numeric field.
+    // At runtime, the field’s value will be used as the bound. Nested fields are supported.
+    //
+    // Example: defining ranges using field references.
+    //
+    // message Ranges {
+    //
+    //     int32 max_employees = 1;
+    //     int32 employees = 2 [(range).value = "[1 .. max_employees"];
+    //
+    //     TempLimits limits = 3;
+    //     int32 temperature = 4 [(range).value = "[limits.low .. limits.high]"];
+    //  }
+    //
+    // message TempLimits {
+    //     int32 low = 1;
+    //     int32 high = 2;
+    // }
+    //
+    // Note: Field type compatibility is not required in this case; the value is
+    // automatically converted. However, only numeric fields can be referenced.
+    // Repeated and map fields are not supported.
+    //
+    //
     string value = 1;
 
     // A user-defined error message.

--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.316`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.317`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -874,12 +874,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 30 21:04:16 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 07 16:59:28 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.316`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.317`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1788,4 +1788,4 @@ This report was generated on **Wed Apr 30 21:04:16 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Wed Apr 30 21:04:16 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Wed May 07 16:59:29 CEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.316</version>
+<version>2.0.0-SNAPSHOT.317</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.316")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.317")


### PR DESCRIPTION
This PR updates specs to `(min)`, `(max)` and `(range)` options to include support of referenced fields.