### PR TITLE
Add tests for `Path.toUnix()` and `ensureFile(File)` on a directory

### DIFF
--- a/base/src/test/kotlin/io/spine/io/EnsureSpec.kt
+++ b/base/src/test/kotlin/io/spine/io/EnsureSpec.kt
@@ -79,6 +79,13 @@ internal class EnsureSpec {
             file.exists() shouldBe true
             returnedValue shouldBe path
         }
+
+        @Test
+        fun `rejecting a directory passed as 'File'`(@TempDir tempDir: Path) {
+            assertThrows<IllegalArgumentException> {
+                ensureFile(tempDir.toFile())
+            }
+        }
     }
 
     @Nested internal inner class

--- a/base/src/test/kotlin/io/spine/io/PathsSpec.kt
+++ b/base/src/test/kotlin/io/spine/io/PathsSpec.kt
@@ -72,4 +72,17 @@ internal class PathsSpec {
         val path = "/my/unix/path"
         path.toUnix() shouldBeSameInstanceAs path
     }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `replace Windows separators in a path`() {
+        Path("C:\\Windows\\path").toUnix() shouldBe Path("C:/Windows/path")
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `return the same path when no Windows separators present`() {
+        val path = Path("/my/unix/path")
+        path.toUnix() shouldBeSameInstanceAs path
+    }
 }


### PR DESCRIPTION
## Summary

Addresses 4 lines flagged as missing coverage by Codecov on PR #931.

- `PathsSpec`: adds tests for `Path.toUnix()` (both branches — Windows-style and Unix-style paths)
- `EnsureSpec`: adds a test for `ensureFile(File)` when the argument is an existing directory (should throw `IllegalArgumentException`)

## Test plan

- [ ] Verify Codecov patch coverage increases to 100% on `increse-coverage` after merge

https://claude.ai/code/session_0196Zs3po6BgzddAtQoRgqHJ

---
_Generated by [Claude Code](https://claude.ai/code/session_0196Zs3po6BgzddAtQoRgqHJ)_