### PR TITLE
Fix duplicate `spine/options.proto` in the sources JAR

### DIFF
--- a/buildSrc/quality/pmd.xml
+++ b/buildSrc/quality/pmd.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-  ~ Copyright 2025, TeamDev. All rights reserved.
+  ~ Copyright 2026, TeamDev. All rights reserved.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -60,10 +60,10 @@
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
     <rule ref="category/java/codestyle.xml/NoPackage"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
+    <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
 

--- a/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
+++ b/buildSrc/src/main/kotlin/io/spine/gradle/publish/PublishingExts.kt
@@ -35,6 +35,7 @@ import java.util.*
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
@@ -248,8 +249,16 @@ fun Project.sourcesJar(): TaskProvider<Jar> = tasks.getOrCreate("sourcesJar") {
     description = "Assembles a JAR with Java, Kotlin, and Proto sources from the `main` source set"
     dependOnGenerateProto()
     archiveClassifier.set("sources")
-    from(sourceSets["main"].allSource) // Puts Java and Kotlin sources.
-    from(protoSources()) // Puts Proto sources.
+    // `allSource` also sees the generated `proto-resources` directory, which bundles
+    // copies of `.proto` files (this module's own and its dependencies') as runtime resources.
+    // This behavior starts from Protobuf Gradle Plugin 0.10.0, and it is not expected
+    // to be changed in the future.
+    // This is why we do not call `from(protoSources())` in this function any more.
+    from(sourceSets["main"].allSource)
+
+    // Even if there are duplicates in sources, we want only one.
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
     exclude("desc.ref", "*.desc") // Exclude descriptor files and the descriptor reference.
 }
 

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -760,7 +760,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1604,7 +1604,7 @@ This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2430,7 +2430,7 @@ This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3336,6 +3336,6 @@ This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Sun Jun 07 20:21:03 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.403`
+# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.404`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -760,14 +760,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:37:28 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.403`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.404`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1604,14 +1604,14 @@ This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:37:29 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.403`
+# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.404`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2430,14 +2430,14 @@ This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:37:28 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.403`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.404`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3336,6 +3336,6 @@ This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Mon Jun 08 18:22:06 WEST 2026** using 
+This report was generated on **Mon Jun 08 18:37:28 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.403</version>
+<version>2.0.0-SNAPSHOT.404</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.403")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.404")


### PR DESCRIPTION
## What

Fixes the `:base:sourcesJar` build failure:

> Entry spine/options.proto is a duplicate but no duplicate handling strategy has been set.

`sourcesJar` was collecting proto sources from two roots that map to the same
archive entry:

- `from(sourceSets["main"].allSource)` — which, since **Protobuf Gradle Plugin 0.10.0**,
  sees the generated `build/generated/proto-resources/main` directory (proto files
  bundled as runtime resources), and
- `from(protoSources())` — the `src/main/proto` sources.

Each of the module's own `.proto` files therefore reached the archive twice at the
same path (`spine/options.proto`, …), failing the build.

## Why this approach

Rather than masking the collision, the cause is removed. `proto-resources` is now
the single source of proto in the sources JAR, so `sourcesJar` drops the redundant
`from(protoSources())` call and sets `duplicatesStrategy = DuplicatesStrategy.EXCLUDE`
as a guard. The change lives in `buildSrc/.../publish/PublishingExts.kt`.

## Verification

- `./gradlew clean build` — `BUILD SUCCESSFUL`
- `:base:sourcesJar` jar inspected: `spine/options.proto` appears **once**, all of
  `base`'s own `spine/*` protos retained, **zero** Google protos leaked
  (`excludeGoogleProtoFromArtifacts` still effective).

## Reviewer notes

- `buildSrc` here is vendored from the `config` repository (the source of truth).
  The identical change must also land in `SpineEventEngine/config` so it is not
  reverted by the next `./config/pull`.
- Version bumped `2.0.0-SNAPSHOT.403` → `.404`; dependency reports regenerated.
- The `sourcesJar` KDoc still mentions the old `protoSources` "special treatment";
  left as-is to avoid drift from `config`, can be refreshed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)