### PR TITLE
Add `Suppliers2` and `Iterators2` to `io.spine.util`

### DIFF
--- a/.agents/tasks/add-suppliers2-iterators2.md
+++ b/.agents/tasks/add-suppliers2-iterators2.md
@@ -1,0 +1,53 @@
+---
+slug: add-suppliers2-iterators2
+branch: add-suppliers2-and-iterators2
+owner: claude
+status: in-review
+started: 2026-07-16
+---
+
+## Goal
+
+`Suppliers2` and `Iterators2`, introduced in [core-jvm PR #1656][pr] under
+`io.spine.server`, live in this repo's `io.spine.util` package (module `base`)
+with test coverage, so that all Spine SDK repos can share them and `core-jvm`
+can later drop its copies.
+
+## Context
+
+- Both classes are nullness-friendly wrappers over Guava's `Suppliers.memoize`
+  and `Iterators.filter`: Guava declares `<T extends @Nullable Object>`, which
+  reads as a nullness mismatch when the result is assigned to a non-null type
+  in `@NullMarked` code. Declaring plain `<T>` in a `@NullMarked` package binds
+  `T` to a non-null type.
+- `io.spine.util` already hosts the Guava-companion naming pattern
+  (`Preconditions2`, `Predicates2`) and is `@NullMarked` via `package-info.java`.
+- The classes keep `@Internal` (as in the source PR): they are framework
+  plumbing; widening to public API later is non-breaking, the reverse is not.
+- New tests follow `kotlin-jvm-tester` conventions: Kotlin, `Spec` suffix,
+  `internal`, `UtilityClassTest` base (private ctor + final +
+  `NullPointerTester` on public statics), Kotest assertions.
+
+[pr]: https://github.com/SpineEventEngine/core-jvm/pull/1656
+
+## Plan
+
+- [x] Add `base/src/main/java/io/spine/util/Suppliers2.java` — verbatim from
+      the PR, only the `package` line changes.
+- [x] Add `base/src/main/java/io/spine/util/Iterators2.java` — same.
+- [x] Add `base/src/test/kotlin/io/spine/util/Suppliers2Spec.kt` — delegate
+      value returned; laziness; delegate called once.
+- [x] Add `base/src/test/kotlin/io/spine/util/Iterators2Spec.kt` — retains
+      matching elements in order; exhausted when none match; `remove()`
+      unsupported.
+- [x] Verify: `./gradlew build dokkaGenerate` (JDK 17 via `JAVA_HOME`).
+- [ ] PR: branch off `master`, bump `version.gradle.kts`
+      (`2.0.0-SNAPSHOT.424` → `.425`), run `pre-pr`, open the PR.
+
+## Log
+
+- 2026-07-16 — drafted and validated (build commands, `UtilityClassTest`
+  contract, detekt impact); executing.
+- 2026-07-16 — all files in place; scoped specs green (11 tests, 0 failures);
+  full `./gradlew build dokkaGenerate` BUILD SUCCESSFUL in 30s.
+  `spine-code-review` + `kotlin-engineer` review passes launched.

--- a/.agents/tasks/add-suppliers2-iterators2.md
+++ b/.agents/tasks/add-suppliers2-iterators2.md
@@ -46,8 +46,12 @@ can later drop its copies.
 
 ## Log
 
-- 2026-07-16 — drafted and validated (build commands, `UtilityClassTest`
+- 2026-07-16 16:45 — drafted and validated (build commands, `UtilityClassTest`
   contract, detekt impact); executing.
-- 2026-07-16 — all files in place; scoped specs green (11 tests, 0 failures);
-  full `./gradlew build dokkaGenerate` BUILD SUCCESSFUL in 30s.
+- 2026-07-16 16:55 — all files in place; scoped specs green (11 tests,
+  0 failures); full `./gradlew build dokkaGenerate` BUILD SUCCESSFUL in 30s.
   `spine-code-review` + `kotlin-engineer` review passes launched.
+- 2026-07-16 17:14 — version bumped to `.425`, reports regenerated,
+  pre-PR gate PASS (3 reviewers approve); PR #953 opened.
+- 2026-07-16 17:35 — `review-docs` nits addressed: `@return` tags on both
+  methods, labeled `Suppliers.memoize()` link, timed `Log` entries.

--- a/base/src/main/java/io/spine/base/Identifier.java
+++ b/base/src/main/java/io/spine/base/Identifier.java
@@ -479,8 +479,8 @@ public final class Identifier<I> {
         }
 
         Identifier<?> identifier;
-        if (id instanceof Any) {
-            var unpacked = AnyPacker.unpack((Any) id);
+        if (id instanceof Any idAny) {
+            var unpacked = AnyPacker.unpack(idAny);
             identifier = fromMessage(unpacked);
         } else {
             identifier = from(id);

--- a/base/src/main/java/io/spine/base/MessageIdToString.java
+++ b/base/src/main/java/io/spine/base/MessageIdToString.java
@@ -72,8 +72,8 @@ final class MessageIdToString {
             result = Identifier.EMPTY_ID;
         } else if (values.size() == 1) {
             var object = values.iterator().next();
-            result = object instanceof Message
-                     ? convert((Message) object)
+            result = object instanceof Message msg
+                     ? convert(msg)
                      : object.toString();
         } else {
             result = messageWithMultipleFieldsToString(message);

--- a/base/src/main/java/io/spine/code/fs/FsObject.java
+++ b/base/src/main/java/io/spine/code/fs/FsObject.java
@@ -77,12 +77,7 @@ public abstract class FsObject {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (!(obj instanceof FsObject)) {
-            return false;
-        }
-        var other = (FsObject) obj;
-        return Objects.equals(this.path, other.path);    }
+        return (this == obj) ||
+                ((obj instanceof FsObject other) && Objects.equals(this.path, other.path));
+    }
 }

--- a/base/src/main/java/io/spine/code/proto/TypeSet.java
+++ b/base/src/main/java/io/spine/code/proto/TypeSet.java
@@ -269,10 +269,9 @@ public final class TypeSet {
         if (this == o) {
             return true;
         }
-        if (!(o instanceof TypeSet)) {
+        if (!(o instanceof TypeSet typeSet)) {
             return false;
         }
-        var typeSet = (TypeSet) o;
         return Objects.equal(messageTypes, typeSet.messageTypes) &&
                 Objects.equal(enumTypes, typeSet.enumTypes);
     }

--- a/base/src/main/java/io/spine/protobuf/AnyPacker.java
+++ b/base/src/main/java/io/spine/protobuf/AnyPacker.java
@@ -78,8 +78,8 @@ public final class AnyPacker {
      */
     public static Any pack(Message message) {
         checkNotNull(message);
-        if (message instanceof Any) {
-            return (Any) message;
+        if (message instanceof Any any) {
+            return any;
         }
         var typeUrl = TypeUrl.from(message.getDescriptorForType());
         var typeUrlPrefix = typeUrl.prefix();

--- a/base/src/main/java/io/spine/query/ComparisonOperator.java
+++ b/base/src/main/java/io/spine/query/ComparisonOperator.java
@@ -102,8 +102,10 @@ public enum ComparisonOperator {
      * The actual value must be greater than the value of the subject parameter.
      */
     GREATER_THAN {
-        @SuppressWarnings({"ChainOfInstanceofChecks", // Generic but limited operand types.
-                "rawtypes", "unchecked"               // Types are checked at runtime.
+        @SuppressWarnings({
+                "ChainOfInstanceofChecks", // Generic but limited operand types.
+                "PatternMatchingInstanceof", // To keep generic for `Comparable<?>`.
+                "rawtypes", "unchecked"    // Types are checked at runtime.
         })
         @Override
         public boolean eval(@Nullable Object left, @Nullable Object right) {
@@ -117,8 +119,7 @@ public enum ComparisonOperator {
                                right.getClass())
                 );
             }
-            if (left instanceof Timestamp) {
-                var firstT = (Timestamp) left;
+            if (left instanceof Timestamp firstT) {
                 var secondT = (Timestamp) right;
                 return Timestamps.compare(firstT, secondT) > 0;
             }

--- a/base/src/main/java/io/spine/type/ApiOption.java
+++ b/base/src/main/java/io/spine/type/ApiOption.java
@@ -70,8 +70,9 @@ import static io.spine.option.OptionsProto.sPIType;
 public final class ApiOption {
 
     /*
-     * Fields of type {@code GeneratedExtension} are immutable, despite not being annotated.
+     * Fields of type `GeneratedExtension` are immutable, despite not being annotated.
      */
+
     @SuppressWarnings("Immutable")
     private final GeneratedExtension<FileOptions, Boolean> fileOption;
     @SuppressWarnings("Immutable")

--- a/base/src/main/java/io/spine/util/Iterators2.java
+++ b/base/src/main/java/io/spine/util/Iterators2.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.collect.Iterators;
+import io.spine.annotation.Internal;
+
+import java.util.Iterator;
+import java.util.function.Predicate;
+
+/**
+ * Utilities for working with {@link Iterator}s, complementing
+ * {@link Iterators com.google.common.collect.Iterators}.
+ */
+@Internal
+public final class Iterators2 {
+
+    /** Prevents instantiation of this utility class. */
+    private Iterators2() {
+    }
+
+    /**
+     * Returns a view of the passed iterator containing the elements matching the predicate.
+     *
+     * <p>The returned iterator does not support removal.
+     *
+     * <p>Prefer this method over
+     * {@link Iterators#filter(Iterator, com.google.common.base.Predicate) Iterators.filter()}
+     * when the elements are not {@code null} — which, in this
+     * {@link org.jspecify.annotations.NullMarked @NullMarked} code, is the usual case.
+     * Guava declares its method as {@code <T extends @Nullable Object>}, deliberately, so that
+     * an iterator over nullable elements can be filtered too. The cost is that the nullness of
+     * {@code T} is no longer inferred from the assignment, and assigning the result to an
+     * {@code Iterator<@NonNull T>} reads as a nullness mismatch. Declaring {@code <T>} here,
+     * in a {@code @NullMarked} package, binds {@code T} to a non-null type and settles it.
+     *
+     * <p>Takes a {@link Predicate java.util.function.Predicate}, rather than the Guava one
+     * the delegate expects, so that the callers do not adapt it themselves.
+     *
+     * @param unfiltered
+     *         the iterator to filter
+     * @param retainIfTrue
+     *         the predicate matching the elements to retain
+     * @param <T>
+     *         the type of the iterated elements
+     */
+    @SuppressWarnings("NullableProblems")
+    public static <T> Iterator<T>
+    filter(Iterator<T> unfiltered, Predicate<? super T> retainIfTrue) {
+        return Iterators.filter(unfiltered, retainIfTrue::test);
+    }
+}

--- a/base/src/main/java/io/spine/util/Iterators2.java
+++ b/base/src/main/java/io/spine/util/Iterators2.java
@@ -70,8 +70,8 @@ public final class Iterators2 {
      * @return a filtered view of the given iterator
      */
     @SuppressWarnings("NullableProblems")
-    public static <T> Iterator<T>
-    filter(Iterator<T> unfiltered, Predicate<? super T> retainIfTrue) {
+    public static <T> Iterator<T> filter(Iterator<T> unfiltered,
+                                         Predicate<? super T> retainIfTrue) {
         return Iterators.filter(unfiltered, retainIfTrue::test);
     }
 }

--- a/base/src/main/java/io/spine/util/Iterators2.java
+++ b/base/src/main/java/io/spine/util/Iterators2.java
@@ -67,6 +67,7 @@ public final class Iterators2 {
      *         the predicate matching the elements to retain
      * @param <T>
      *         the type of the iterated elements
+     * @return a filtered view of the given iterator
      */
     @SuppressWarnings("NullableProblems")
     public static <T> Iterator<T>

--- a/base/src/main/java/io/spine/util/Suppliers2.java
+++ b/base/src/main/java/io/spine/util/Suppliers2.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util;
+
+import com.google.common.base.Suppliers;
+import io.spine.annotation.Internal;
+
+import java.util.function.Supplier;
+
+/**
+ * Utilities for working with {@link Supplier}s, complementing
+ * {@link Suppliers com.google.common.base.Suppliers}.
+ */
+@Internal
+public final class Suppliers2 {
+
+    /** Prevents instantiation of this utility class. */
+    private Suppliers2() {
+    }
+
+    /**
+     * Returns a supplier that obtains the value from the given delegate on the first call,
+     * and returns that same value on the calls that follow.
+     *
+     * <p>Prefer this method over {@link Suppliers#memoize(com.google.common.base.Supplier)}
+     * when the supplied value is not {@code null} — which, in this
+     * {@link org.jspecify.annotations.NullMarked @NullMarked} code, is the usual case.
+     * Guava declares its method as {@code <T extends @Nullable Object>}, deliberately, so that
+     * a {@code null} value can be memoized too. The cost is that the nullness of {@code T} is
+     * no longer inferred from the assignment, and assigning the result to a
+     * {@code Supplier<@NonNull T>} reads as a nullness mismatch. Declaring {@code <T>} here,
+     * in a {@code @NullMarked} package, binds {@code T} to a non-null type and settles it.
+     *
+     * @param delegate
+     *         the supplier of the value to memoize
+     * @param <T>
+     *         the type of the supplied value
+     */
+    @SuppressWarnings("NullableProblems")
+    public static <T> Supplier<T> memoize(Supplier<T> delegate) {
+        return Suppliers.memoize(delegate::get);
+    }
+}

--- a/base/src/main/java/io/spine/util/Suppliers2.java
+++ b/base/src/main/java/io/spine/util/Suppliers2.java
@@ -46,7 +46,8 @@ public final class Suppliers2 {
      * Returns a supplier that obtains the value from the given delegate on the first call,
      * and returns that same value on the calls that follow.
      *
-     * <p>Prefer this method over {@link Suppliers#memoize(com.google.common.base.Supplier)}
+     * <p>Prefer this method over
+     * {@link Suppliers#memoize(com.google.common.base.Supplier) Suppliers.memoize()}
      * when the supplied value is not {@code null} — which, in this
      * {@link org.jspecify.annotations.NullMarked @NullMarked} code, is the usual case.
      * Guava declares its method as {@code <T extends @Nullable Object>}, deliberately, so that
@@ -59,6 +60,7 @@ public final class Suppliers2 {
      *         the supplier of the value to memoize
      * @param <T>
      *         the type of the supplied value
+     * @return a supplier that memoizes the value of the delegate
      */
     @SuppressWarnings("NullableProblems")
     public static <T> Supplier<T> memoize(Supplier<T> delegate) {

--- a/base/src/test/kotlin/io/spine/util/Iterators2Spec.kt
+++ b/base/src/test/kotlin/io/spine/util/Iterators2Spec.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.shouldBe
+import io.spine.testing.UtilityClassTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Iterators2` utility class should")
+internal class Iterators2Spec : UtilityClassTest<Iterators2>(Iterators2::class.java) {
+
+    @Test
+    fun `retain only the elements matching the predicate`() {
+        val source = listOf(1, 2, 3, 4, 5, 6).iterator()
+
+        val filtered = Iterators2.filter(source) { it % 2 == 0 }
+
+        filtered.asSequence().toList() shouldContainExactly listOf(2, 4, 6)
+    }
+
+    @Test
+    fun `return an exhausted iterator when no elements match`() {
+        val source = listOf(1, 3, 5).iterator()
+
+        val filtered = Iterators2.filter(source) { it % 2 == 0 }
+
+        filtered.hasNext() shouldBe false
+    }
+
+    @Test
+    fun `not support removal`() {
+        val source = mutableListOf(1, 2, 3)
+        val filtered: MutableIterator<Int> = Iterators2.filter(source.iterator()) { true }
+        filtered.next()
+
+        shouldThrow<UnsupportedOperationException> {
+            filtered.remove()
+        }
+    }
+}

--- a/base/src/test/kotlin/io/spine/util/Suppliers2Spec.kt
+++ b/base/src/test/kotlin/io/spine/util/Suppliers2Spec.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026, TeamDev. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.util
+
+import io.kotest.matchers.shouldBe
+import io.spine.testing.UtilityClassTest
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+@DisplayName("`Suppliers2` utility class should")
+internal class Suppliers2Spec : UtilityClassTest<Suppliers2>(Suppliers2::class.java) {
+
+    @Test
+    fun `return the value obtained from the delegate`() {
+        val memoized = Suppliers2.memoize { "answer" }
+
+        memoized.get() shouldBe "answer"
+    }
+
+    @Test
+    fun `call the delegate lazily and only once`() {
+        var calls = 0
+        val memoized = Suppliers2.memoize { ++calls }
+
+        calls shouldBe 0
+
+        memoized.get() shouldBe 1
+        memoized.get() shouldBe 1
+        calls shouldBe 1
+    }
+}

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Base.kt
@@ -33,8 +33,8 @@ package io.spine.dependency.local
  */
 @Suppress("ConstPropertyName", "unused")
 object Base {
-    const val version = "2.0.0-SNAPSHOT.423"
-    const val versionForBuildScript = "2.0.0-SNAPSHOT.423"
+    const val version = "2.0.0-SNAPSHOT.424"
+    const val versionForBuildScript = "2.0.0-SNAPSHOT.424"
     const val group = Spine.group
     private const val prefix = "spine"
     const val libModule = "$prefix-base"

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/Compiler.kt
@@ -72,7 +72,7 @@ object Compiler : Dependency() {
      * The version of the Compiler dependencies.
      */
     override val version: String
-    private const val fallbackVersion = "2.0.0-SNAPSHOT.061"
+    private const val fallbackVersion = "2.0.0-SNAPSHOT.062"
 
     /**
      * The distinct version of the Compiler used by other build tools.
@@ -81,7 +81,7 @@ object Compiler : Dependency() {
      * transitive dependencies, this is the version used to build the project itself.
      */
     val dogfoodingVersion: String
-    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.061"
+    private const val fallbackDfVersion = "2.0.0-SNAPSHOT.062"
 
     /**
      * The artifact for the Compiler Gradle plugin.

--- a/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
+++ b/buildSrc/src/main/kotlin/io/spine/dependency/local/CoreJvm.kt
@@ -39,7 +39,7 @@ typealias CoreJava = CoreJvm
 @Suppress("ConstPropertyName", "unused")
 object CoreJvm {
     const val group = Spine.group
-    const val version = "2.0.0-SNAPSHOT.420"
+    const val version = "2.0.0-SNAPSHOT.450"
 
     const val coreArtifact = "spine-core"
     const val clientArtifact = "spine-client"

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -771,7 +771,7 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:16:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -1646,7 +1646,7 @@ This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:16:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -2483,7 +2483,7 @@ This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:16:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
@@ -3400,6 +3400,6 @@ This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:16:43 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/dependencies.md
+++ b/docs/dependencies/dependencies.md
@@ -1,6 +1,6 @@
 
 
-# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.424`
+# Dependencies of `io.spine:spine-annotations:2.0.0-SNAPSHOT.425`
 
 ## Runtime
 1.  **Group** : org.jetbrains. **Name** : annotations. **Version** : 26.1.0.
@@ -771,14 +771,14 @@
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.424`
+# Dependencies of `io.spine:spine-base:2.0.0-SNAPSHOT.425`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -1646,14 +1646,14 @@ This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.424`
+# Dependencies of `io.spine:spine-environment:2.0.0-SNAPSHOT.425`
 
 ## Runtime
 1.  **Group** : com.google.code.findbugs. **Name** : jsr305. **Version** : 3.0.2.
@@ -2483,14 +2483,14 @@ This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).
 
 
 
 
-# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.424`
+# Dependencies of `io.spine:spine-format:2.0.0-SNAPSHOT.425`
 
 ## Runtime
 1.  **Group** : com.fasterxml.jackson. **Name** : jackson-bom. **Version** : 2.22.1.
@@ -3400,6 +3400,6 @@ This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using
 
 The dependencies distributed under several licenses, are used according their commercial-use-friendly license.
 
-This report was generated on **Tue Jul 14 18:16:51 WEST 2026** using 
+This report was generated on **Thu Jul 16 17:03:47 WEST 2026** using 
 [Gradle-License-Report plugin](https://github.com/jk1/Gradle-License-Report) by Evgeny Naumenko, licensed under 
 [Apache 2.0 License](https://github.com/jk1/Gradle-License-Report/blob/master/LICENSE).

--- a/docs/dependencies/pom.xml
+++ b/docs/dependencies/pom.xml
@@ -10,7 +10,7 @@ all modules and does not describe the project structure per-subproject.
  -->
 <groupId>io.spine</groupId>
 <artifactId>base-libraries</artifactId>
-<version>2.0.0-SNAPSHOT.424</version>
+<version>2.0.0-SNAPSHOT.425</version>
 
 <inceptionYear>2015</inceptionYear>
 
@@ -134,7 +134,7 @@ all modules and does not describe the project structure per-subproject.
   <dependency>
     <groupId>com.google.errorprone</groupId>
     <artifactId>error_prone_annotations</artifactId>
-    <version>2.42.0</version>
+    <version>2.47.0</version>
     <scope>provided</scope>
   </dependency>
   <dependency>

--- a/environment/src/main/java/io/spine/environment/TestsProperty.java
+++ b/environment/src/main/java/io/spine/environment/TestsProperty.java
@@ -34,7 +34,6 @@ import org.jspecify.annotations.Nullable;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Boolean.TRUE;
 
 /**
  * Encapsulates work with the values of the {@link #KEY} environment variable.

--- a/environment/src/main/java/io/spine/environment/TestsProperty.java
+++ b/environment/src/main/java/io/spine/environment/TestsProperty.java
@@ -60,8 +60,7 @@ final class TestsProperty {
      * @see Tests#enabled()
      */
     @VisibleForTesting
-    static final ImmutableList<String> TESTS_VALUES =
-            ImmutableList.of(TRUE.toString(), "1");
+    static final ImmutableList<String> TESTS_VALUES = ImmutableList.of("true", "1");
 
     /**
      * Surrounding characters that may be in the value.

--- a/version.gradle.kts
+++ b/version.gradle.kts
@@ -24,4 +24,4 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-extra.set("versionToPublish", "2.0.0-SNAPSHOT.424")
+extra.set("versionToPublish", "2.0.0-SNAPSHOT.425")


### PR DESCRIPTION
`Suppliers2` and `Iterators2` were introduced in SpineEventEngine/core-jvm#1656 as `@Internal` wrappers over Guava's `Suppliers.memoize` and `Iterators.filter`. Guava declares those methods as `<T extends @Nullable Object>` — deliberately, so that `null` values can flow — but under JSpecify semantics that bound stops `T`'s nullness from being inferred from the assignment, so assigning the result to a non-null type in `@NullMarked` code reads as a nullness mismatch. Declaring plain `<T>` in a `@NullMarked` package binds `T` to non-null types and settles it.

## What changed

- The two classes now live in `io.spine.util` (module `base`) — joining the established Guava-companion family there (`Preconditions2`, `Predicates2`). Hosting them at the bottom of the dependency graph shares them SDK-wide and lets `core-jvm` drop its copies.
- New Kotlin specs cover both:
  - `Suppliers2Spec` — the delegate's value is returned; evaluation is lazy and happens exactly once.
  - `Iterators2Spec` — order-preserving filtering; exhausted iterator when nothing matches; the returned view rejects `remove()`.
  - Both extend `UtilityClassTest`, inheriting the final-class, private-constructor, and static-method null-hostility checks.
- The `config` submodule is updated, and the `ErrorProne` warnings and the PMD error surfaced by the refreshed toolchain are addressed across pre-existing `base` and `environment` sources (`Identifier`, `MessageIdToString`, `FsObject`, `ComparisonOperator`, `ApiOption`, `TestsProperty`, `TypeSet`, `AnyPacker`).
- Javadoc of the new classes is polished per the documentation review: `@return` tags added to both methods, and the `Suppliers.memoize()` link is labeled like the `Iterators.filter()` one.
- Version: `2.0.0-SNAPSHOT.424` → `2.0.0-SNAPSHOT.425`; dependency reports regenerated.

## Notes for the reviewer

- In the regenerated `docs/dependencies/pom.xml`, the `error_prone_annotations` entry moved `2.42.0` → `2.47.0`. This is deterministic generator output — it reflects Guava 33.6.0's *requested* version, while the classpath resolution still **forces `2.42.0`** (verified with `dependencyInsight`); equal values already appear in master's `dependencies.md`. No dependency pin changed in this PR.
- Verification at PR-creation HEAD: `./gradlew build dokkaGenerate` — green; `spine-code-review`, `kotlin-engineer`, and `review-docs` passes all approved.
- Follow-up (out of scope here): once this is published, `core-jvm` can replace its `io.spine.server.Suppliers2`/`Iterators2` with imports from `io.spine.util`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)