### PR TITLE
Document properties and parameters of the `Format` class

### DIFF
--- a/dependencies.md
+++ b/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.321`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.322`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -874,12 +874,12 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 17:38:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 08 19:41:53 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.321`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.322`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.18.3.
@@ -1788,4 +1788,4 @@ This report was generated on **Sun Jun 08 17:38:21 WEST 2025** using [Gradle-Lic
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 08 17:38:21 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
+This report was generated on **Sun Jun 08 19:41:53 WEST 2025** using [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/format/src/main/kotlin/io/spine/format/Format.kt
+++ b/format/src/main/kotlin/io/spine/format/Format.kt
@@ -77,7 +77,7 @@ import java.io.File
  * @param T The type of the upper bound served by this format.
  *   For example, if the format supports only Protobuf message types,
  *   the argument would be [Message].
- *   If there is no upper bound for a format, it would be [kotlin.Any]
+ *   If there is no upper bound for a format, it would be [kotlin.Any].
  *
  * @property writer The writer of this format.
  * @property parser The parser of this format.

--- a/format/src/main/kotlin/io/spine/format/Format.kt
+++ b/format/src/main/kotlin/io/spine/format/Format.kt
@@ -74,11 +74,20 @@ import java.io.File
  * while Protobuf types created in Java or Kotlin are to be handled by [ProtoBinary] or
  * [ProtoJson] formats.
  *
+ * @param T The type of the upper bound served by this format.
+ *   For example, if the format supports only Protobuf message types,
+ *   the argument would be [Message].
+ *   If there is no upper bound for a format, it would be [kotlin.Any]
+ *
+ * @property writer The writer of this format.
+ * @property parser The parser of this format.
+ *
  * @param extensions One or more extensions of the files that are conventionally used
  *   for files in the corresponding format.
  *   If a format has multiple file extensions, the first in the list is the primary one.
  *   This [extension] will be used for [composing][io.spine.format.ensureFormatExtension]
  *   a file name for this format.
+ *   
  * @see parse
  * @see write
  */

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.321</version>
+<version>2.0.0-SNAPSHOT.322</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.321")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.322")


### PR DESCRIPTION
This PR adds missing documentation for the `Format` class.