### PR TITLE
Introduce `QueryCriterion.isEqualTo` (Kotlin-friendly alias for `is`)

### DIFF
--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,6 @@ tasks {
     excludeGoogleProtoFromArtifacts()
 }
 
-
 // For generating test fixtures. See `src/test/proto`.
 protobuf {
     configurations.excludeProtobufLite()
@@ -99,6 +98,15 @@ protobuf {
     }
 
     generateProtoTasks.all().configureEach {
+        // The `doLast` action below deletes files from this task's own output
+        // directory, which is not reproduced when the task is restored from the
+        // Gradle build cache. A cached restoration yields an output (and a
+        // downstream descriptor set on the test classpath) that differs from a
+        // fresh run, intermittently leaving `io.spine.type.KnownTypes` with an
+        // incomplete set of types. Opt this task out of the build cache so it
+        // always executes and the deletion is always applied.
+        outputs.cacheIf { false }
+
         // Delete files generated in `com.google` packages because
         // we add `protobuf(Protobuf.protoSrcLib)` dependency above.
         doLast {

--- a/base/src/main/java/io/spine/query/QueryCriterion.java
+++ b/base/src/main/java/io/spine/query/QueryCriterion.java
@@ -86,7 +86,7 @@ abstract class QueryCriterion<R extends Message,
 
     /**
      * Appends an associated query builder with a criterion checking that the value
-     * of the associated column equals to the one provided.
+     * of the associated column equals the one provided.
      *
      * <p>The shorter {@link #is(Object) is()} alias has the same effect and reads more
      * fluently from Java. Prefer this method in Kotlin, where {@code is} is a reserved

--- a/base/src/main/java/io/spine/query/QueryCriterion.java
+++ b/base/src/main/java/io/spine/query/QueryCriterion.java
@@ -88,14 +88,40 @@ abstract class QueryCriterion<R extends Message,
      * Appends an associated query builder with a criterion checking that the value
      * of the associated column equals to the one provided.
      *
+     * <p>The shorter {@link #is(Object) is()} alias has the same effect and reads more
+     * fluently from Java. Prefer this method in Kotlin, where {@code is} is a reserved
+     * word and calling {@code is()} requires wrapping the name in backticks.
+     *
      * @param value
      *         the column value to use when querying
      * @return the instance of query builder associated with this criterion
+     * @see #is(Object)
+     */
+    @CanIgnoreReturnValue
+    public B isEqualTo(V value) {
+        checkNotNull(value);
+        return addParameter(builder, column, EQUALS, value);
+    }
+
+    /**
+     * Appends an associated query builder with a criterion checking that the value
+     * of the associated column equals to the one provided.
+     *
+     * <p>This method is a short form of {@link #isEqualTo(Object) isEqualTo()}.
+     * It is a convenience wrapper for working with a {@code QueryCriterion} from Java.
+     *
+     * <p>In Kotlin, prefer {@link #isEqualTo(Object) isEqualTo()} because {@code is} is
+     * a reserved word there, so calling this method requires wrapping its name in
+     * backticks.
+     *
+     * @param value
+     *         the column value to use when querying
+     * @return the instance of query builder associated with this criterion
+     * @see #isEqualTo(Object)
      */
     @CanIgnoreReturnValue
     public B is(V value) {
-        checkNotNull(value);
-        return addParameter(builder, column, EQUALS, value);
+        return isEqualTo(value);
     }
 
     /**

--- a/base/src/main/java/io/spine/query/QueryCriterion.java
+++ b/base/src/main/java/io/spine/query/QueryCriterion.java
@@ -105,7 +105,7 @@ abstract class QueryCriterion<R extends Message,
 
     /**
      * Appends an associated query builder with a criterion checking that the value
-     * of the associated column equals to the one provided.
+     * of the associated column equals the one provided.
      *
      * <p>This method is a short form of {@link #isEqualTo(Object) isEqualTo()}.
      * It is a convenience wrapper for working with a {@code QueryCriterion} from Java.

--- a/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
+++ b/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2022, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Redistribution and use in source and/or binary forms, with or without
  * modification, must retain the above copyright notice and the following
@@ -251,6 +251,38 @@ class RecordQueryBuilderTest {
             var query = builder.build();
             var actualBuilder = query.toBuilder();
             assertThat(actualBuilder).isSameInstanceAs(builder);
+        }
+    }
+
+    @Nested
+    @DisplayName("treat `is` as a short form of `isEqualTo`")
+    final class IsEqualToAlias {
+
+        @Test
+        @DisplayName("appending an `EQUALS` parameter via `isEqualTo`")
+        void appendEqualsParameter() {
+            var isinValue = "JP 3496600002";
+            var parameters = queryManufacturer()
+                    .where(isin).isEqualTo(isinValue)
+                    .predicate()
+                    .parameters();
+            assertThat(parameters).hasSize(1);
+            assertHasParamValue(parameters, isin, EQUALS, isinValue);
+        }
+
+        @Test
+        @DisplayName("producing the same parameter as `is`")
+        void matchIs() {
+            var isinValue = "JP 3496600002";
+            var viaIs = queryManufacturer()
+                    .where(isin).is(isinValue)
+                    .predicate()
+                    .parameters();
+            var viaIsEqualTo = queryManufacturer()
+                    .where(isin).isEqualTo(isinValue)
+                    .predicate()
+                    .parameters();
+            assertThat(viaIsEqualTo).isEqualTo(viaIs);
         }
     }
 

--- a/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
+++ b/base/src/test/java/io/spine/query/RecordQueryBuilderTest.java
@@ -255,8 +255,8 @@ class RecordQueryBuilderTest {
     }
 
     @Nested
-    @DisplayName("treat `is` as a short form of `isEqualTo`")
-    final class IsEqualToAlias {
+    @DisplayName("support filtering by given values")
+    final class IsEqualTo {
 
         @Test
         @DisplayName("appending an `EQUALS` parameter via `isEqualTo`")
@@ -271,7 +271,7 @@ class RecordQueryBuilderTest {
         }
 
         @Test
-        @DisplayName("producing the same parameter as `is`")
+        @DisplayName("providing `is` alias for `isEqualTo`")
         void matchIs() {
             var isinValue = "JP 3496600002";
             var viaIs = queryManufacturer()

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -760,14 +760,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using 
+This report was generated on **Tue Jun 23 00:11:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1604,14 +1604,14 @@ This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using 
+This report was generated on **Tue Jun 23 00:11:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2430,14 +2430,14 @@ This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using 
+This report was generated on **Tue Jun 23 00:11:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.420`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.421`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.0.
@@ -3336,6 +3336,6 @@ This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jun 18 20:57:17 WEST 2026** using 
+This report was generated on **Tue Jun 23 00:11:07 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.420</version>
+<version>2.0.0-SNAPSHOT.421</version>
 
 <inceptionYear>2015</inceptionYear>
 

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025, TeamDev. All rights reserved.
+ * Copyright 2026, TeamDev. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.420")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.421")

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-val versionToPublish: String by extra("2.0.0-SNAPSHOT.413")
+val versionToPublish: String by extra("2.0.0-SNAPSHOT.420")


### PR DESCRIPTION
## What

Introduces `QueryCriterion.isEqualTo(V)`, carrying the behavior previously
implemented by `is(V)`, and makes `is(V)` delegate to it.

`isEqualTo` is now the canonical "equals" criterion. `is` is documented as a
short form of it — a convenience wrapper for working with a `QueryCriterion`
from Java.

## Why

Calling `is(...)` from **Kotlin** is awkward: `is` is a reserved word there, so
the call has to be wrapped in backticks:

```kotlin
builder.where(column).`is`(value)      // before — backticks required
builder.where(column).isEqualTo(value) // now — reads cleanly
```

`isEqualTo` reads naturally from both Java and Kotlin, while `is` stays
available (and convenient) for Java callers.

## Changes

- `QueryCriterion.isEqualTo(V)` — new canonical method (null-check + `EQUALS`
  parameter), inherited by `EntityCriterion` and `RecordCriterion`.
- `QueryCriterion.is(V)` — now delegates to `isEqualTo`; KDoc/Javadoc updated to
  describe it as the Java-convenient short form and to point Kotlin callers to
  `isEqualTo`.
- `RecordQueryBuilderTest` — new `IsEqualToAlias` tests: `isEqualTo` appends an
  `EQUALS` parameter, and yields the same parameter as `is`.

`is` is intentionally **not** deprecated — it remains a first-class Java-side
short form.

## Build fix (unrelated pre-existing CI flake)

While verifying this PR, CI's **Build on Ubuntu** failed with ~30–80 failures in
packages unrelated to this change (`io.spine.type`, `io.spine.base`,
`io.spine.protobuf`, `io.spine.code`) — `io.spine.type.KnownTypes` loading an
incomplete descriptor set. **Zero** `io.spine.query` tests were affected.

Root cause (reproduced deterministically, independent of the `isEqualTo`
change): `generateProto`/`generateTestProto` delete `com.google` files from
their own output directory in a `doLast` action. That mutation is not reproduced
when the task is restored from the **Gradle build cache**, so a cached
restoration leaves an inconsistent descriptor set on the test classpath and
`KnownTypes` loads a partial type set. This is why `master` (cache miss →
executed → green) and a branch that restored the cache entry (cache hit → red)
behaved differently — pure cache-population order, not the code change.

Fix: opt those tasks out of the build cache (`outputs.cacheIf { false }`) so they
always execute and the deletion is always applied. Verified: with the cache
enabled, `clean build` now passes 3/3 (previously failed deterministically when
`generateTestProto` was restored from cache).

## Testing

- `./gradlew :base:test --tests "io.spine.query.*"` → **133/133 pass** (incl. the
  two new tests).
- `./gradlew clean build` (cache enabled) → green and deterministic after the
  build fix.

## Review notes

- `spine-code-review` and `review-docs` reviewed the `isEqualTo` change;
  `spine-code-review` reviewed the build fix — all APPROVE.
- Version bumped `2.0.0-SNAPSHOT.420` → `2.0.0-SNAPSHOT.421`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
